### PR TITLE
Adding the ability to generate CFN parameters file from sceptre config files

### DIFF
--- a/integration-tests/features/test-generate-parameters-file.feature
+++ b/integration-tests/features/test-generate-parameters-file.feature
@@ -1,0 +1,6 @@
+Feature: test sceptre's generate-parameter-file
+
+  Scenario: check sceptre can create a json parameters file
+    Given the generate-parameter-file command is run
+    Then the parameters file json syntax is correct
+    And the parameters file contains a valid cidr range

--- a/integration-tests/steps/test_generate_parameters_file.py
+++ b/integration-tests/steps/test_generate_parameters_file.py
@@ -21,7 +21,4 @@ def step_impl(context):
 
 @then("the parameters file contains a valid cidr range")
 def step_impl(context):
-    assert(context.param_json \
-        ["Resources"]["VirtualPrivateCloud"]["Type"] == \
-        "AWS::EC2::VPC"
-    )
+    assert(context.param_json[0]["ParameterValue"] == "10.0.0.0/16")

--- a/integration-tests/steps/test_generate_parameters_file.py
+++ b/integration-tests/steps/test_generate_parameters_file.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from behave import *
+import subprocess
+import json
+
+
+@given("the generate-parameter-file command is run")
+def step_impl(context):
+    context.param_json = subprocess.check_output([
+        "sceptre", "--dir", context.sceptre_dir, "generate-parameters-file",
+        "test-env/a", "vpc"
+    ])
+
+
+@then("the parameters file json syntax is correct")
+def step_impl(context):
+    context.param_json = \
+        json.loads(context.template_json_str.decode("utf8"))
+
+
+@then("the parameters file contains a valid cidr range")
+def step_impl(context):
+    assert(context.param_json \
+        ["Resources"]["VirtualPrivateCloud"]["Type"] == \
+        "AWS::EC2::VPC"
+    )

--- a/sceptre/cli.py
+++ b/sceptre/cli.py
@@ -168,6 +168,21 @@ def generate_template(ctx, environment, stack):
     write(template_output)
 
 
+@cli.command(name="generate-parameter-file")
+@stack_options
+@click.pass_context
+@catch_exceptions
+def generate_parameters_file(ctx, environment, stack):
+    """
+    Displays the parameters used when creating a Cloudformation stack.
+
+    Prints ENVIRONMENT/STACK's input parameters.
+    """
+    env = get_env(ctx.obj["sceptre_dir"], environment, ctx.obj["options"])
+    parameters = stack._format_parameters(env.stacks[stack].parameters)
+    write(parameters)
+
+
 @cli.command(name="lock-stack")
 @stack_options
 @click.pass_context


### PR DESCRIPTION
Sceptre generates the CFN parameters file at dynamically at stack creation time - it would be useful for some use cases to be able to generate the raw CFN template and parameters file from the sceptre configuration, such as when providing the templates and inputs to users that need to make use of the templates outwith the scope of Sceptre.

It slightly goes against the practices of having Sceptre control the full stack deployment but this content is generated by the tool internally and it would be useful to have access to this content directly.

Took a stab at adding this based on the existing code but very likely missed something, so any input you might have would be most appreciated!