### PR TITLE
Fix misleading empty environment error

### DIFF
--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -201,16 +201,21 @@ class Environment(object):
         :param command: The stack command to run. Can be (launch | delete).
         :type command: str
         """
-        num_stacks = len(self.stacks)
-        with ThreadPoolExecutor(max_workers=num_stacks) as executor:
-            futures = [
-                executor.submit(
-                    self._manage_stack_build, stack,
-                    command, threading_events, stack_statuses, dependencies
-                )
-                for stack in self.stacks.values()
-            ]
-            wait(futures)
+        if self.stacks:
+            num_stacks = len(self.stacks)
+            with ThreadPoolExecutor(max_workers=num_stacks) as executor:
+                futures = [
+                    executor.submit(
+                        self._manage_stack_build, stack,
+                        command, threading_events, stack_statuses, dependencies
+                    )
+                    for stack in self.stacks.values()
+                ]
+                wait(futures)
+        else:
+            self.logger.info(
+                "No stacks found for environment: '%s'", self.path
+            )
 
     def _manage_stack_build(
             self, stack, command, threading_events,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -156,6 +156,11 @@ class TestEnvironment(object):
             sentinel.stack_statuses, sentinel.dependencies
         )
 
+    def test_launch_succeeds_with_empty_env(self):
+        self.environment.stacks = {}
+        response = self.environment.launch()
+        assert response == {}
+
     @patch("sceptre.environment.Environment._build")
     @patch("sceptre.environment.Environment._check_for_circular_dependencies")
     @patch("sceptre.environment.Environment._get_delete_dependencies")
@@ -180,6 +185,11 @@ class TestEnvironment(object):
             "delete", sentinel.threading_events,
             sentinel.stack_statuses, sentinel.dependencies
         )
+
+    def test_delete_succeeds_with_empty_env(self):
+        self.environment.stacks = {}
+        response = self.environment.delete()
+        assert response == {}
 
     def test_describe_with_running_stack(self):
         mock_stack = Mock()


### PR DESCRIPTION
Now when an empty environment (folder) is encountered, an exception will be raises when loading stacks. This exception provides feedback to the developer concerning their invalid environment hierarchy. Prior to this change, various misleading exceptions could be thrown depending on the cli command and placement of the empty environment.

This addresses the issue #163


