### PR TITLE
Entry point hooks

### DIFF
--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -102,19 +102,25 @@ Users can define their own custom hooks, allowing users to extend hooks and inte
 
 A hook is a Python class which inherits from abstract base class `Hook` found in the `sceptre.hooks module`.
 
-Hooks are require to implement a `run()` function that takes no parameters and to call the base class initializer on initialisation.
+Hooks are require to implement a `run()` function that takes no parameters and to call the base class initializer.
 
-Hooks may have access to `argument`,  `stack_config`, `environment_config` and `connection_manager` as an attribute of `self`. For example `self.stack_config`.
+Hooks may have access to `argument`,  `stack_config`, `environment_config` and `connection_manager` as object attributes. For example `self.stack_config`.
+
+Sceptre uses the `sceptre.hooks` entry point to locate hook classes. Your custom hook can be written anywhere and is installed as Python package.
 
 Hook classes are defined in python files located at:
 
-```
-<sceptre_project_dir>/hooks/<your hook>.py
-```
-
-Sceptre retrieves any class which inherits from base class Hook found within this directory. The name of the hook is the class name in snake case format. e.g. `class CustomHook` is `custom_hook`.  An arbitrary file name may be used as it is not checked by Sceptre.
+### Example
 
 The following python module template can be copied and used:
+
+```bash
+custom_hook
+├── custom_hook.py
+└── setup.py
+```
+
+#### custom_hook.py
 
 ```python
 from sceptre.hooks import Hook
@@ -131,16 +137,32 @@ class CustomHook(Hook):
         intended by this hook.
 
         self.argument is available from the base class and contains the
-        argument defined in the sceptre config file (see below)
+        argument defined in the Sceptre config file (see below)
 
         The following attributes may be available from the base class:
         self.stack_config  (A dict of data from <stack_name>.yaml)
         self.environment_config  (A dict of data from config.yaml)
         self.connection_manager (A connection_manager)
         """
-        print self.argument
+        print(self.argument)
 ```
 
+#### setup.py
+
+```python
+from setuptools import setup
+
+setup(
+    name='custom_hook',
+    entry_points={
+        'sceptre.hooks': [
+            'custom_hook = custom_hook:CustomHook',
+        ],
+    }
+)
+```
+
+Then install using `python setup.py install` or `pip install .` commands.
 
 This hook can be used in a stack config file with the following syntax:
 

--- a/docs/docs/resolvers.md
+++ b/docs/docs/resolvers.md
@@ -110,16 +110,23 @@ Resolvers are require to implement a `resolve()` function that takes no paramete
 
 Resolvers may have access to `argument`,  `stack_config`, `environment_config` and `connection_manager` as an attribute of `self`. For example `self.stack_config`.
 
-This class should be defined in a file which is located at:
+Sceptre uses the `sceptre.resolvers` entry point to locate resolver classes. Your custom resolver can be written anywhere and is installed as Python package.
 
-```
-<sceptre_dir>/resolvers/<your resolver>.py
-```
+Resolver classes are defined in python files located at:
 
-An arbitrary file name may be used as it is not checked by Sceptre.
+### Example
 
 The following python module template can be copied and used:
 
+```bash
+custom_resolver
+├── custom_resolver.py
+└── setup.py
+```
+
+The following python module template can be copied and used:
+
+#### custom_resolver.py
 
 ```python
 from sceptre.resolvers import Resolver
@@ -145,6 +152,23 @@ class CustomResolver(Resolver):
     """
     return self.argument
 ```
+
+#### setup.py
+
+```python
+from setuptools import setup
+
+setup(
+    name='custom_resolver',
+    entry_points={
+        'sceptre.hooks': [
+            'custom_resolver = custom_resolver:CustomResolver',
+        ],
+    }
+)
+```
+
+Then install using `python setup.py install` or `pip install .` commands.
 
 This resolver can be used in a stack config file with the following syntax:
 

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -115,10 +115,10 @@ class Config(dict):
         """
         obj = cls(sceptre_dir, environment_path, base_file_name)
         obj._add_yaml_constructors(
-            "sceptre.resolvers", environment_config, connection_manager
+            "sceptre.resolvers", connection_manager, environment_config
         )
         obj._add_yaml_constructors(
-            "sceptre.hooks", environment_config, connection_manager
+            "sceptre.hooks", connection_manager, environment_config
         )
         return obj
 

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -11,6 +11,8 @@ import logging
 import os
 import yaml
 import collections
+import pkg_resources
+
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from packaging.specifiers import SpecifierSet
@@ -22,7 +24,6 @@ from .exceptions import EnvironmentPathNotFoundError
 from .exceptions import VersionIncompatibleError
 from .hooks import Hook
 from .resolvers import Resolver
-from .helpers import get_subclasses
 
 ConfigAttributes = collections.namedtuple("Attributes", "required optional")
 
@@ -113,10 +114,12 @@ class Config(dict):
         :type connection_manager: sceptre.connection_manager.ConnectionManager
         """
         obj = cls(sceptre_dir, environment_path, base_file_name)
