### PR TITLE
Fix dependency namming when using dependencies

### DIFF
--- a/docs/stack_config.rst
+++ b/docs/stack_config.rst
@@ -103,7 +103,7 @@ A custom name name to use instead of the Sceptre default.
     parameters:
       VpcID: !stack_output_external <custom-named-vpc-stack>::VpcID
     dependencies:
-      - <stack/name>
+      - <environment>/<stack>
 
 ``stack_tags``
 ``````````````


### PR DESCRIPTION
This is how it works now. I don't see the point to have here the environment, but maybe it can be optional.