### PR TITLE
Add hook for ASG that supports all scaling processes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,5 +23,5 @@ Contributors
 * Amy Bruce-Gardner `@amybg <https://github.com/amybg>`_
 * Marius Galbinasu `@galbinasu <https://github.com/galbinasu>`_
 * Matthew Taylor `@matalo33 <https://github.com/matalo33>`_
-* Yvonne Beumer `@pinkee <https://github.com/pinkieee>`_
+* Yvonne Beumer `@pinkeee <https://github.com/pinkieee>`_
 * Max Eskenazi <max@eskenazi.net>

--- a/docs/stack_config.rst
+++ b/docs/stack_config.rst
@@ -375,7 +375,7 @@ Suspends or resumes autoscaling scaling processes.
 
 Syntax:
 
-.. code-block::
+.. code-block:: yaml
 
     <hook_point>:
       - !asg_scaling_processes <suspend|resume>::<process-name>

--- a/docs/stack_config.rst
+++ b/docs/stack_config.rst
@@ -368,6 +368,28 @@ Example:
       - !asg_scheduled_actions "suspend"
 
 
+``asg_scaling_processes``
+*************************
+
+Suspends or resumes autoscaling scaling processes.
+
+Syntax:
+
+.. code-block::
+
+    <hook_point>:
+      - !asg_scaling_processes <suspend|resume>::<process-name>
+
+Example:
+
+.. code-block:: yaml
+
+    before_update:
+      - !asg_scaling_processes suspend::ScheduledActions
+
+Full documentation on the suspend and resume processes:
+http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html
+
 Hook Examples
 `````````````
 

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -110,6 +110,12 @@ class InvalidHookArgumentTypeError(SceptreException):
     """
 
 
+class InvalidHookArgumentSyntaxError(SceptreException):
+    """
+    Error raised if a hook's argument syntax is invalid.
+    """
+
+
 class InvalidHookArgumentValueError(SceptreException):
     """
     Error raised if a hook's argument value is invalid.

--- a/sceptre/hooks/asg_scaling_processes.py
+++ b/sceptre/hooks/asg_scaling_processes.py
@@ -8,16 +8,9 @@ from sceptre.exceptions import InvalidHookArgumentValueError
 
 class ASGScalingProcesses(Hook):
     """
-    A command to resume or suspend autoscaling group scaling processes. This is
+    Resumes or suspends autoscaling group scaling processes. This is
     useful as scheduled actions must be suspended when updating stacks with
     autoscaling groups.
-    This command supports all autoscaling scaling processes.
-    Example configuration:
-    hooks:
-      before_update:
-        - !asg_scaling_processes suspend::ScheduledActions
-    Full documentation on the suspend and resume processes
-    http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html
     """
 
     def __init__(self, *args, **kwargs):
@@ -26,7 +19,11 @@ class ASGScalingProcesses(Hook):
     def run(self):
         """
         Either suspends or resumes any scaling processes on all autoscaling
-        groups with in the current stack.
+        groups within the current stack.
+
+        :raises: InvalidHookArgumentSyntaxError, when syntax is not using "::".
+        :raises: InvalidHookArgumentTypeError, if argument is not a string.
+        :raises: InvalidHookArgumentValueError, if not using resume or suspend.
         """
 
         if not isinstance(self.argument, basestring):
@@ -37,7 +34,9 @@ class ASGScalingProcesses(Hook):
         if "::" not in str(self.argument):
             raise InvalidHookArgumentSyntaxError(
                 'Wrong syntax for the argument "{0}" - asg_scaling_processes '
-                'hooks use the format: "suspend::Terminate".'.format(self.argument)
+                'hooks use:'
+                '- !asg_scaling_processes <suspend|resume>::<process-name>'
+                .format(self.argument)
             )
 
         action, scaling_processes = self.argument.split("::")

--- a/sceptre/hooks/asg_scaling_processes.py
+++ b/sceptre/hooks/asg_scaling_processes.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+from sceptre.hooks import Hook
+from sceptre.exceptions import InvalidHookArgumentTypeError
+from sceptre.exceptions import InvalidHookArgumentSyntaxError
+from sceptre.exceptions import InvalidHookArgumentValueError
+
+
+class ASGScalingProcesses(Hook):
+    """
+    A command to resume or suspend autoscaling group scaling processes. This is
+    useful as scheduled actions must be suspended when updating stacks with
+    autoscaling groups.
+    This command supports all autoscaling scaling processes.
+    Example configuration:
+    hooks:
+      before_update:
+        - !asg_scaling_processes suspend::ScheduledActions
+    Full documentation on the suspend and resume processes
+    http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ASGScalingProcesses, self).__init__(*args, **kwargs)
+
+    def run(self):
+        """
+        Either suspends or resumes any scaling processes on all autoscaling
+        groups with in the current stack.
+        """
+
+        if not isinstance(self.argument, basestring):
+            raise InvalidHookArgumentTypeError(
+                'The argument "{0}" is the wrong type - asg_scaling_processes '
+                'hooks require arguments of type string.'.format(self.argument)
+            )
+        if "::" not in str(self.argument):
+            raise InvalidHookArgumentSyntaxError(
+                'Wrong syntax for the argument "{0}" - asg_scaling_processes '
+                'hooks use the format: "suspend::Terminate".'.format(self.argument)
+            )
+
+        action, scaling_processes = self.argument.split("::")
+
+        if action not in ["resume", "suspend"]:
+            raise InvalidHookArgumentValueError(
+                'The argument "{0}" is invalid - valid arguments for '
+                'asg_scaling_processes hooks are "resume" or "suspend".'
+                .format(action)
+            )
+
+        action += "_processes"
+
+        autoscaling_group_names = self._find_autoscaling_groups()
+        for autoscaling_group in autoscaling_group_names:
+            self.connection_manager.call(
+                service="autoscaling",
+                command=action,
+                kwargs={
+                    "AutoScalingGroupName": autoscaling_group,
+                    "ScalingProcesses": [scaling_processes]
+                }
+            )
+
+    def _get_stack_resources(self):
+        """
+        Retrieves all resources in stack.
+        :return: list
+        """
+        full_stack_name = "-".join([
+            self.environment_config["project_code"],
+            self.environment_config.environment_path,
+            self.stack_config.name
+        ]).replace("/", "-")
+        response = self.connection_manager.call(
+            service="cloudformation",
+            command="describe_stack_resources",
+            kwargs={"StackName": full_stack_name}
+        )
+        return response.get("StackResources", [])
+
+    def _find_autoscaling_groups(self):
+        """
+        Retrieves all the autoscaling groups
+        :return: list [str]
+        """
+        asg_names = []
+        resources = self._get_stack_resources()
+        resource_type = "AWS::AutoScaling::AutoScalingGroup"
+        for resource in resources:
+            if resource.get("ResourceType", False) == resource_type:
+                asg_names.append(resource["PhysicalResourceId"])
+
+        return asg_names

--- a/tests/test_hooks/test_asg_scaling_processes.py
+++ b/tests/test_hooks/test_asg_scaling_processes.py
@@ -103,7 +103,7 @@ class TestASGScalingProcesses(object):
         ".ASGScalingProcesses._find_autoscaling_groups"
     )
     def test_run_with_suspend_argument(self, mock_find_autoscaling_groups):
-        self.mock_asg_scaling_processes.argument = u"suspend::ScheduledActions"
+        self.mock_asg_scaling_processes.argument = "suspend::ScheduledActions"
         mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
         self.mock_asg_scaling_processes.connection_manager = Mock()
         self.mock_asg_scaling_processes.run()

--- a/tests/test_hooks/test_asg_scaling_processes.py
+++ b/tests/test_hooks/test_asg_scaling_processes.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+
+from mock import Mock,  patch, MagicMock
+import pytest
+from sceptre.config import Config
+from sceptre.hooks.asg_scaling_processes import ASGScalingProcesses
+from sceptre.exceptions import InvalidHookArgumentValueError
+from sceptre.exceptions import InvalidHookArgumentSyntaxError
+from sceptre.exceptions import InvalidHookArgumentTypeError
+
+
+class TestASGScalingProcesses(object):
+    def setup_method(self, test_method):
+        self.mock_asg_scaling_processes = ASGScalingProcesses()
+
+    def test_get_stack_resources_sends_correct_request(self):
+        mock_environment_config = MagicMock(spec=Config)
+        mock_environment_config.__getitem__.return_value = "project_code"
+        mock_environment_config.environment_path = "path"
+        self.mock_asg_scaling_processes.environment_config =\
+            mock_environment_config
+        mock_stack_config = MagicMock(spec=Config)
+        mock_stack_config.name = "stack"
+        self.mock_asg_scaling_processes.stack_config = mock_stack_config
+        mock_connection_manager = Mock()
+        mock_connection_manager.call.return_value = {
+            "StackResources": [
+                {
+                    "ResourceType": "AWS::AutoScaling::AutoScalingGroup",
+                    'PhysicalResourceId': 'cloudreach-examples-asg'
+                }
+            ]
+        }
+        self.mock_asg_scaling_processes.\
+            connection_manager = mock_connection_manager
+        self.mock_asg_scaling_processes\
+            ._get_stack_resources()
+        mock_connection_manager.call.\
+            assert_called_with(
+                service="cloudformation",
+                command="describe_stack_resources",
+                kwargs={
+                    "StackName": "project_code-path-stack",
+                }
+            )
+
+    @patch(
+        "sceptre.hooks.asg_scaling_processes"
+        ".ASGScalingProcesses._get_stack_resources"
+    )
+    def test_find_autoscaling_groups_with_stack_with_asgs(
+        self, mock_get_stack_resources
+    ):
+        mock_get_stack_resources.return_value = [{
+            'LogicalResourceId': 'AutoScalingGroup',
+            'PhysicalResourceId': 'cloudreach-examples-asg',
+            'ResourceStatus': 'CREATE_COMPLETE',
+            'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+            'StackId': 'arn:aws:...',
+            'StackName': 'cloudreach-examples-dev-vpc'
+        }]
+        response = self.mock_asg_scaling_processes.\
+            _find_autoscaling_groups()
+
+        assert response == ["cloudreach-examples-asg"]
+
+    @patch(
+        "sceptre.hooks.asg_scaling_processes"
+        ".ASGScalingProcesses._get_stack_resources"
+    )
+    def test_find_autoscaling_groups_with_stack_without_asgs(
+        self, mock_get_stack_resources
+    ):
+        mock_get_stack_resources.return_value = []
+        response = self.mock_asg_scaling_processes.\
+            _find_autoscaling_groups()
+
+        assert response == []
+
+    @patch(
+        "sceptre.hooks.asg_scaling_processes"
+        ".ASGScalingProcesses._find_autoscaling_groups"
+    )
+    def test_run_with_resume_argument(self, mock_find_autoscaling_groups):
+        self.mock_asg_scaling_processes.argument = u"resume::ScheduledActions"
+        mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
+        self.mock_asg_scaling_processes.connection_manager = Mock()
+        self.mock_asg_scaling_processes.run()
+        self.mock_asg_scaling_processes.connection_manager\
+            .call.assert_called_once_with(
+                service="autoscaling",
+                command="resume_processes",
+                kwargs={
+                    "AutoScalingGroupName": "autoscaling_group_1",
+                    "ScalingProcesses": [
+                        "ScheduledActions"
+                    ]
+                }
+            )
+
+    @patch(
+        "sceptre.hooks.asg_scaling_processes"
+        ".ASGScalingProcesses._find_autoscaling_groups"
+    )
+    def test_run_with_suspend_argument(self, mock_find_autoscaling_groups):
+        self.mock_asg_scaling_processes.argument = u"suspend::ScheduledActions"
+        mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
+        self.mock_asg_scaling_processes.connection_manager = Mock()
+        self.mock_asg_scaling_processes.run()
+        self.mock_asg_scaling_processes.connection_manager\
+            .call.assert_called_once_with(
+                service="autoscaling",
+                command="suspend_processes",
+                kwargs={
+                    "AutoScalingGroupName": "autoscaling_group_1",
+                    "ScalingProcesses": [
+                        "ScheduledActions"
+                    ]
+                }
+            )
+
+    @patch(
+        "sceptre.hooks.asg_scaling_processes"
+        ".ASGScalingProcesses._find_autoscaling_groups"
+    )
+    def test_run_with_invalid_string_argument(
+        self, mock_find_autoscaling_groups
+    ):
+        self.mock_asg_scaling_processes.argument = u"invalid_string"
+        mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
+        self.mock_asg_scaling_processes.connection_manager = Mock()
+        with pytest.raises(InvalidHookArgumentSyntaxError):
+            self.mock_asg_scaling_processes.run()
+
+    @patch(
+        "sceptre.hooks.asg_scaling_processes"
+        ".ASGScalingProcesses._find_autoscaling_groups"
+    )
+    def test_run_with_non_supported_argument(self, mock_find_autoscaling_groups):
+        self.mock_asg_scaling_processes.argument = "start::Healthcheck"
+        mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
+        self.mock_asg_scaling_processes.connection_manager = Mock()
+        with pytest.raises(InvalidHookArgumentValueError):
+            self.mock_asg_scaling_processes.run()
+
+    @patch(
+        "sceptre.hooks.asg_scaling_processes"
+        ".ASGScalingProcesses._find_autoscaling_groups"
+    )
+    def test_run_with_non_string_argument(self, mock_find_autoscaling_groups):
+        self.mock_asg_scaling_processes.argument = 10
+        mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
+        self.mock_asg_scaling_processes.connection_manager = Mock()
+        with pytest.raises(InvalidHookArgumentTypeError):
+            self.mock_asg_scaling_processes.run()


### PR DESCRIPTION
This sceptre hook can suspend/resume any autoscaling processes as they are defined in the AWS documentation:

http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html