### PR TITLE
Update nested dictionnaries in cascaded configs

### DIFF
--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -114,7 +114,8 @@ class Config(dict):
 
         Traverses the environment path, from top to bottom, reading in all
         relevant config files. If config items appear in files lower down the
-        environment tree, they overwrite items from further up. Jinja2 is used
+        environment tree, they overwrite items from further up. If a config item holds a nested
+        dictionnary, update it recursively instead of the config item itself. Jinja2 is used
         to template in variables from user_variables, environment variables,
         and the segments of the environment path.
 
@@ -152,7 +153,14 @@ class Config(dict):
                     if yaml_data is not None:
                         config = yaml_data
                 cascaded_config = get_config(os.path.dirname(path))
-                cascaded_config.update(config)
+
+                for key, value in config.items():
+                    if (key in cascaded_config and isinstance(cascaded_config[key], dict)
+                            and isinstance(value, dict)):
+                        cascaded_config[key].update(value)
+                    else:
+                        cascaded_config[key] = value
+
                 return cascaded_config
 
         config = get_config(path)

--- a/tests/fixtures/config/account/environment/instances.yaml
+++ b/tests/fixtures/config/account/environment/instances.yaml
@@ -1,0 +1,6 @@
+parameters:
+  param1: val1
+sceptre_user_data:
+  key1: data1
+  key3: data3
+role_arn: arn/foo/bar

--- a/tests/fixtures/config/account/environment/region/instances.yaml
+++ b/tests/fixtures/config/account/environment/region/instances.yaml
@@ -1,0 +1,5 @@
+stack_name: test_stack
+sceptre_user_data:
+  key1: overwrite
+  key2: data2
+role_arn: arn/test-cascading

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,6 +115,29 @@ class TestConfig(object):
             'dependencies': []
         }
 
+    def test_read_cascades_config_join(self):
+        self.config.sceptre_dir = os.path.join(
+            os.getcwd(), "tests", "fixtures"
+        )
+        self.config.environment_path = os.path.join(
+            "account", "environment", "region"
+        )
+        self.config.name = "instances"
+        self.config.read()
+        assert self.config == {
+            "stack_name": "test_stack",
+            "role_arn": "arn/test-cascading",
+            "parameters": {
+                "param1": "val1"
+            },
+            "sceptre_user_data": {
+                "key1": "overwrite",
+                "key2": "data2",
+                "key3": "data3"
+            },
+            'dependencies': []
+        }
+
     def test_read_with_templated_config_file(self):
         self.config.sceptre_dir = os.path.join(
             os.getcwd(), "tests", "fixtures"

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -442,7 +442,8 @@ class TestEnvironment(object):
         assert sorted(response) == sorted([
             "account/environment/region/vpc",
             "account/environment/region/subnets",
-            "account/environment/region/security_groups"
+            "account/environment/region/security_groups",
+            "account/environment/region/instances"
         ])
 
     @patch("sceptre.environment.Stack")


### PR DESCRIPTION
Instead of overwriting nested configs, check if the config item is a dict and if so, update it instead.

This allows generic definitions of nested dictionaries, such as parameters or scepte_user_data for instance.
See the updated test for example.
Really enjoying sceptre here at ubisoft, thanks for sharing!