### PR TITLE
Simplify execution protection

### DIFF
--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -16,7 +16,6 @@ from concurrent.futures import as_completed
 from botocore.exceptions import ClientError
 
 from .exceptions import RetryLimitExceededError
-from .exceptions import ProtectedStackError
 
 
 def exponential_backoff(func):
@@ -52,31 +51,6 @@ def exponential_backoff(func):
         raise RetryLimitExceededError(
             "Exceeded request limit {0} times. Aborting.".format(max_retries)
         )
-
-    return decorated
-
-
-def execution_protection(func):
-    """
-    Raises an exception if a stack func is called with protection enabled.
-
-    :param func: The function to protect.
-    :type func: func
-    :returns: The execution protected function.
-    :rtype: func
-    :raises: sceptre.exceptions.ProtectedStackError
-    """
-    logger = logging.getLogger(__name__)
-
-    @wraps(func)
-    def decorated(self, *args, **kwargs):
-        if self.config.get("protect", False):
-            logger.error(
-                "%s Stack protected, action skipped", self.name
-            )
-            raise ProtectedStackError("Stack protection is currently enabled")
-        else:
-            return func(self, *args, **kwargs)
 
     return decorated
 

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -187,7 +187,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        _protect_execution(self.config.get("protect", False), self.name)
+        self._protect_execution()
         self.logger.info("%s - Creating stack", self.name)
         create_stack_kwargs = {
             "StackName": self.external_name,
@@ -221,7 +221,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        _protect_execution(self.config.get("protect", False), self.name)
+        self._protect_execution()
         self.logger.info("%s - Updating stack", self.name)
         update_stack_kwargs = {
             "StackName": self.external_name,
@@ -259,7 +259,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        _protect_execution(self.config.get("protect", False), self.name)
+        self._protect_execution()
         self.logger.info("%s - Launching stack", self.name)
         try:
             existing_status = self.get_status()
@@ -315,7 +315,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        _protect_execution(self.config.get("protect", False), self.name)
+        self._protect_execution()
         self.logger.info("%s - Deleting stack", self.name)
         try:
             status = self.get_status()
@@ -594,7 +594,7 @@ class Stack(object):
         :param change_set_name: The name of the change set.
         :type change_set_name: str
         """
-        _protect_execution(self.config.get("protect", False), self.name)
+        self._protect_execution()
         self.logger.debug(
             "%s - Executing change set '%s'", self.name, change_set_name
         )
@@ -703,6 +703,19 @@ class Stack(object):
             }
         else:
             return {}
+
+    def _protect_execution(self):
+        """
+        Raises a ProtectedStackError if protect == True.
+        This error is meant to stop the
+
+        :parameter protect: Bool indicating whether to
+        """
+        if self.config.get("protect", False):
+            raise ProtectedStackError(
+                "Cannot perform action on '{0}': stack protection is currently "
+                "enabled".format(self.name)
+            )
 
     def _wait_for_completion(self):
         """
@@ -844,11 +857,3 @@ class Stack(object):
             return StackChangeSetStatus.DEFUNCT
         else:  # pragma: no cover
             raise Exception("This else should not be reachable.")
-
-
-def _protect_execution(protect, name):
-    if protect:
-        raise ProtectedStackError(
-            "Cannot perform action on '{0}': stack protection is currently "
-            "enabled".format(name)
-        )

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -709,7 +709,7 @@ class Stack(object):
         Raises a ProtectedStackError if protect == True.
         This error is meant to stop the
 
-        :parameter protect: Bool indicating whether to
+        :raises: sceptre.exceptions.ProtectedStackError
         """
         if self.config.get("protect", False):
             raise ProtectedStackError(

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -187,7 +187,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        protect_execution(self.config.get("protect", False), self.name)
+        _protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Creating stack", self.name)
         create_stack_kwargs = {
             "StackName": self.external_name,
@@ -221,7 +221,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        protect_execution(self.config.get("protect", False), self.name)
+        _protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Updating stack", self.name)
         update_stack_kwargs = {
             "StackName": self.external_name,
@@ -259,7 +259,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        protect_execution(self.config.get("protect", False), self.name)
+        _protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Launching stack", self.name)
         try:
             existing_status = self.get_status()
@@ -315,7 +315,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
-        protect_execution(self.config.get("protect", False), self.name)
+        _protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Deleting stack", self.name)
         try:
             status = self.get_status()
@@ -594,7 +594,7 @@ class Stack(object):
         :param change_set_name: The name of the change set.
         :type change_set_name: str
         """
-        protect_execution(self.config.get("protect", False), self.name)
+        _protect_execution(self.config.get("protect", False), self.name)
         self.logger.debug(
             "%s - Executing change set '%s'", self.name, change_set_name
         )
@@ -846,7 +846,7 @@ class Stack(object):
             raise Exception("This else should not be reachable.")
 
 
-def protect_execution(protect, name):
+def _protect_execution(protect, name):
     if protect:
         raise ProtectedStackError(
             "Cannot perform action on '{0}': stack protection is currently "

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -24,13 +24,14 @@ from .stack_status import StackChangeSetStatus
 from .template import Template
 
 from .hooks import add_stack_hooks
-from .helpers import execution_protection, get_name_tuple
+from .helpers import get_name_tuple
 from .helpers import get_external_stack_name
 
 from .exceptions import CannotUpdateFailedStackError
 from .exceptions import UnknownStackStatusError
 from .exceptions import UnknownStackChangeSetStatusError
 from .exceptions import StackDoesNotExistError
+from .exceptions import ProtectedStackError
 
 
 class Stack(object):
@@ -179,7 +180,6 @@ class Stack(object):
         return self._external_name
 
     @add_stack_hooks
-    @execution_protection
     def create(self):
         """
         Creates the stack.
@@ -187,6 +187,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
+        protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Creating stack", self.name)
         create_stack_kwargs = {
             "StackName": self.external_name,
@@ -212,7 +213,6 @@ class Stack(object):
 
         return status
 
-    @execution_protection
     @add_stack_hooks
     def update(self):
         """
@@ -221,6 +221,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
+        protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Updating stack", self.name)
         update_stack_kwargs = {
             "StackName": self.external_name,
@@ -246,7 +247,6 @@ class Stack(object):
 
         return status
 
-    @execution_protection
     def launch(self):
         """
         Launches the stack.
@@ -259,6 +259,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
+        protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Launching stack", self.name)
         try:
             existing_status = self.get_status()
@@ -306,7 +307,6 @@ class Stack(object):
             )
         return status
 
-    @execution_protection
     @add_stack_hooks
     def delete(self):
         """
@@ -315,6 +315,7 @@ class Stack(object):
         :returns: The stack's status.
         :rtype: sceptre.stack_status.StackStatus
         """
+        protect_execution(self.config.get("protect", False), self.name)
         self.logger.info("%s - Deleting stack", self.name)
         try:
             status = self.get_status()
@@ -586,7 +587,6 @@ class Stack(object):
             }
         )
 
-    @execution_protection
     def execute_change_set(self, change_set_name):
         """
         Executes the change set ``change_set_name``.
@@ -594,6 +594,7 @@ class Stack(object):
         :param change_set_name: The name of the change set.
         :type change_set_name: str
         """
+        protect_execution(self.config.get("protect", False), self.name)
         self.logger.debug(
             "%s - Executing change set '%s'", self.name, change_set_name
         )
@@ -843,3 +844,11 @@ class Stack(object):
             return StackChangeSetStatus.DEFUNCT
         else:  # pragma: no cover
             raise Exception("This else should not be reachable.")
+
+
+def protect_execution(protect, name):
+    if protect:
+        raise ProtectedStackError(
+            "Cannot perform action on '{0}': stack protection is currently "
+            "enabled".format(name)
+        )

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -713,8 +713,8 @@ class Stack(object):
         """
         if self.config.get("protect", False):
             raise ProtectedStackError(
-                "Cannot perform action on '{0}': stack protection is currently "
-                "enabled".format(self.name)
+                "Cannot perform action on '{0}': stack protection is "
+                "currently enabled".format(self.name)
             )
 
     def _wait_for_completion(self):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,18 +8,15 @@ from mock import Mock, patch, sentinel
 from botocore.exceptions import ClientError
 
 from sceptre.exceptions import RetryLimitExceededError
-from sceptre.exceptions import ProtectedStackError
 from sceptre.helpers import exponential_backoff
 from sceptre.helpers import get_subclasses
 from sceptre.helpers import camel_to_snake_case
-from sceptre.helpers import execution_protection
 from sceptre.helpers import recurse_into_sub_environments
 from sceptre.helpers import get_name_tuple
 from sceptre.helpers import resolve_stack_name
 from sceptre.helpers import get_external_stack_name
 from sceptre.hooks import Hook
 from sceptre.resolvers import Resolver
-from sceptre.stack import Stack
 
 
 class TestHelpers(object):
@@ -117,28 +114,6 @@ class TestHelpers(object):
         assert classes["project_variables"].__name__ == \
             "ProjectVariables"
         assert len(classes) == 5
-
-    def test_execution_protection_allows_function_execution(self):
-        mock_stack = Mock(spec=Stack)
-        mock_stack.config = {"protect": False}
-        mock_function = Mock()
-        mock_stack.mock_function = mock_function
-        mock_stack.mock_function.__name__ = 'mock_function'
-
-        execution_protection(mock_stack.mock_function)(mock_stack)
-
-        assert mock_stack.mock_function.call_count == 1
-
-    def test_execution_protection_raises_exception(self):
-        mock_stack = Mock(spec=Stack)
-        mock_stack.config = {"protect": True}
-        mock_function = Mock()
-        mock_stack.name = sentinel.name
-        mock_stack.mock_function = mock_function
-        mock_stack.mock_function.__name__ = 'mock_function'
-
-        with pytest.raises(ProtectedStackError):
-            execution_protection(mock_stack.mock_function)(mock_stack)
 
     def test_camel_to_snake_case(self):
         snake_case_string = camel_to_snake_case("Bash")

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -857,7 +857,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
 
     def test_protect_execution_without_explicit_protection(self):
         self.stack._config = {}
-        # Function should do nothing if protect == False
+        # Function should do nothing if protect isn't explicitly set
         self.stack._protect_execution()
 
     def test_protect_execution_with_protection(self):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -855,6 +855,11 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         # Function should do nothing if protect == False
         self.stack._protect_execution()
 
+    def test_protect_execution_without_explicit_protection(self):
+        self.stack._config = {}
+        # Function should do nothing if protect == False
+        self.stack._protect_execution()
+
     def test_protect_execution_with_protection(self):
         self.stack._config = {"protect": True}
         with pytest.raises(ProtectedStackError):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -9,7 +9,7 @@ from dateutil.tz import tzutc
 from botocore.exceptions import ClientError
 
 from sceptre.config import Config
-from sceptre.stack import Stack, _protect_execution
+from sceptre.stack import Stack
 from sceptre.template import Template
 from sceptre.stack_status import StackStatus
 from sceptre.stack_status import StackChangeSetStatus
@@ -850,6 +850,16 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack.config["role_arn"] = sentinel.role_arn
         assert self.stack._get_role_arn() == {"RoleARN": sentinel.role_arn}
 
+    def test_protect_execution_without_protection(self):
+        self.stack._config = {"protect": False}
+        # Function should do nothing if protect == False
+        self.stack._protect_execution()
+
+    def test_protect_execution_with_protection(self):
+        self.stack._config = {"protect": True}
+        with pytest.raises(ProtectedStackError):
+            self.stack._protect_execution()
+
     @patch("sceptre.stack.time")
     @patch("sceptre.stack.Stack._log_new_events")
     @patch("sceptre.stack.Stack.get_status")
@@ -992,13 +1002,3 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         )
         with pytest.raises(ClientError):
             self.stack._get_cs_status(sentinel.change_set_name)
-
-
-def test_protect_execution_without_protection():
-    # Function should do nothing if protect == False
-    _protect_execution(False, "name")
-
-
-def test_protect_execution_with_protection():
-    with pytest.raises(ProtectedStackError):
-        _protect_execution(True, "name")

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -9,7 +9,7 @@ from dateutil.tz import tzutc
 from botocore.exceptions import ClientError
 
 from sceptre.config import Config
-from sceptre.stack import Stack
+from sceptre.stack import Stack, protect_execution
 from sceptre.template import Template
 from sceptre.stack_status import StackStatus
 from sceptre.stack_status import StackChangeSetStatus
@@ -17,6 +17,7 @@ from sceptre.exceptions import CannotUpdateFailedStackError
 from sceptre.exceptions import UnknownStackStatusError
 from sceptre.exceptions import UnknownStackChangeSetStatusError
 from sceptre.exceptions import StackDoesNotExistError
+from sceptre.exceptions import ProtectedStackError
 
 
 class TestStack(object):
@@ -991,3 +992,13 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         )
         with pytest.raises(ClientError):
             self.stack._get_cs_status(sentinel.change_set_name)
+
+
+def test_protect_execution_without_protection():
+    # Function should do nothing if protect == False
+    protect_execution(False, "name")
+
+
+def test_protect_execution_with_protection():
+    with pytest.raises(ProtectedStackError):
+        protect_execution(True, "name")

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -9,7 +9,7 @@ from dateutil.tz import tzutc
 from botocore.exceptions import ClientError
 
 from sceptre.config import Config
-from sceptre.stack import Stack, protect_execution
+from sceptre.stack import Stack, _protect_execution
 from sceptre.template import Template
 from sceptre.stack_status import StackStatus
 from sceptre.stack_status import StackChangeSetStatus
@@ -996,9 +996,9 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
 
 def test_protect_execution_without_protection():
     # Function should do nothing if protect == False
-    protect_execution(False, "name")
+    _protect_execution(False, "name")
 
 
 def test_protect_execution_with_protection():
     with pytest.raises(ProtectedStackError):
-        protect_execution(True, "name")
+        _protect_execution(True, "name")


### PR DESCRIPTION
This pull request aims to simplify execution protection. It is motivated by #120 and it's PR #121, and is a "proposal" PR.

The previous implementation used a decorator, `@execution_protection`, which was applied to all "unsafe" commands (`create`, `delete` etc). The decorator code was very tightly coupled with the stack code. The decorator function assumed that: 

- the first argument passed was `self` (i.e. it could only be applied to an object)
- the object has a `dict` attribute `config`
- the object has an attribute `name`

This tight coupling makes the function difficult to test. The previous implementation mocked out `Stack` completely, so when changes were made to `Stack` (`full_stack_name` -> `name`), the fact that this decorator still used the old value wasn't picked up (#121)

This new implementation removes the decorator, and replaces it with a method. This new method: 

- removes the coupling (and the `Mock`)
- is easier to test
- is easier to understand