### PR TITLE
Rename `anonymise_key` to `mask_key` 

### DIFF
--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -13,7 +13,7 @@ import threading
 
 import boto3
 
-from .helpers import anonymise_key
+from .helpers import mask_key
 from .helpers import exponential_backoff
 
 
@@ -85,10 +85,10 @@ class ConnectionManager(object):
                     self.logger.debug(
                         "Using temporary credential set: %s",
                         {
-                            "AccessKeyId": anonymise_key(
+                            "AccessKeyId": mask_key(
                                 credentials["AccessKeyId"]
                             ),
-                            "SecretAccessKey": anonymise_key(
+                            "SecretAccessKey": mask_key(
                                 credentials["SecretAccessKey"]
                             )
                         }
@@ -102,10 +102,10 @@ class ConnectionManager(object):
                         "Using credential set from %s: %s",
                         self._boto_session.get_credentials().method,
                         {
-                            "AccessKeyId": anonymise_key(
+                            "AccessKeyId": mask_key(
                                 self._boto_session.get_credentials().access_key
                             ),
-                            "SecretAccessKey": anonymise_key(
+                            "SecretAccessKey": mask_key(
                                 self._boto_session.get_credentials().secret_key
                             ),
                             "Region": self._boto_session.region_name

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -184,22 +184,22 @@ def get_external_stack_name(project_code, stack_name):
     ])
 
 
-def anonymise_key(key):
+def mask_key(key):
     """
-    Returns an anonymised version of ``key``.
+    Returns an masked version of ``key``.
 
     Returned version has all but the last four characters are replaced with the
     character "*".
 
-    :param key: The string to anonymise.
+    :param key: The string to mask.
     :type key: str
-    :returns: An anonymised version of the key
+    :returns: An masked version of the key
     :rtype: str
     """
-    num_anonymised_chars = len(key) - 4
+    num_mask_chars = len(key) - 4
 
     return "".join([
-        "*" if i < num_anonymised_chars else c
+        "*" if i < num_mask_chars else c
         for i, c in enumerate(key)
     ])
 


### PR DESCRIPTION
Renamed `anonymise_key` function in sceptre/helpers.py to `mask_key` as old name didn't properly describe the function. 