### PR TITLE
added mfa support to role assumption

### DIFF
--- a/docs/environment_config.rst
+++ b/docs/environment_config.rst
@@ -13,6 +13,8 @@ An environment config file is a yaml object of key-value pairs configuring Scept
 
 - `iam_role`_ *(optional)*
 
+- `require_mfa`_ *(optional)*
+
 - `project_code`_ *(required)*
 
 - `region`_ *(required)*
@@ -30,6 +32,11 @@ iam_role
 ````````
 
 The ARN of a role for Sceptre to assume before interacting with the environment. If not supplied, Sceptre uses the user's AWS CLI credentials.
+
+require_mfa
+````````
+
+Whether or not the `iam_role` given requires MFA to assume it. It is only used when `iam_role` is set. If not set, it defaults to `false`.
 
 project_code
 ````````````

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -393,7 +393,8 @@ class Environment(object):
         config = self._get_config()
         connection_manager = ConnectionManager(
             region=config["region"],
-            iam_role=config.get("iam_role")
+            iam_role=config.get("iam_role"),
+            require_mfa=config.get('require_mfa', False)
         )
         stacks = {}
         for stack_name in self._get_available_stacks():

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -433,7 +433,7 @@ class TestEnvironment(object):
     ):
         mock_config = {
             "region": sentinel.region,
-            "iam_role": sentinel.iam_role
+            "iam_role": sentinel.iam_role,
         }
         mock_get_config.return_value = mock_config
         mock_ConnectionManager.return_value = sentinel.connection_manager
@@ -445,7 +445,8 @@ class TestEnvironment(object):
         # Check ConnectionManager() is called with correct arguments
         mock_ConnectionManager.assert_called_once_with(
             region=sentinel.region,
-            iam_role=sentinel.iam_role
+            iam_role=sentinel.iam_role,
+            require_mfa=False
         )
 
         # Check Stack() is called with correct arguments


### PR DESCRIPTION
Closes #104 

It adds a new config in the environment `require_mfa` (boolean). When turned on and there is an `iam_role` set it will try to get the current user's information using the `get_user` api and builds the virtual MFA device's arn. When `get_user` errors due to MFA limitation, it will still contain enough information to create the MFA arn.