### PR TITLE
Add simplified Config and ConnectionManager inits

### DIFF
--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -38,7 +38,7 @@ def environment(sceptre_dir, environment_path, user_variables=None):
     :returns: The Config for the environment
     :rtype: sceptre.config.Config
     """
-    user_variables = user_variables if user_variables != None else {}
+    user_variables = user_variables if user_variables is not None else {}
     env_config = Config(sceptre_dir, environment_path, "config")
     env_config.read(user_variables)
     return env_config
@@ -56,7 +56,7 @@ def stack(sceptre_dir, stack_name, user_variables=None):
     :returns: The Config for the stack
     :rtype: sceptre.config.Config
     """
-    user_variables = user_variables if user_variables != None else {}
+    user_variables = user_variables if user_variables is not None else {}
     environment_path = os.path.dirname(stack_name)
     basename = os.path.basename(stack_name)
     stack_config = Config.with_yaml_constructors(

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -16,12 +16,55 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from . import __version__
+import connection_manager
 from .exceptions import ConfigItemNotFoundError
 from .exceptions import EnvironmentPathNotFoundError
 from .exceptions import VersionIncompatibleError
 from .hooks import Hook
 from .resolvers import Resolver
+from .helpers import _memoize
 from .helpers import get_subclasses
+
+
+@_memoize
+def environment(sceptre_dir, environment_path):
+    """
+    Returns the Config for the environment ``environment_path``.
+
+    :param sceptre_dir: The absolute path to the Sceptre directory.
+    :type sceptre_dir: str
+    :param environment_path: Path to the environment
+    :type environment_path: str
+    :returns: The Config for the environment
+    :rtype: sceptre.config.Config
+    """
+    env_config = Config(sceptre_dir, environment_path, "config")
+    env_config.read()
+    return env_config
+
+
+@_memoize
+def stack(sceptre_dir, stack_name):
+    """
+    Returns the Config for the stack ``stack_name``.
+
+    :param sceptre_dir: The absolute path to the Sceptre directory.
+    :type sceptre_dir: str
+    :param stack_name: Name of the stack
+    :type stack_name: str
+    :returns: The Config for the stack
+    :rtype: sceptre.config.Config
+    """
+
+    environment_path = os.path.dirname(stack_name)
+    basename = os.path.basename(stack_name)
+    stack_config = Config.with_yaml_constructors(
+        sceptre_dir, environment_path, basename,
+        environment(sceptre_dir, environment_path),
+        connection_manager.connection_manager(sceptre_dir, environment_path)
+    )
+    stack_config.read()
+    return stack_config
 
 
 class Config(dict):
@@ -33,7 +76,7 @@ class Config(dict):
     ``environment_path`` from ``sceptre_dir``.
 
     :param sceptre_dir: The absolute path to the Sceptre directory.
-    :type project dir: str
+    :type sceptre_dir: str
     :param environment_path: The name of the environment.
     :type environment_path: str
     :param base_file_name: The basename of the file to read in \

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -27,7 +27,7 @@ from .helpers import get_subclasses
 
 
 @_memoize
-def environment(sceptre_dir, environment_path):
+def environment(sceptre_dir, environment_path, user_variables=None):
     """
     Returns the Config for the environment ``environment_path``.
 
@@ -38,13 +38,14 @@ def environment(sceptre_dir, environment_path):
     :returns: The Config for the environment
     :rtype: sceptre.config.Config
     """
+    user_variables = user_variables if user_variables != None else {}
     env_config = Config(sceptre_dir, environment_path, "config")
-    env_config.read()
+    env_config.read(user_variables)
     return env_config
 
 
 @_memoize
-def stack(sceptre_dir, stack_name):
+def stack(sceptre_dir, stack_name, user_variables=None):
     """
     Returns the Config for the stack ``stack_name``.
 
@@ -55,7 +56,7 @@ def stack(sceptre_dir, stack_name):
     :returns: The Config for the stack
     :rtype: sceptre.config.Config
     """
-
+    user_variables = user_variables if user_variables != None else {}
     environment_path = os.path.dirname(stack_name)
     basename = os.path.basename(stack_name)
     stack_config = Config.with_yaml_constructors(
@@ -63,7 +64,7 @@ def stack(sceptre_dir, stack_name):
         environment(sceptre_dir, environment_path),
         connection_manager.connection_manager(sceptre_dir, environment_path)
     )
-    stack_config.read()
+    stack_config.read(user_variables)
     return stack_config
 
 

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -13,8 +13,29 @@ import threading
 
 import boto3
 
+import config
+from .helpers import _memoize
 from .helpers import mask_key
 from .helpers import exponential_backoff
+
+
+@_memoize
+def connection_manager(sceptre_dir, environment_path):
+    """
+    Returns the ConnectionManager for the environment ``environment_path``.
+
+    :param sceptre_dir: The absolute path to the Sceptre directory.
+    :type sceptre_dir: str
+    :param environment_path: Path to the environment
+    :type environment_path: str
+    :returns: The ConnectionManager for the environment
+    :rtype: sceptre.connection_manager.ConnectionManager
+    """
+    env_config = config.environment(sceptre_dir, environment_path)
+    return ConnectionManager(
+        region=env_config["region"],
+        iam_role=env_config.get("iam_role")
+    )
 
 
 class ConnectionManager(object):

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -20,7 +20,7 @@ from .helpers import exponential_backoff
 
 
 @_memoize
-def connection_manager(sceptre_dir, environment_path):
+def connection_manager(sceptre_dir, environment_path, user_variables=None):
     """
     Returns the ConnectionManager for the environment ``environment_path``.
 
@@ -31,7 +31,10 @@ def connection_manager(sceptre_dir, environment_path):
     :returns: The ConnectionManager for the environment
     :rtype: sceptre.connection_manager.ConnectionManager
     """
-    env_config = config.environment(sceptre_dir, environment_path)
+    user_variables = user_variables if user_variables != None else {}
+    env_config = config.environment(
+        sceptre_dir, environment_path, user_variables
+    )
     return ConnectionManager(
         region=env_config["region"],
         iam_role=env_config.get("iam_role")

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -31,7 +31,7 @@ def connection_manager(sceptre_dir, environment_path, user_variables=None):
     :returns: The ConnectionManager for the environment
     :rtype: sceptre.connection_manager.ConnectionManager
     """
-    user_variables = user_variables if user_variables != None else {}
+    user_variables = user_variables if user_variables is not None else {}
     env_config = config.environment(
         sceptre_dir, environment_path, user_variables
     )

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -235,13 +235,13 @@ def _memoize(func):
     store = {}
 
     @wraps(func)
-    def wrapper(sceptre_dir, name):
+    def wrapper(sceptre_dir, name, user_variables=None):
         # hashable combination of sceptre_dir and environment_name used to
         # uniquely identify the pair of arguments
         key = (sceptre_dir, name)
         if key in store:
             return store[key]
-        return_val = func(sceptre_dir, name)
+        return_val = func(sceptre_dir, name, user_variables)
         store[key] = return_val
         return return_val
     return wrapper

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -219,3 +219,29 @@ def get_subclasses(class_type, directory=None):
                         classes[camel_to_snake_case(attr.__name__)] = attr
 
     return classes
+
+
+# XXX: This may not be thread-safe.
+def _memoize(func):
+    """
+    Memoizes the result of calls to connection_manager.connection_manager(),
+    config.environment() and config.stack()
+
+    :param func: a function with the signature (sceptre_dir, name).
+    :type func: func
+    :returns: The memoized function.
+    :rtype: func
+    """
+    store = {}
+
+    @wraps(func)
+    def wrapper(sceptre_dir, name):
+        # hashable combination of sceptre_dir and environment_name used to
+        # uniquely identify the pair of arguments
+        key = (sceptre_dir, name)
+        if key in store:
+            return store[key]
+        return_val = func(sceptre_dir, name)
+        store[key] = return_val
+        return return_val
+    return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def fixtures_dir():
+    """
+    Returns the absolute path to the fixtures directory.
+
+    Located at <sceptre_root>/tests/fixtures
+
+    :returns: Path to the fixtures directory.
+    :rtype: str
+    """
+    test_dir = os.path.dirname(__file__)
+    fixtures_dir = os.path.join(test_dir, "fixtures")
+    return fixtures_dir

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,12 +7,49 @@ import os
 from mock import patch, sentinel, call, Mock, ANY
 import pytest
 
+import sceptre.config
 from sceptre.config import Config
 from sceptre.hooks import Hook
 from sceptre.resolvers import Resolver
 from sceptre.exceptions import ConfigItemNotFoundError
 from sceptre.exceptions import EnvironmentPathNotFoundError
 from sceptre.exceptions import VersionIncompatibleError
+
+
+def test_environment_returns_Config(fixtures_dir):
+    conf = sceptre.config.environment(
+        fixtures_dir, "account/environment/region"
+    )
+    assert type(conf) == Config
+
+
+def test_environment_memoizes(fixtures_dir):
+    conf_a = sceptre.config.environment(
+        fixtures_dir, "account/environment/region"
+    )
+    conf_b = sceptre.config.environment(
+        fixtures_dir, "account/environment/region"
+    )
+
+    assert id(conf_a) == id(conf_b)
+
+
+def test_stack_returns_Config(fixtures_dir):
+    conf = sceptre.config.stack(
+        fixtures_dir, "account/environment/region/vpc"
+    )
+    assert type(conf) == Config
+
+
+def test_stack_memoizes(fixtures_dir):
+    conf_a = sceptre.config.stack(
+        fixtures_dir, "account/environment/region/vpc"
+    )
+    conf_b = sceptre.config.stack(
+        fixtures_dir, "account/environment/region/vpc"
+    )
+
+    assert id(conf_a) == id(conf_b)
 
 
 class TestConfig(object):

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -3,9 +3,27 @@ import pytest
 from mock import Mock, patch, sentinel, MagicMock
 from moto import mock_s3
 
+import sceptre.connection_manager
 from sceptre.connection_manager import ConnectionManager
 from boto3.session import Session
 import botocore
+
+
+def test_connection_manager_returns_ConnectionManager(fixtures_dir):
+    cm = sceptre.connection_manager.connection_manager(
+        fixtures_dir, "account/environment/region"
+    )
+    assert type(cm) == ConnectionManager
+
+
+def test_connection_manager_memoizes(fixtures_dir):
+    cm_a = sceptre.connection_manager.connection_manager(
+        fixtures_dir, "account/environment/region"
+    )
+    cm_b = sceptre.connection_manager.connection_manager(
+        fixtures_dir, "account/environment/region"
+    )
+    assert id(cm_a) == id(cm_b)
 
 
 class TestConnectionManager(object):


### PR DESCRIPTION
Config and ConnectionManager both require quite a lot of
context to initialise. This commit adds new functions for
initialising them. The new function require only the sceptre
directory, an environment path or stack name. This should
make it easier to create config and connection managers
without having to instantiate an environment or stack
first. All new functions implement memoization. If a
particular Config or ConnectionManager is requested twice,
a cached version is returned the second time. The functions
aren't being used at the moment, but we should note that they
aren't necessarily thread safe.

The code here hasn't been integrated into the rest of the codebase yet. I'm opening this PR to show my initial sketch of how I think it should work. 