### PR TITLE
fixed misleading \"The template does not have the required..\" error

### DIFF
--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -111,7 +111,13 @@ class Template(object):
         try:
             body = module.sceptre_handler(self.sceptre_user_data)
         except AttributeError as e:
-            raise e
+            if 'sceptre_handler' in e.message:
+                raise TemplateSceptreHandlerError(
+                    "The template does not have the required "
+                    "'sceptre_handler(sceptre_user_data)' function."
+                )
+            else:
+                raise e
         for directory in relpaths_to_add:
             sys.path.remove(os.path.join(os.getcwd(), directory))
         return body

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -111,15 +111,7 @@ class Template(object):
         try:
             body = module.sceptre_handler(self.sceptre_user_data)
         except AttributeError as e:
-            if 'sceptre_handler' in e.message:
-                raise TemplateSceptreHandlerError(
-                    "The template does not have the required "
-                    "'sceptre_handler(sceptre_user_data)' function."
-                )
-            else:
-                raise TemplateSceptreHandlerError(
-                    "Error generating the template: {}".format(e.message)
-                )
+            raise e
         for directory in relpaths_to_add:
             sys.path.remove(os.path.join(os.getcwd(), directory))
         return body

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -110,11 +110,16 @@ class Template(object):
 
         try:
             body = module.sceptre_handler(self.sceptre_user_data)
-        except AttributeError:
-            raise TemplateSceptreHandlerError(
-                "The template does not have the required "
-                "'sceptre_handler(sceptre_user_data)' function."
-            )
+        except AttributeError as e:
+            if 'sceptre_handler' in e.message:
+                raise TemplateSceptreHandlerError(
+                    "The template does not have the required "
+                    "'sceptre_handler(sceptre_user_data)' function."
+                )
+            else:
+                raise TemplateSceptreHandlerError(
+                    "Error generating the template: {}".format(e.message)
+                )
         for directory in relpaths_to_add:
             sys.path.remove(os.path.join(os.getcwd(), directory))
         return body


### PR DESCRIPTION
A fix for if we have a class which calls a non-existing function:

    class SomeClass(object):
        def __init__(self, sceptre_user_data):
            self.template = Template()
            self.sceptre_user_data = sceptre_user_data
            self.non_existing_function()

The template generating class outputs a a misleading error:

`The template does not have the required 'sceptre_handler(sceptre_user_data)' function.`

