### PR TITLE
Fix circle ci tag regex

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,9 +19,10 @@ test:
     - make docs
 deployment:
     production:
-        tag: /v*/
+        tag: /v[0-9]+(\.[0-9]+)*/
         commands:
             - aws s3 sync ~/sceptre/docs/_build/html s3://sceptre.cloudreach.com/docs/ --delete
+            - aws s3 sync ~/sceptre/docs/_build/html s3://sceptre.cloudreach.com/dev/docs/ --delete
     develop:
         branch: master
         commands:

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,6 @@ deployment:
         tag: /v[0-9]+(\.[0-9]+)*/
         commands:
             - aws s3 sync ~/sceptre/docs/_build/html s3://sceptre.cloudreach.com/docs/ --delete
-            - aws s3 sync ~/sceptre/docs/_build/html s3://sceptre.cloudreach.com/dev/docs/ --delete
     develop:
         branch: master
         commands:


### PR DESCRIPTION
Fix tag regex. `/v*/` (match 0 or more of the character 'v') doesn't actually match our tagging pattern e.g: `v1.1.1`. I've switched it to the regex Circle recommend in their [docs](https://circleci.com/docs/1.0/configuration/#tags).

Note we can't actually test this until we do a release, but I've been doing some testing of my own [here](https://github.com/jamesroutley/circleci-test), and I think it should work.