### PR TITLE
Sptr 4/parameter as lists

### DIFF
--- a/docs/stack_config.rst
+++ b/docs/stack_config.rst
@@ -39,7 +39,7 @@ A list of arbitrary shell or python commands or scripts to run. Find out more in
 
 A dictionary of key-value pairs to be supplied to a CloudFormation or Troposphere template as parameters. The keys must match up with the name of the parameter, and the value must be of the type as defined in the template. Note that Boto3 throws an exception if parameters are supplied to a template that are not required by that template. Resolvers can be used to add functionality to this key. Find out more in the `Resolvers`_ section.
 
-Parameters can be specified as a single or list of values/resolvers. Lists of values/resolvers will be formatted into an AWS compatible comma separated string e.g. "value1,value2,value3". Lists can contain a mixture of values and resolvers.
+A parameter can be specified either as a single value/resolver or a list of values/resolvers. Lists of values/resolvers will be formatted into an AWS compatible comma separated string e.g. "value1,value2,value3". Lists can contain a mixture of values and resolvers.
 
 Syntax:
 

--- a/docs/stack_config.rst
+++ b/docs/stack_config.rst
@@ -39,6 +39,44 @@ A list of arbitrary shell or python commands or scripts to run. Find out more in
 
 A dictionary of key-value pairs to be supplied to a CloudFormation or Troposphere template as parameters. The keys must match up with the name of the parameter, and the value must be of the type as defined in the template. Note that Boto3 throws an exception if parameters are supplied to a template that are not required by that template. Resolvers can be used to add functionality to this key. Find out more in the `Resolvers`_ section.
 
