### PR TITLE
Parallelise circle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-all:
 	tox
 
 test-integration: install
-	cd integration-tests && behave && cd ..
+	behave integration-tests/
 
 coverage:
 	coverage run --source sceptre setup.py test

--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,9 @@ dependencies:
     - pip install -r requirements_tests.txt
     - python setup.py install
 test:
-  post:
+  override:
     - make lint
+    - make test-all
     - behave:
         parallel: true
         files:

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
   override:
     - make lint
     - make test-all
-    - behave --junit --junit-directory:
+    - behave --junit --junit-directory $CIRCLE_TEST_REPORTS/behave/junit.xml:
         parallel: true
         files:
           - integration-tests/features/*.feature

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ test:
   override:
     - make lint
     - make test-all
-    - cd integration-tests && behave --include:
+    - cd integration-tests && behave:
         parallel: true
         files:
           - integration-tests/features/*.feature

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
   override:
     - make lint
     - make test-all
-    - behave:
+    - behave --junit --junit-directory:
         parallel: true
         files:
           - integration-tests/features/*.feature

--- a/circle.yml
+++ b/circle.yml
@@ -7,13 +7,14 @@ dependencies:
   override:
     - pip install -r requirements.txt
     - pip install -r requirements_tests.txt
-test:
-  pre:
     - python setup.py install
+test:
+  # pre:
+  #   - python setup.py install
   override:
     - make lint
     - make test-all
-    - python setup.py install && behave:
+    - behave:
         parallel: true
         files:
           - integration-tests/features/*.feature

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ test:
   override:
     - make lint
     - make test-all
-    - cd integration-tests && behave --junit --junit-directory $CIRCLE_TEST_REPORTS/behave/junit.xml --include:
+    - cd integration-tests && behave --include:
       parallel: true
       files:
         - features/*.feature

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ test:
   override:
     - make lint
     - make test-all
-    - cd integration-tests && behave:
+    - behave:
         parallel: true
         files:
           - integration-tests/features/*.feature

--- a/circle.yml
+++ b/circle.yml
@@ -9,11 +9,8 @@ dependencies:
     - pip install -r requirements_tests.txt
     - python setup.py install
 test:
-  # pre:
-  #   - python setup.py install
   override:
     - make lint
-    - make test-all
     - behave:
         parallel: true
         files:

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ test:
     - cd integration-tests && behave --include:
         parallel: true
         files:
-          - features/*.feature
+          - test-change-set.feature
     - make docs
 deployment:
     production:

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ test:
   override:
     - make lint
     - make test-all
-    - behave:
+    - python setup.py install && behave:
         parallel: true
         files:
           - integration-tests/features/*.feature

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ test:
     - cd integration-tests && behave --include:
         parallel: true
         files:
-          - test-change-set.feature
+          - integration-tests/features/*.feature
     - make docs
 deployment:
     production:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   override:
     - pip install -r requirements.txt
     - pip install -r requirements_tests.txt
-    - python setup.py install
+    - make install
 test:
   override:
     - make lint

--- a/circle.yml
+++ b/circle.yml
@@ -14,9 +14,9 @@ test:
     - make lint
     - make test-all
     - cd integration-tests && behave --include:
-      parallel: true
-      files:
-        - features/*.feature
+        parallel: true
+        files:
+          - features/*.feature
     - make docs
 deployment:
     production:

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,10 @@ test:
   override:
     - make lint
     - make test-all
-    - cd integration-tests && behave --junit --junit-directory $CIRCLE_TEST_REPORTS/behave/junit.xml
+    - cd integration-tests && behave --junit --junit-directory $CIRCLE_TEST_REPORTS/behave/junit.xml --include:
+      parallel: true
+      files:
+        - features/*.feature
     - make docs
 deployment:
     production:

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
     - pip install -r requirements_tests.txt
     - python setup.py install
 test:
-  override:
+  post:
     - make lint
     - behave:
         parallel: true

--- a/integration-tests/environment.py
+++ b/integration-tests/environment.py
@@ -14,6 +14,7 @@ def before_all(context):
     integration tests can be run in parallel without stack name clashes.
     """
     build_uuid = uuid.uuid1().hex
+    context.sceptre_dir = os.path.dirname(__file__)
     context.environment_path_a = "test-env-a"
     context.environment_path_b = "test-env-b"
     context.project_code = "sceptre-integration-tests-{0}".format(

--- a/integration-tests/steps/test_change_set.py
+++ b/integration-tests/steps/test_change_set.py
@@ -9,7 +9,8 @@ import os
 @when("we run create change set")
 def step_impl(context):
     subprocess.call([
-        "sceptre", "create-change-set", "test-env/a", "vpc", "test-change-set"
+        "sceptre", "--dir", context.sceptre_dir, "create-change-set",
+        "test-env/a", "vpc", "test-change-set"
     ])
     # Wait for change set to be created
     time.sleep(5)
@@ -31,8 +32,8 @@ def step_impl(context):
 @then("the change set should be described")
 def step_impl(context):
     raw_response = subprocess.check_output([
-        "sceptre", "describe-change-set", "test-env/a",
-        "vpc", "test-change-set"
+        "sceptre", "--dir", context.sceptre_dir, "describe-change-set",
+        "test-env/a", "vpc", "test-change-set"
     ])
 
     response = yaml.safe_load(raw_response)
@@ -72,7 +73,8 @@ def step_impl(context):
 @then("the change set can be listed")
 def step_impl(context):
     raw_response = subprocess.check_output([
-        "sceptre", "list-change-sets", "test-env/a", "vpc"
+        "sceptre", "--dir", context.sceptre_dir, "list-change-sets",
+        "test-env/a", "vpc"
     ])
 
     response = yaml.safe_load(raw_response)
@@ -83,7 +85,8 @@ def step_impl(context):
 @when("the change set is executed")
 def step_impl(context):
     subprocess.call([
-        "sceptre", "execute-change-set", "test-env/a", "vpc", "test-change-set"
+        "sceptre", "--dir", context.sceptre_dir, "execute-change-set",
+        "test-env/a", "vpc", "test-change-set"
     ])
 
 
@@ -119,7 +122,8 @@ def step_impl(context):
 @when("we execute delete change set")
 def step_impl(context):
     subprocess.call([
-        "sceptre", "delete-change-set", "test-env/a", "vpc", "test-change-set"
+        "sceptre", "--dir", context.sceptre_dir, "delete-change-set",
+        "test-env/a", "vpc", "test-change-set"
     ])
     # Wait for change set to be deleted
     time.sleep(5)

--- a/integration-tests/steps/test_continue_update_rollback.py
+++ b/integration-tests/steps/test_continue_update_rollback.py
@@ -92,7 +92,7 @@ def step_impl(context):
 def step_impl(context):
     subprocess.call(
         [
-            "sceptre",
+            "sceptre", "--dir", context.sceptre_dir,
             "continue-update-rollback",
             "test-env/a",
             "security-group"

--- a/integration-tests/steps/test_create_stack.py
+++ b/integration-tests/steps/test_create_stack.py
@@ -1,13 +1,16 @@
 from behave import *
 import subprocess
 import boto3
+import os
 
 
 @when("we run create stack")
 def step_impl(context):
-    subprocess.call(
-        ["sceptre", "create-stack", "test-env/a", "wait-condition-handle"]
-    )
+    print(os.getcwd())
+    subprocess.call([
+        "sceptre", "--dir", context.sceptre_dir, "create-stack",
+        "test-env/a", "wait-condition-handle"
+    ])
 
 
 @then("a stack is created")

--- a/integration-tests/steps/test_delete_env.py
+++ b/integration-tests/steps/test_delete_env.py
@@ -5,7 +5,9 @@ import boto3
 
 @when("we run delete env")
 def step_impl(context):
-    subprocess.call(["sceptre", "delete-env", "test-env"])
+    subprocess.call([
+        "sceptre", "--dir", context.sceptre_dir, "delete-env", "test-env"
+    ])
 
 
 @then("the env is deleted")

--- a/integration-tests/steps/test_delete_stack.py
+++ b/integration-tests/steps/test_delete_stack.py
@@ -5,9 +5,10 @@ import boto3
 
 @when("we run delete stack")
 def step_impl(context):
-    subprocess.call(
-        ["sceptre", "delete-stack", "test-env/a", "wait-condition-handle"]
-    )
+    subprocess.call([
+        "sceptre", "--dir", context.sceptre_dir, "delete-stack", "test-env/a",
+        "wait-condition-handle"
+    ])
 
 
 @then("the stack is deleted")

--- a/integration-tests/steps/test_describe_env_and_describe_env_resources.py
+++ b/integration-tests/steps/test_describe_env_and_describe_env_resources.py
@@ -28,7 +28,8 @@ def step_impl(context):
 @then("the env resources are described")
 def step_impl(context):
     raw_response = subprocess.check_output([
-        "sceptre", "describe-env-resources", "test-env"
+        "sceptre", "--dir", context.sceptre_dir, "describe-env-resources",
+        "test-env"
     ])
     response = yaml.safe_load(raw_response)
 

--- a/integration-tests/steps/test_describe_env_and_describe_env_resources.py
+++ b/integration-tests/steps/test_describe_env_and_describe_env_resources.py
@@ -8,7 +8,7 @@ import yaml
 @then("the env is described")
 def step_impl(context):
     raw_response = subprocess.check_output([
-        "sceptre", "describe-env", "test-env"
+        "sceptre", "--dir", context.sceptre_dir, "describe-env", "test-env"
     ])
     response = yaml.safe_load(raw_response)
 

--- a/integration-tests/steps/test_describe_stack_resources.py
+++ b/integration-tests/steps/test_describe_stack_resources.py
@@ -8,7 +8,7 @@ import yaml
 @then("the stack resources are listed")
 def step_impl(context):
     raw_response = subprocess.check_output([
-        "sceptre", "describe-stack-resources",
+        "sceptre", "--dir", context.sceptre_dir, "describe-stack-resources",
         "test-env/a", "wait-condition-handle"
     ])
     response = yaml.safe_load(raw_response)

--- a/integration-tests/steps/test_generate_template.py
+++ b/integration-tests/steps/test_generate_template.py
@@ -8,7 +8,8 @@ import json
 @given("the generate-template command is run")
 def step_impl(context):
     context.template_json_str = subprocess.check_output([
-        "sceptre", "generate-template", "test-env/a", "vpc"
+        "sceptre", "--dir", context.sceptre_dir, "generate-template",
+        "test-env/a", "vpc"
     ])
 
 

--- a/integration-tests/steps/test_launch_env.py
+++ b/integration-tests/steps/test_launch_env.py
@@ -5,7 +5,9 @@ import boto3
 
 @when("we run launch env")
 def step_impl(context):
-    subprocess.call(["sceptre", "launch-env", "test-env"])
+    subprocess.call([
+        "sceptre", "--dir", context.sceptre_dir, "launch-env", "test-env"
+    ])
 
 
 @then("an env is created")

--- a/integration-tests/steps/test_lock_unlock_stack.py
+++ b/integration-tests/steps/test_lock_unlock_stack.py
@@ -7,7 +7,8 @@ import os
 @when("we run lock stack")
 def step_impl(context):
     subprocess.call([
-        "sceptre", "lock-stack", "test-env/a", "wait-condition-handle"
+        "sceptre", "--dir", context.sceptre_dir, "lock-stack", "test-env/a",
+        "wait-condition-handle"
     ])
 
 
@@ -33,7 +34,8 @@ def step_impl(context):
 @when("we run unlock stack")
 def step_impl(context):
     subprocess.call([
-        "sceptre", "unlock-stack", "test-env/a", "wait-condition-handle"
+        "sceptre", "--dir", context.sceptre_dir, "unlock-stack", "test-env/a",
+        "wait-condition-handle"
     ])
 
 

--- a/integration-tests/steps/test_update_stack.py
+++ b/integration-tests/steps/test_update_stack.py
@@ -23,7 +23,10 @@ def step_impl(context):
 
 @when("we run update stack")
 def step_impl(context):
-    subprocess.call(["sceptre", "update-stack", "test-env/a", "vpc"])
+    subprocess.call([
+        "sceptre", "--dir", context.sceptre_dir, "update-stack", "test-env/a",
+        "vpc"
+    ])
 
 
 @then("the stack is updated")

--- a/integration-tests/steps/test_validate_template.py
+++ b/integration-tests/steps/test_validate_template.py
@@ -8,7 +8,7 @@ import yaml
 @when("validate template is run")
 def step_impl(context):
     context.response = subprocess.check_output([
-        "sceptre", "validate-template",
+        "sceptre", "--dir", context.sceptre_dir, "validate-template",
         "test-env/a", "wait-condition-handle"
     ])
 


### PR DESCRIPTION
This PR makes use of CircleCI's parallel tests [feature](https://circleci.com/docs/1.0/parallel-manual-setup/#using-configuration-files-modifier) to speed up our integration tests. 

Circle's simple parallelism is file based. You supply a command and a list of files to run that command on. In our case, the command is `behave`, and the list of files is the result of the glob `integration-tests/features/*.feature`.

This command has to be run from the root directory, `sceptre/`. Previously, our integration tests were run from `sceptre/integration-tests`, where we store the config files and templates used by sceptre to run the tests. To get `behave` to run from the root dir, the integration tests have been modified so all sceptre commands are explicitly supplied with the sceptre directory to use. 

For example:
```
sceptre create-stack dev vpc
```

Has been changed to:
```
sceptre --dir /path/to/sceptre/integration-tests dev vpc
```

This parallelisation means our int tests are run over 4 containers rather than 1. This has sped up the integration tests from 22 mins to 7 mins, and the overall test from 25 mins to 10 mins. (all times approximate)