### PR TITLE
Add change-set-type param to create-change-set

### DIFF
--- a/sceptre/cli.py
+++ b/sceptre/cli.py
@@ -346,9 +346,14 @@ def continue_update_rollback(ctx, environment, stack):
 
 @cli.command(name="create-change-set")
 @change_set_options
+@click.option(
+    "--change-set-type", type=click.Choice(["UPDATE", "CREATE"]),
+    default="UPDATE", help="The type of change set operation. To create a "
+    "change set for a new stack, specify CREATE. To create a change set for "
+    "an existing stack, specify UPDATE.")
 @click.pass_context
 @catch_exceptions
-def create_change_set(ctx, environment, stack, change_set_name):
+def create_change_set(ctx, environment, stack, change_set_name, change_set_type):
     """
     Creates a change set.
 
@@ -356,7 +361,7 @@ def create_change_set(ctx, environment, stack, change_set_name):
     CHANGE_SET_NAME.
     """
     env = get_env(ctx.obj["sceptre_dir"], environment, ctx.obj["options"])
-    env.stacks[stack].create_change_set(change_set_name)
+    env.stacks[stack].create_change_set(change_set_name, change_set_type)
 
 
 @cli.command(name="delete-change-set")

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -508,18 +508,22 @@ class Stack(object):
         )
         return response
 
-    def create_change_set(self, change_set_name):
+    def create_change_set(self, change_set_name, change_set_type):
         """
         Creates a change set with the name ``change_set_name``.
 
         :param change_set_name: The name of the change set.
         :type change_set_name: str
+        :param change_set_type: The type of change set operation, UPDATE \
+            or CREATE.
+        :type change_set_type: str
         """
         create_change_set_kwargs = {
             "StackName": self.external_name,
             "Parameters": self._format_parameters(self.parameters),
             "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
             "ChangeSetName": change_set_name,
+            "ChangeSetType": change_set_type,
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
                 for k, v in self.config.get("stack_tags", {}).items()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,14 +215,27 @@ class TestCli(object):
 
     @patch("sceptre.cli.os.getcwd")
     @patch("sceptre.cli.get_env")
-    def test_create_change_set(self, mock_get_env, mock_getcwd):
+    def test_create_change_set_for_update(self, mock_get_env, mock_getcwd):
         mock_getcwd.return_value = sentinel.cwd
         self.runner.invoke(
-            cli, ["create-change-set", "dev", "vpc", "cs1"]
+            cli, ["create-change-set", "dev", "vpc", "cs1",
+                "--change-set-type", "UPDATE"]
         )
         mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
         mock_get_env.return_value.stacks["vpc"].create_change_set\
-            .assert_called_with("cs1")
+            .assert_called_with("cs1", "UPDATE")
+
+    @patch("sceptre.cli.os.getcwd")
+    @patch("sceptre.cli.get_env")
+    def test_create_change_set_for_create(self, mock_get_env, mock_getcwd):
+        mock_getcwd.return_value = sentinel.cwd
+        self.runner.invoke(
+            cli, ["create-change-set", "dev", "vpc", "cs1",
+                "--change-set-type", "CREATE"]
+        )
+        mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
+        mock_get_env.return_value.stacks["vpc"].create_change_set\
+            .assert_called_with("cs1", "CREATE")
 
     @patch("sceptre.cli.os.getcwd")
     @patch("sceptre.cli.get_env")

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -599,7 +599,9 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         }
         self.stack.config["role_arn"] = sentinel.role_arn
 
-        self.stack.create_change_set(sentinel.change_set_name)
+        CHANGE_SET_TYPE = 'UPDATE'
+
+        self.stack.create_change_set(sentinel.change_set_name, CHANGE_SET_TYPE)
         self.stack.connection_manager.call.assert_called_with(
             service="cloudformation",
             command="create_change_set",
@@ -609,6 +611,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
                 "Parameters": sentinel.parameters,
                 "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                 "ChangeSetName": sentinel.change_set_name,
+                "ChangeSetType": CHANGE_SET_TYPE,
                 "RoleARN": sentinel.role_arn,
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}


### PR DESCRIPTION
This allows creating stacks via change sets, rather than exclusively updating existing stacks.

(My use case for this is to be able to create stacks from templates which use a `Transform` directive, necessary for Serverless Application Model templates - for some reason, `create-stack` fails with these and the workaround is to create the stack view a change set instead.)

Addresses #198 