-        obj.add_resolver_constructors(
-            environment_config, connection_manager)
-        obj.add_hook_constructors(
-            environment_config, connection_manager)
+        obj._add_yaml_constructors(
+            "sceptre.resolvers", environment_config, connection_manager
+        )
+        obj._add_yaml_constructors(
+            "sceptre.hooks", environment_config, connection_manager
+        )
         return obj
 
     def __getitem__(self, item):
@@ -227,52 +230,15 @@ class Config(dict):
                     )
                 )
 
-    def add_resolver_constructors(
-            self, environment_config, connection_manager
+    def _add_yaml_constructors(
+        self, entry_point_name, connection_manager, environment_config
     ):
         """
-        Adds PyYAML constructors for all resolver classes found in the
-        resolvers folder within Sceptre library and the current Sceptre project
-        folder.
+        Adds PyYAML constructors for all classes found registered at the
+        entry_point_name.
 
-        :param environment_config: A environment config.
-        :type environment_config: sceptre.config.Config
-        :param connection_manager: A connection manager.
-        :type connection_manager: sceptre.connection_manager.ConnectionManager
-        """
-        self.logger.debug("Adding resolver yaml constructors")
-
-        def resolver_constructor_factory(node_class):
-            """
-            Returns a lambda function that will contruct objects from a
-            given node class.
-
-            :param node_class: A resolver class to construct of objects from.
-            :type node_class: class
-            :returns: A lambda that constructs resolver objects.
-            :rtype: func
-            """
-            return lambda loader, node: node_class(
-                loader.construct_scalar(node),
-                connection_manager,
-                environment_config,
-                self
-            )  # pragma: no cover
-
-        resolvers_folder = os.path.join(os.path.dirname(__file__), "resolvers")
-        self.add_yaml_constructors(
-            resolvers_folder, Resolver, resolver_constructor_factory
-        )
-        external_resolver_folder = os.path.join(self.sceptre_dir, "resolvers")
-        self.add_yaml_constructors(
-            external_resolver_folder, Resolver, resolver_constructor_factory
-        )
-
-    def add_hook_constructors(self, environment_config, connection_manager):
-        """
-        Adds PyYAML constructors for all hook classes found in the hooks folder
-        within Sceptre library and the current Sceptre project folder.
-
+        :param entry_point_name: The name of the entry point.
+        :type entry_point_name: str
         :param environment_config: A environment config.
         :type environment_config: Config
         :param connection_manager: A connection manager.
@@ -280,7 +246,7 @@ class Config(dict):
         """
         self.logger.debug("Adding hook yaml constructors")
 
-        def hook_constructor_factory(node_class):
+        def factory(node_class):
             """
             This returns a lambda function that will contruct objects from a
             given node class.
@@ -297,34 +263,9 @@ class Config(dict):
                 self
             )  # pragma: no cover
 
-        library_hook_folder = os.path.join(os.path.dirname(__file__), "hooks")
-        self.add_yaml_constructors(
-            library_hook_folder, Hook, hook_constructor_factory
-        )
-
-        project_hook_folder = os.path.join(self.sceptre_dir, "hooks")
-        self.add_yaml_constructors(
-            project_hook_folder, Hook, hook_constructor_factory
-        )
-
-    def add_yaml_constructors(self, base_directory, base_type, factory):
-        """
-        Adds PyYAML constructors for all classes which inherit from a
-        specific base type within a given directory.
-
-        :param base_directory: A path of a directory to search for classes.
-        :type base_directory: str
-        :param base_type: The base class in which the class must inherit from.
-        :type base_type: class
-        :param factory: A function to use to construct objects.
-        :type factory: function
-        """
-        classes = get_subclasses(
-            directory=base_directory, class_type=base_type
-        )
-
-        for node_name, node_class in classes.items():
-            node_tag = u'!' + node_name
+        for entry_point in pkg_resources.iter_entry_points(entry_point_name):
+            node_tag = u'!' + entry_point.name
+            node_class = entry_point.load()
             yaml.SafeLoader.add_constructor(
                 node_tag, factory(node_class)
             )

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -7,12 +7,11 @@ This module implements a Config class, which stores a stack or environment's
 configuration.
 """
 
+import collections
 import logging
 import os
-import yaml
-import collections
 import pkg_resources
-
+import yaml
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from packaging.specifiers import SpecifierSet
@@ -22,8 +21,6 @@ from . import __version__
 from .exceptions import ConfigItemNotFoundError
 from .exceptions import EnvironmentPathNotFoundError
 from .exceptions import VersionIncompatibleError
-from .hooks import Hook
-from .resolvers import Resolver
 
 ConfigAttributes = collections.namedtuple("Attributes", "required optional")
 

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,24 @@ setup(
         "sceptre": "sceptre"
     },
     py_modules=["sceptre"],
-    entry_points="""
-        [console_scripts]
-        sceptre=sceptre.cli:cli
-    """,
+    entry_points={
+        "console_scripts": [
+            'sceptre = sceptre.cli:cli'
+        ],
+        "sceptre.hooks":[
+            "asg_scheduled_actions ="
+            "sceptre.hooks.asg_scheduled_actions:ASGScheduledActions",
+            "cmd = sceptre.hooks.cmd:Cmd"
+        ],
+        "sceptre.resolvers":[
+            "environment_variable ="
+            "sceptre.resolvers.environment_variable:EnvironmentVariable",
+            "file_contents = sceptre.resolvers.file_contents:FileContents",
+            "stack_output = sceptre.resolvers.stack_output:StackOutput",
+            "stack_output_external ="
+            "sceptre.resolvers.stack_output:StackOutputExternal"
+        ]
+    },
     data_files=[
         ("sceptre/stack_policies", [
             "sceptre/stack_policies/lock.json",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ],
         "sceptre.hooks":[
             "asg_scheduled_actions ="
-            "sceptre.hooks.asg_scheduled_actions:ASGScheduledActions",
+            "sceptre.hooks.asg_scaling_processes:ASGScalingProcesses",
             "cmd = sceptre.hooks.cmd:Cmd"
         ],
         "sceptre.resolvers":[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,16 +2,13 @@
 
 from contextlib import contextmanager
 from tempfile import mkdtemp
-import shutil
 import os
-from mock import patch, sentinel, call, Mock, ANY
+from mock import patch, sentinel
 import pytest
+import shutil
 import yaml
 
 from sceptre.config import Config
-from sceptre.hooks import Hook
-from sceptre.hooks.cmd import Cmd
-from sceptre.resolvers import Resolver
 from sceptre.exceptions import ConfigItemNotFoundError
 from sceptre.exceptions import EnvironmentPathNotFoundError
 from sceptre.exceptions import VersionIncompatibleError

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,6 @@ class TestConfig(object):
         assert "!cmd" in yaml.SafeLoader.yaml_constructors
         assert "!asg_scheduled_actions" in yaml.SafeLoader.yaml_constructors
 
-
     def test_get_attribute_with_valid_attribute(self):
         self.config["key"] = "value"
         assert self.config["key"] == "value"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,9 +6,11 @@ import shutil
 import os
 from mock import patch, sentinel, call, Mock, ANY
 import pytest
+import yaml
 
 from sceptre.config import Config
 from sceptre.hooks import Hook
+from sceptre.hooks.cmd import Cmd
 from sceptre.resolvers import Resolver
 from sceptre.exceptions import ConfigItemNotFoundError
 from sceptre.exceptions import EnvironmentPathNotFoundError
@@ -36,12 +38,9 @@ class TestConfig(object):
         assert self.config.environment_path == "environment_path"
         assert self.config.name == "config"
 
-    @patch("sceptre.config.Config.add_hook_constructors")
-    @patch("sceptre.config.Config.add_resolver_constructors")
     @patch("sceptre.config.Config._check_env_path_exists")
     def test_initialise_with_yaml_constructors(
-        self, mock_check_env_path_exists,
-        mock_add_resolver_constructors, mock_add_hook_constructors
+        self, mock_check_env_path_exists
     ):
         config = Config.with_yaml_constructors(
             sceptre_dir="sceptre_dir",
@@ -53,12 +52,13 @@ class TestConfig(object):
         assert config.sceptre_dir == "sceptre_dir"
         assert config.environment_path == "environment_path"
         assert config.name == "config"
-        mock_add_resolver_constructors.assert_called_once_with(
-            sentinel.environment_config, sentinel.connection_manager
-        )
-        mock_add_hook_constructors.assert_called_once_with(
-            sentinel.environment_config, sentinel.connection_manager
-        )
+        assert "!stack_output" in yaml.SafeLoader.yaml_constructors
+        assert "!stack_output_external" in yaml.SafeLoader.yaml_constructors
+        assert "!environment_variable" in yaml.SafeLoader.yaml_constructors
+        assert "!file_contents" in yaml.SafeLoader.yaml_constructors
+        assert "!cmd" in yaml.SafeLoader.yaml_constructors
+        assert "!asg_scheduled_actions" in yaml.SafeLoader.yaml_constructors
+
 
     def test_get_attribute_with_valid_attribute(self):
         self.config["key"] = "value"
@@ -151,56 +151,3 @@ class TestConfig(object):
         self.config['require_version'] = '<0'
         with pytest.raises(VersionIncompatibleError):
             self.config._check_version()
-
-    @patch("sceptre.config.get_subclasses")
-    @patch("sceptre.config.yaml.SafeLoader.add_constructor")
-    def test_add_yaml_constructors(
-        self, mock_add_constructors, mock_get_subclasses
-    ):
-        mock_get_subclasses.return_value = {
-            "class_1": sentinel.class_1,
-            "class_2": sentinel.class_2,
-            "class_3": sentinel.class_3,
-        }
-        directory = "directory/path"
-        base_type = str
-        function = Mock(return_value="class")
-        self.config.add_yaml_constructors(directory, base_type, function)
-        calls = [call(u'!class_1', "class"),
-                 call(u'!class_2', "class"),
-                 call(u'!class_3', "class")]
-        mock_add_constructors.assert_has_calls(calls, any_order=True)
-
-    @patch("sceptre.config.os.path.dirname")
-    @patch("sceptre.config.Config.add_yaml_constructors")
-    def test_add_resolver_constructors(
-        self, mock_add_yaml_constructors, mock_dirname
-    ):
-        mock_dirname.return_value = "folder/with/file"
-        environment_config = sentinel.environment_config
-        connection_manager = sentinel.connection_manager
-        self.config.add_resolver_constructors(
-            environment_config, connection_manager
-        )
-        calls = [
-            call("folder/with/file/resolvers", Resolver, ANY),
-            call("sceptre_dir/resolvers", Resolver, ANY)
-        ]
-        mock_add_yaml_constructors.assert_has_calls(calls, any_order=False)
-
-    @patch("sceptre.config.os.path.dirname")
-    @patch("sceptre.config.Config.add_yaml_constructors")
-    def test_add_hook_constructors(
-        self, mock_add_yaml_constructors, mock_dirname
-    ):
-        mock_dirname.return_value = "folder/with/file"
-        environment_config = sentinel.environment_config
-        connection_manager = sentinel.connection_manager
-        self.config.add_hook_constructors(
-            environment_config, connection_manager
-        )
-        calls = [
-            call("folder/with/file/hooks", Hook, ANY),
-            call("sceptre_dir/hooks", Hook, ANY)
-        ]
-        mock_add_yaml_constructors.assert_has_calls(calls, any_order=False)


### PR DESCRIPTION
This PR changes the way in which resolvers and hooks integrate with Sceptre. With this PR Sceptre takes advantages of entry points to enable plugins. This means custom resolvers and hooks can now be pip installed. Main refactor occurs in the Config class whereby the "hooks" and "resolvers" folder within the local project and the Sceptre installation are searched to find subclasses of either Hook or Resolver. Now the Config class will use classes registered at the `sceptre.hooks` and sceptre.resolvers` entry points to create the Yaml constructors. Unit tests and documentation have been updated. No further integration tests added as should be covered by the tests specific for each resolver or hook.