### PR TITLE
Recreate STS session if expired

### DIFF
--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -8,6 +8,7 @@ from sceptre.exceptions import RetryLimitExceededError
 from boto3.session import Session
 import botocore
 from botocore.exceptions import ClientError
+from datetime import datetime
 
 
 class TestConnectionManager(object):
@@ -94,7 +95,8 @@ class TestConnectionManager(object):
             "Credentials": {
                 "AccessKeyId": "id",
                 "SecretAccessKey": "key",
-                "SessionToken": "token"
+                "SessionToken": "token",
+                "Expiration": datetime(2020, 1, 1)
             }
         }
 
@@ -125,7 +127,8 @@ class TestConnectionManager(object):
             "Credentials": {
                 "AccessKeyId": "id",
                 "SecretAccessKey": "key",
-                "SessionToken": "token"
+                "SessionToken": "token",
+                "Expiration": datetime(2020, 1, 1)
             }
         }
 
@@ -172,6 +175,16 @@ class TestConnectionManager(object):
     @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
     def test_get_client_with_exisiting_client(self, mock_get_credentials):
         service = "cloudformation"
+        client_1 = self.connection_manager._get_client(service)
+        client_2 = self.connection_manager._get_client(service)
+        assert client_1 == client_2
+
+    @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
+    def test_get_client_with_exisiting_client_and_iam_role_none(
+            self, mock_get_credentials
+    ):
+        service = "cloudformation"
+        self.connection_manager._iam_role = None
         client_1 = self.connection_manager._get_client(service)
         client_2 = self.connection_manager._get_client(service)
         assert client_1 == client_2


### PR DESCRIPTION
STS sessions are limited to maximum 1 hour, if a deploy takes
longer than this, sceptre will fail. This commit fixes this by
caching the expiry time and validating it against current time
when a call is made.

Fixes issue in #179 

------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2].
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
