### PR TITLE
Bugfix for environment paths with backslashes

### DIFF
--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -369,19 +369,18 @@ class Environment(object):
         config_files = glob(os.path.join(
             self.sceptre_dir, "config", self.path, "*.yaml"
         ))
-        base_config_file_names = [
-            os.path.basename(config_file).split(".")[0]
+        stack_basenames = [
+            os.path.splitext(os.path.basename(config_file))[0]
             for config_file in config_files
         ]
-        stack_basenames = [
-            basename for basename in base_config_file_names
-            if basename != "config"
+
+        if "config" in stack_basenames:
+            stack_basenames.remove("config")
+
+        stack_names = [
+            "/".join([self.path, basename]) for basename in stack_basenames
         ]
-        available_stacks = [
-            "/".join([self.path, basename])
-            for basename in stack_basenames
-        ]
-        return available_stacks
+        return stack_names
 
     def _load_stacks(self):
         """

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -53,10 +53,8 @@ class Environment(object):
         self.logger = logging.getLogger(__name__)
 
         self.sceptre_dir = sceptre_dir
-        self.path = os.path.normpath(environment_path).replace('\\', '/')
+        self.path = self._validate_path(environment_path)
         self._options = {} if options is None else options
-
-        self._check_env_path_valid(self.path)
 
         self._is_leaf = None
 
@@ -74,20 +72,25 @@ class Environment(object):
         )
 
     @staticmethod
-    def _check_env_path_valid(path):
+    def _validate_path(path):
         """
+        Normalises paths and converts backslashes to forward slashes.
         Raises an InvalidEnvironmentPathError if the path has a leading or
         trailing slash.
 
         :param path: A directory path
         :type path: str
         :raises: sceptre.exceptions.InvalidEnvironmentPathError
+        :returns: A normalised path with forward slashes.
+        :returns: string
         """
+        path = path.replace('\\', '/')
         if path.endswith("/") or path.startswith("/"):
             raise InvalidEnvironmentPathError(
                 "'{0}' is an invalid path string. Environment paths should "
                 "not have leading or trailing slashes.".format(path)
             )
+        return os.path.normpath(path)
 
     @property
     def is_leaf(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -53,7 +53,7 @@ class Environment(object):
         self.logger = logging.getLogger(__name__)
 
         self.sceptre_dir = sceptre_dir
-        self.path = environment_path
+        self.path = os.path.normpath(environment_path).replace('\\', '/')
         self._options = {} if options is None else options
 
         self._check_env_path_valid(self.path)

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -74,7 +74,7 @@ class Environment(object):
     @staticmethod
     def _validate_path(path):
         """
-        Converts backslashes to forward slashes.
+        Normalises backslashes to forward slashes for non-unix systems.
         Raises an InvalidEnvironmentPathError if the path has a leading or
         trailing slash.
 
@@ -82,9 +82,9 @@ class Environment(object):
         :type path: str
         :raises: sceptre.exceptions.InvalidEnvironmentPathError
         :returns: A normalised path with forward slashes.
-        :returns: string
+        :rtype: string
         """
-        path = path.replace('\\', '/')
+        path = path.replace("\\", "/")
         if path.endswith("/") or path.startswith("/"):
             raise InvalidEnvironmentPathError(
                 "'{0}' is an invalid path string. Environment paths should "
@@ -372,16 +372,16 @@ class Environment(object):
         config_files = glob(os.path.join(
             self.sceptre_dir, "config", self.path, "*.yaml"
         ))
-        stack_basenames = [
+        basenames = [
             os.path.splitext(os.path.basename(config_file))[0]
             for config_file in config_files
         ]
 
-        if "config" in stack_basenames:
-            stack_basenames.remove("config")
+        if "config" in basenames:
+            basenames.remove("config")
 
         stack_names = [
-            "/".join([self.path, basename]) for basename in stack_basenames
+            "/".join([self.path, basename]) for basename in basenames
         ]
         return stack_names
 

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -74,7 +74,7 @@ class Environment(object):
     @staticmethod
     def _validate_path(path):
         """
-        Normalises paths and converts backslashes to forward slashes.
+        Converts backslashes to forward slashes.
         Raises an InvalidEnvironmentPathError if the path has a leading or
         trailing slash.
 
@@ -90,7 +90,7 @@ class Environment(object):
                 "'{0}' is an invalid path string. Environment paths should "
                 "not have leading or trailing slashes.".format(path)
             )
-        return os.path.normpath(path)
+        return path
 
     @property
     def is_leaf(self):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -84,25 +84,31 @@ class TestEnvironment(object):
         assert path == "valid/env/path"
 
     def test_validate_path_with_double_backslashes_in_path(self):
-        path = self.environment._validate_path("valid\\env\\path")
+        path = self.environment._validate_path('valid\\env\\path')
         assert path == "valid/env/path"
 
-    def test_validate_path_with_invalid_path_leading_slash(self):
+    def test_validate_path_with_leading_slash(self):
         with pytest.raises(InvalidEnvironmentPathError):
             self.environment._validate_path(
                 "/this/environment/path/is/invalid"
             )
 
-    def test_validate_path_with_invalid_path_trailing_slash(self):
+    def test_validate_path_with_leading_backslash(self):
+        with pytest.raises(InvalidEnvironmentPathError):
+            self.environment._validate_path(
+                '\\this\environment\path\is\invalid'
+            )
+
+    def test_validate_path_with_trailing_slash(self):
         with pytest.raises(InvalidEnvironmentPathError):
             self.environment._validate_path(
                 "this/environment/path/is/invalid/"
             )
 
-    def test_validate_path_with_path_leading_backslash(self):
+    def test_validate_path_with_trailing_backslash(self):
         with pytest.raises(InvalidEnvironmentPathError):
             self.environment._validate_path(
-                "/this/environment/path/is/invalid\\"
+                'this\environment\path\is\invalid\\'
             )
 
     def test_is_leaf_with_leaf_dir(self):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -84,7 +84,7 @@ class TestEnvironment(object):
         assert path == "valid/env/path"
 
     def test_validate_path_with_double_backslashes_in_path(self):
-        path = self.environment._validate_path('valid\\env\\path')
+        path = self.environment._validate_path("valid\\env\\path")
         assert path == "valid/env/path"
 
     def test_validate_path_with_leading_slash(self):
@@ -96,7 +96,7 @@ class TestEnvironment(object):
     def test_validate_path_with_leading_backslash(self):
         with pytest.raises(InvalidEnvironmentPathError):
             self.environment._validate_path(
-                '\\this\environment\path\is\invalid'
+                "\\this\environment\path\is\invalid"
             )
 
     def test_validate_path_with_trailing_slash(self):
@@ -108,7 +108,7 @@ class TestEnvironment(object):
     def test_validate_path_with_trailing_backslash(self):
         with pytest.raises(InvalidEnvironmentPathError):
             self.environment._validate_path(
-                'this\environment\path\is\invalid\\'
+                "this\environment\path\is\invalid\\"
             )
 
     def test_is_leaf_with_leaf_dir(self):


### PR DESCRIPTION
This PR make sure Environment objects being given a path with forward slashes. Fixes a bug whereby launching nested environments in a Windows environment would fail due to environment paths containing backslashes.