### PR TITLE
Fix PYPI README.rst rendering.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Python:
   stack = env.stacks["stack_name"]
   stack.create()
 
-A full API description of the sceptre package can be found in the `Documentation <http://sceptre.cloudreach.com/docs/sceptre.html>`_.
+A full API description of the sceptre package can be found in the `Documentation <http://sceptre.cloudreach.com/docs/sceptre.html>`__.
 
 
 Install
@@ -150,7 +150,7 @@ Tutorial and Documentation
 --------------------------
 
 - `Get Started <http://sceptre.cloudreach.com/docs/get_started.html>`_
-- `Documentation <http://sceptre.cloudreach.com/docs/>`_
+- `Documentation <http://sceptre.cloudreach.com/docs/>`__
 
 
 Contributions

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,4 @@ setuptools==20.8.1
 flake8==2.5.1
 tox==2.3.1
 coverage==4.0.3
+pygments==2.2.0


### PR DESCRIPTION
This branch has no error when rendering README.rst with Pygments pack installed using the following commands:

`python setup.py check --restructuredtext -s `

and

`rst2html.py --strict README.rst`

This should fix PYPI README.rst rendering issues.