### PR TITLE
Sptr 120 - Replace deprecated stack attribute

### DIFF
--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -72,7 +72,7 @@ def execution_protection(func):
     def decorated(self, *args, **kwargs):
         if self.config.get("protect", False):
             logger.error(
-                "%s Stack protected, action skipped", self.full_stack_name
+                "%s Stack protected, action skipped", self.name
             )
             raise ProtectedStackError("Stack protection is currently enabled")
         else:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -133,7 +133,7 @@ class TestHelpers(object):
         mock_stack = Mock(spec=Stack)
         mock_stack.config = {"protect": True}
         mock_function = Mock()
-        mock_stack.full_stack_name = sentinel.name
+        mock_stack.name = sentinel.name
         mock_stack.mock_function = mock_function
         mock_stack.mock_function.__name__ = 'mock_function'
 


### PR DESCRIPTION
Replacing deprecated stack attribute `self.full_stack_name` with `self.name` so that using the `protect` key on a stack config does not raise an AttributeError.