### PR TITLE
Fix launch requirements

### DIFF
--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -232,9 +232,9 @@ class Environment(object):
         """
         for dependency in dependencies[stack.name]:
             threading_events[dependency].wait()
-            if stack_statuses[dependency] == StackStatus.FAILED:
+            if stack_statuses[dependency] != StackStatus.COMPLETE:
                 self.logger.debug(
-                    "%s, which %s depends on has failed. Marking "
+                    "%s, which %s depends is not complete. Marking "
                     "%s as failed.", dependency, stack.name, dependency
                 )
                 stack_statuses[stack.name] = StackStatus.FAILED


### PR DESCRIPTION
Previously, when launching an environment, a stack would be launched if
all parent stacks were not in the *_FAILED state. This commit changes
this to only launch a stack if all parent stacks are in the *_COMPLETE
state. These stricter requirements fix issues which occur when a parent
stack is in an e.g. DELETE_FAILED state.