### PR TITLE
140 Nonscalar resolvers and hooks

### DIFF
--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -7,6 +7,7 @@ This module implements a Config class, which stores a stack or environment's
 configuration.
 """
 
+import copy
 import logging
 import os
 import yaml
@@ -221,7 +222,7 @@ class Config(dict):
             :rtype: func
             """
             return lambda loader, node: node_class(
-                loader.construct_scalar(node),
+                loader.construct_object(self.resolve_node_tag(loader, node)),
                 connection_manager,
                 environment_config,
                 self
@@ -258,8 +259,9 @@ class Config(dict):
             :returns: A lambda that constructs hook objects.
             :rtype: func
             """
+
             return lambda loader, node: node_class(
-                loader.construct_scalar(node),
+                loader.construct_object(self.resolve_node_tag(loader, node)),
                 connection_manager,
                 environment_config,
                 self
@@ -300,3 +302,9 @@ class Config(dict):
                 "Added constructor for %s with node tag %s",
                 str(node_class), node_tag
             )
+
+
+    def resolve_node_tag(self, loader, node):
+        node = copy.copy(node)
+        node.tag = loader.resolve(type(node), node.value, (True, False))
+        return node

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -2,6 +2,8 @@ import abc
 import logging
 from functools import wraps
 
+from ..resolvers import ResolvableProperty
+
 
 class Hook(object):
     """
@@ -21,6 +23,8 @@ class Hook(object):
     :type connection_manager: sceptre.connection_manager.ConnectionManager
     """
     __metaclass__ = abc.ABCMeta
+    argument = ResolvableProperty("argument")
+    config = {}
 
     def __init__(
             self, argument=None, connection_manager=None,

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -3,46 +3,6 @@ import abc
 import logging
 
 
-class Resolver(object):
-    """
-    Resolver is an abstract base class that should be inherited by all
-    resolvers. Environment config, stack config and the connection
-    manager are supplied to the class, as they may be of use to inheriting
-    classes.
-
-    :param environment_config: The environment_config from config.yaml files.
-    :type environment_config: sceptre.config.Config
-    :param stack_config: The stack config.
-    :type stack_config: sceptre.config.Config
-    :param connection_manager: A connection manager.
-    :type connection_manager: sceptre.connection_manager.ConnectionManager
-    :param argument: Arguments to pass to the resolver.
-    :type argument: str
-    """
-
-    __metaclass__ = abc.ABCMeta
-
-    def __init__(
-        self, argument=None, connection_manager=None,
-        environment_config=None, stack_config=None
-    ):
-        self.logger = logging.getLogger(__name__)
-        self.environment_config = environment_config
-        self.stack_config = stack_config
-        self.connection_manager = connection_manager
-        self.argument = argument
-
-    @abc.abstractmethod
-    def resolve(self):
-        """
-        An abstract method which must be overwritten by all inheriting classes.
-        This method is called to retrieve the final desired value.
-        Implementation of this method in subclasses must return a suitable
-        object or primitive type.
-        """
-        pass  # pragma: no cover
-
-
 class ResolvableProperty(object):
     """
     This is a descriptor class used to store an attribute that may contain
@@ -98,3 +58,43 @@ class ResolvableProperty(object):
                 elif isinstance(value, list) or isinstance(value, dict):
                     self.resolve_values(value)
         return attr
+
+
+class Resolver(object):
+    """
+    Resolver is an abstract base class that should be inherited by all
+    resolvers. Environment config, stack config and the connection
+    manager are supplied to the class, as they may be of use to inheriting
+    classes.
+
+    :param environment_config: The environment_config from config.yaml files.
+    :type environment_config: sceptre.config.Config
+    :param stack_config: The stack config.
+    :type stack_config: sceptre.config.Config
+    :param connection_manager: A connection manager.
+    :type connection_manager: sceptre.connection_manager.ConnectionManager
+    :param argument: Arguments to pass to the resolver.
+    :type argument: str
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(
+        self, argument=None, connection_manager=None,
+        environment_config=None, stack_config=None
+    ):
+        self.logger = logging.getLogger(__name__)
+        self.environment_config = environment_config
+        self.stack_config = stack_config
+        self.connection_manager = connection_manager
+        self.argument = argument
+
+    @abc.abstractmethod
+    def resolve(self):
+        """
+        An abstract method which must be overwritten by all inheriting classes.
+        This method is called to retrieve the final desired value.
+        Implementation of this method in subclasses must return a suitable
+        object or primitive type.
+        """
+        pass  # pragma: no cover

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -78,6 +78,8 @@ class Resolver(object):
     """
 
     __metaclass__ = abc.ABCMeta
+    argument = ResolvableProperty("argument")
+    config = {}
 
     def __init__(
         self, argument=None, connection_manager=None,

--- a/sceptre/resolvers/environment_variable.py
+++ b/sceptre/resolvers/environment_variable.py
@@ -23,4 +23,4 @@ class EnvironmentVariable(Resolver):
         :returns: Value of the environment variable.
         :rtype: str
         """
-        return os.environ.get(self.argument)
+        return os.environ.get(None if self.argument == {} else self.argument)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,9 @@ from contextlib import contextmanager
 from tempfile import mkdtemp
 import shutil
 import os
-from mock import patch, sentinel, call, Mock, ANY
+from mock import patch, sentinel, call, MagicMock, Mock, ANY
 import pytest
+import yaml
 
 from sceptre.config import Config
 from sceptre.hooks import Hook
@@ -204,3 +205,15 @@ class TestConfig(object):
             call("sceptre_dir/hooks", Hook, ANY)
         ]
         mock_add_yaml_constructors.assert_has_calls(calls, any_order=False)
+
+    def test_resolve_node_tag(self):
+        mock_loader = MagicMock(yaml.Loader)
+        mock_loader.resolve.return_value = "new_tag"
+
+        mock_node = MagicMock(yaml.Node)
+        mock_node.tag = "old_tag"
+        mock_node.value = "String"
+        
+        new_node = self.config.resolve_node_tag(mock_loader, mock_node)
+
+        assert new_node.tag == 'new_tag'

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -2,6 +2,7 @@
 from mock import MagicMock
 
 from sceptre.hooks import Hook, add_stack_hooks, execute_hooks
+from sceptre.resolvers import Resolver
 
 
 class MockHook(Hook):
@@ -9,6 +10,11 @@ class MockHook(Hook):
         super(MockHook, self).__init__(*args, **kwargs)
 
     def run(self):
+        pass
+
+
+class MockResolver(Resolver):
+    def resolve(self):
         pass
 
 
@@ -66,3 +72,20 @@ class TestHook(object):
 
     def test_hook_inheritance(self):
         assert isinstance(self.hook, Hook)
+
+    def test_getting_nonscalar_argument(self):
+        mock_resolver = MagicMock(spec=MockResolver)
+        mock_resolver.resolve.return_value = "Resolved"
+
+        nonscalar_hook = MockHook()
+        nonscalar_hook.argument = {
+            "String": "String",
+            "Resolver": mock_resolver
+        }
+
+        resolved_argument = {
+            "String": "String",
+            "Resolver": "Resolved"
+        }
+
+        assert nonscalar_hook.argument == resolved_argument

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -263,3 +263,20 @@ class TestResolvablePropertyDescriptor(object):
         self.mock_object._resolvable_property = complex_data_structure
         property = self.mock_object.resolvable_property
         assert property == resolved_complex_data_structure
+
+    def test_getting_nonscalar_argument(self):
+        mock_resolver = MagicMock(spec=MockResolver)
+        mock_resolver.resolve.return_value = "Resolved"
+
+        nonscalar_resolver = MockResolver()
+        nonscalar_resolver.argument = {
+            "String": "String",
+            "Resolver": mock_resolver
+        }
+
+        resolved_argument = {
+            "String": "String",
+            "Resolver": "Resolved"
+        }
+
+        assert nonscalar_resolver.argument == resolved_argument


### PR DESCRIPTION
Resolves #140 

This adds support for nonscalar arguments to resolvers and hooks, including arguments that themselves contain other resolvers. As a hypothetical example:

```
!s3_upload
  path: some/file/path
  s3_bucket: !stack_output another_stack::BucketName
  s3_object_key: some_key
```

Took me a while to find a solution that felt right, but I finally came to simply changing both `Resolver` and `Hook`'s `argument` properties to be `ResolvableProperty`s.

When creating the YAML tag constructors, we replace the call to `loader.construct_scalar` with `loader.construct_object` (which can handle any type of value). However, just doing this meant that `loader.construct_object` would complain that is seeing the resolver/hook node twice, because when constructing those resolvers/hooks we want to reevaluate the node to pass as the resolver/hook's argument. To fix this, I've added a function `resolve_node_tag` which copies the node and re-resolves its tag to match whatever value it has, removing the explicit resolver/hook tag.

A few thoughts/concerns:

- `ResolvableProperty` is a little bit scary - I've never seen this descriptor protocol in Python before, but it's a little odd that it's basically affecting the object that its a property of. Not only that, but the specific implementation of `ResolvableProperty` relies on the *containing* object to have a `config` property. I'm not 100% sure what that's for (it seems like it basically would provide a default value for the resolvable property?), but it feels a bit awkward.
- There's [a couple of lines](https://github.com/cloudreach/sceptre/blob/7ff56cd58f6885847d8577dade2524663958fb72/sceptre/resolvers/__init__.py#L69-L70) in `ResolvableProperty` that effectively coerce a `None` value into an empty dict. This becomes a problem for cases where the argument of a resolver/hook is actually meant to be `None`. However, there's a test for it so I assume if I changed it it would be considered a breaking change (although, I don't know what depends on it since removing it breaks only that one test). So instead, I've updated the `EnvironmentVariable` resolver (which has a test for when its argument is `None`) to turn the argument back into `None` before using it. Not super nice, but it avoids any breaking changes.
- There are not a lot of integration tests for config files with resolvers and hooks, so I would suggest testing this change on a few existing and complex sceptre stacks before merging! There's also some of the deeper parts of `Config` that aren't tested much (such as where the call to `loader.construct_object` now is).
- There's nothing in the documentation (as far as I can tell) that suggests that nonscalar arguments shouldn't be possible, so I saw this more as removing an unexpected restriction rather than adding a new feature, so I'm not sure whether documentation specifically for this is necessary.

Commit b1a4be0 is just to make the give the second commit a nicer diff - `Resolver` now has a `ResolvableProperty`, so needed to reorder the classes.