### PR TITLE
Bugfix unable to delete partial env

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -321,7 +321,7 @@ class Stack(object):
             status = self.get_status()
         except StackDoesNotExistError:
             self.logger.info("%s does not exist.", self.name)
-            status = StackStatus.PENDING
+            status = StackStatus.COMPLETE
             return status
 
         delete_stack_kwargs = {"StackName": self.external_name}

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -455,7 +455,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack._config = {"protect": False}
         mock_get_status.side_effect = StackDoesNotExistError()
         status = self.stack.delete()
-        assert status == StackStatus.PENDING
+        assert status == StackStatus.COMPLETE
 
     def test_describe_stack_sends_correct_request(self):
         self.stack.describe()


### PR DESCRIPTION
This PR fixes a bug introduce in this [commit](https://github.com/cloudreach/sceptre/commit/970c118f2a18105e13e5bb370930f6e2de2ed674). The bug was where partial created environments could not be deleted with the delete-env command.