### PR TITLE
143 Restore the iam_profile option

### DIFF
--- a/docs/environment_config.rst
+++ b/docs/environment_config.rst
@@ -13,6 +13,8 @@ An environment config file is a yaml object of key-value pairs configuring Scept
 
 - `iam_role`_ *(optional)*
 
+- `iam_profile`_ *(optional)*
+
 - `project_code`_ *(required)*
 
 - `region`_ *(required)*
@@ -29,7 +31,12 @@ Sceptre only checks for and uses the above keys in environment config files, but
 iam_role
 ````````
 
-The ARN of a role for Sceptre to assume before interacting with the environment. If not supplied, Sceptre uses the user's AWS CLI credentials.
+The ARN of a role for Sceptre to assume before interacting with the environment. If not supplied, Sceptre uses the user's AWS CLI credentials. iam_role and iam_profile are mutualy exclusive.
+
+iam_profile
+````````
+
+The name of the local role as defined in ~/.aws/config and ~/.aws/credentials. If not supplied, Sceptre uses the user's AWS CLI credentials. iam_role and iam_profile are mutualy exclusive.
 
 project_code
 ````````````

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -393,7 +393,8 @@ class Environment(object):
         config = self._get_config()
         connection_manager = ConnectionManager(
             region=config["region"],
-            iam_role=config.get("iam_role")
+            iam_role=config.get("iam_role"),
+            iam_profile=config.get("iam_profile")
         )
         stacks = {}
         for stack_name in self._get_available_stacks():

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -433,7 +433,8 @@ class TestEnvironment(object):
     ):
         mock_config = {
             "region": sentinel.region,
-            "iam_role": sentinel.iam_role
+            "iam_role": sentinel.iam_role,
+            "iam_profile": sentinel.iam_profile
         }
         mock_get_config.return_value = mock_config
         mock_ConnectionManager.return_value = sentinel.connection_manager
@@ -445,7 +446,8 @@ class TestEnvironment(object):
         # Check ConnectionManager() is called with correct arguments
         mock_ConnectionManager.assert_called_once_with(
             region=sentinel.region,
-            iam_role=sentinel.iam_role
+            iam_role=sentinel.iam_role,
+            iam_profile=sentinel.iam_profile
         )
 
         # Check Stack() is called with correct arguments


### PR DESCRIPTION
When config files are interprated sceptre will look for an iam_profile
or an iam_role. By default, user should use iam_role. An iam_profile can
be set to give the iam_profile as its in ~/.aws/credentials or
~/.aws/config. Config file should probably commited so iam_profile use
remains local.