### PR TITLE
Add confirmation step when deleting a stack.

### DIFF
--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -130,7 +130,7 @@ Delete Stack
 
 Delete the stack::
 
-  $ sceptre delete-stack dev vpc
+  $ sceptre delete-stack dev vpc [--yes]
 
 
 Next Steps

--- a/sceptre/cli.py
+++ b/sceptre/cli.py
@@ -247,6 +247,7 @@ def create_stack(ctx, environment, stack):
 
 @cli.command(name="delete-stack")
 @stack_options
+@click.confirmation_option(help='Are you sure you want to delete the stack?')
 @click.pass_context
 @catch_exceptions
 def delete_stack(ctx, environment, stack):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ class TestCli(object):
     @patch("sceptre.cli.get_env")
     def test_delete_stack(self, mock_get_env, mock_getcwd):
         mock_getcwd.return_value = sentinel.cwd
-        self.runner.invoke(cli, ["delete-stack", "dev", "vpc"])
+        self.runner.invoke(cli, ["delete-stack", "dev", "vpc", "--yes"])
         mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
         mock_get_env.return_value.stacks["vpc"].delete\
             .assert_called_with()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,13 @@ class TestCli(object):
 
     @patch("sceptre.cli.os.getcwd")
     @patch("sceptre.cli.get_env")
+    def test_delete_stack_without_confirmation(self, mock_get_env, mock_getcwd):
+        mock_getcwd.return_value = sentinel.cwd
+        result = self.runner.invoke(cli, ["delete-stack", "dev", "vpc"])
+        assert result.exit_code == 1
+
+    @patch("sceptre.cli.os.getcwd")
+    @patch("sceptre.cli.get_env")
     def test_update_stack(self, mock_get_env, mock_getcwd):
         mock_getcwd.return_value = sentinel.cwd
         self.runner.invoke(cli, ["update-stack", "dev", "vpc"])


### PR DESCRIPTION
Fixes #61  

To automate your stack deletions  add --yes to your delete stack command.

This uses [Click: Yes Parameters](http://click.pocoo.org/5/options/#yes-parameters) [further detail can be found here](http://click.pocoo.org/5/api/#click.confirmation_option)