### PR TITLE
Update string type check in get_subclasses to account for unicode

### DIFF
--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -218,10 +218,12 @@ def get_subclasses(class_type, directory=None):
     :returns: A dict of classes found.
     :rtype: dict
     """
-    if not isinstance(directory, str):
-        raise TypeError("'directory' object should be a str")
+    try:
+        glob_expression = os.path.join(directory, "*.py")
+    except (AttributeError, TypeError):
+        raise TypeError("'directory' object should be a string")
 
-    module_paths = glob.glob(os.path.join(directory, "*.py"))
+    module_paths = glob.glob(glob_expression)
 
     sys.path.append(directory)
 


### PR DESCRIPTION
The string check in `helpers.get_subclasses` was checking against `str`, meaning that passing a unicode string would fail.

The simple fix is to change the `isinstance` check to match against `basestring`.

**Note:** This isn't Python 3 compatible, but I didn't see any evidence that it's supported currently. Let me know if that's not the case.