+Parameters can be specified as a single or list of values/resolvers. Lists of values/resolvers will be formatted into an AWS compatible comma separated string e.g. "value1,value2,value3". Lists can contain a mixture of values and resolvers.
+
+Syntax:
+
+.. code-block:: yaml
+
+  parameters:
+    <parameter1_name>: "value"
+    <parameter2_name>: !<resolver_name> <resolver_value>
+    <parameter3_name>:
+      - "value1"
+      - "value2"
+      - "value3"
+    <parameter4_name>:
+      - !<resolver_name> <resolver_value>
+      - !<resolver_name> <resolver_value>
+      - !<resolver_name> <resolver_value>
+    <parameter5_name>:
+      - !<resolver_name> <resolver_value>
+      - "value1"
+      - !<resolver_name> <resolver_value>
+
+Example:
+
+.. code-block:: yaml
+
+    parameters:
+      database_username: "mydbuser"
+      database_password: !environment_variable DATABASE_PASSWORD
+      subnet_ids:
+        - "subnet-12345678"
+        - "subnet-87654321"
+        - "subnet-11111111"
+      security_group_ids:
+        - "sg-12345678"
+        - !stack_output security-groups::BaseSecurityGroupId
+        - !file_contents /file/with/security_group_id.txt
+
 ``protect``
 ```````````
 

--- a/docs/stack_config.rst
+++ b/docs/stack_config.rst
@@ -51,15 +51,12 @@ Syntax:
     <parameter3_name>:
       - "value1"
       - "value2"
-      - "value3"
     <parameter4_name>:
-      - !<resolver_name> <resolver_value>
       - !<resolver_name> <resolver_value>
       - !<resolver_name> <resolver_value>
     <parameter5_name>:
       - !<resolver_name> <resolver_value>
       - "value1"
-      - !<resolver_name> <resolver_value>
 
 Example:
 
@@ -71,7 +68,6 @@ Example:
       subnet_ids:
         - "subnet-12345678"
         - "subnet-87654321"
-        - "subnet-11111111"
       security_group_ids:
         - "sg-12345678"
         - !stack_output security-groups::BaseSecurityGroupId

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -651,8 +651,18 @@ class Stack(object):
         :returns: A list of the formatted parameters.
         :rtype: list
         """
-        return [{"ParameterKey": name, "ParameterValue": value}
-                for name, value in parameters.items() if value is not None]
+        formatted_parameters = []
+        for name, value in parameters.items():
+            if value is None:
+                continue
+            if isinstance(value, list):
+                value = ",".join(value)
+            formatted_parameters.append({
+                "ParameterKey": name,
+                "ParameterValue": value
+            })
+
+        return formatted_parameters
 
     def _get_template_details(self):
         """

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -695,6 +695,27 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             {"ParameterKey": "key3", "ParameterValue": "value3"}
         ])
 
+    def test_format_parameters_with_none_values(self):
+        parameters = {
+            "key1": None,
+            "key2": None,
+            "key3": None
+        }
+        formatted_parameters = self.stack._format_parameters(parameters)
+        assert sorted(formatted_parameters) == []
+
+    def test_format_parameters_with_none_and_string_values(self):
+        parameters = {
+            "key1": "value1",
+            "key2": None,
+            "key3": "value3"
+        }
+        formatted_parameters = self.stack._format_parameters(parameters)
+        assert sorted(formatted_parameters) == sorted([
+            {"ParameterKey": "key1", "ParameterValue": "value1"},
+            {"ParameterKey": "key3", "ParameterValue": "value3"}
+        ])
+
     def test_format_parameters_with_list_values(self):
         parameters = {
             "key1": ["value1", "value2", "value3"],
@@ -705,6 +726,18 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         assert sorted(formatted_parameters) == sorted([
             {"ParameterKey": "key1", "ParameterValue": "value1,value2,value3"},
             {"ParameterKey": "key2", "ParameterValue": "value4,value5,value6"},
+            {"ParameterKey": "key3", "ParameterValue": "value7,value8,value9"}
+        ])
+
+    def test_format_parameters_with_none_and_list_values(self):
+        parameters = {
+            "key1": ["value1", "value2", "value3"],
+            "key2": None,
+            "key3": ["value7", "value8", "value9"]
+        }
+        formatted_parameters = self.stack._format_parameters(parameters)
+        assert sorted(formatted_parameters) == sorted([
+            {"ParameterKey": "key1", "ParameterValue": "value1,value2,value3"},
             {"ParameterKey": "key3", "ParameterValue": "value7,value8,value9"}
         ])
 
@@ -719,6 +752,18 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             {"ParameterKey": "key1", "ParameterValue": "value1,value2,value3"},
             {"ParameterKey": "key2", "ParameterValue": "value4"},
             {"ParameterKey": "key3", "ParameterValue": "value5,value6,value7"}
+        ])
+
+    def test_format_parameters_with_none_list_and_string_values(self):
+        parameters = {
+            "key1": ["value1", "value2", "value3"],
+            "key2": "value4",
+            "key3": None
+        }
+        formatted_parameters = self.stack._format_parameters(parameters)
+        assert sorted(formatted_parameters) == sorted([
+            {"ParameterKey": "key1", "ParameterValue": "value1,value2,value3"},
+            {"ParameterKey": "key2", "ParameterValue": "value4"},
         ])
 
     @patch("sceptre.stack.Stack.describe")

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -682,7 +682,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             "tests/fixtures/stack_policies/unlock.json"
         )
 
-    def test_format_parameters(self):
+    def test_format_parameters_with_sting_values(self):
         parameters = {
             "key1": "value1",
             "key2": "value2",
@@ -693,6 +693,32 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             {"ParameterKey": "key1", "ParameterValue": "value1"},
             {"ParameterKey": "key2", "ParameterValue": "value2"},
             {"ParameterKey": "key3", "ParameterValue": "value3"}
+        ])
+
+    def test_format_parameters_with_list_values(self):
+        parameters = {
+            "key1": ["value1", "value2", "value3"],
+            "key2": ["value4", "value5", "value6"],
+            "key3": ["value7", "value8", "value9"]
+        }
+        formatted_parameters = self.stack._format_parameters(parameters)
+        assert sorted(formatted_parameters) == sorted([
+            {"ParameterKey": "key1", "ParameterValue": "value1,value2,value3"},
+            {"ParameterKey": "key2", "ParameterValue": "value4,value5,value6"},
+            {"ParameterKey": "key3", "ParameterValue": "value7,value8,value9"}
+        ])
+
+    def test_format_parameters_with_list_and_string_values(self):
+        parameters = {
+            "key1": ["value1", "value2", "value3"],
+            "key2": "value4",
+            "key3": ["value5", "value6", "value7"]
+        }
+        formatted_parameters = self.stack._format_parameters(parameters)
+        assert sorted(formatted_parameters) == sorted([
+            {"ParameterKey": "key1", "ParameterValue": "value1,value2,value3"},
+            {"ParameterKey": "key2", "ParameterValue": "value4"},
+            {"ParameterKey": "key3", "ParameterValue": "value5,value6,value7"}
         ])
 
     @patch("sceptre.stack.Stack.describe")


### PR DESCRIPTION
Add functionality to format a yaml list of parameters in a stack config as an AWS compatible comma separated list.