### PR TITLE
Add passing environment_config to stack template render

### DIFF
--- a/docs/docs/stack_config.md
+++ b/docs/docs/stack_config.md
@@ -130,6 +130,16 @@ Stack config can be cascaded in the same way Environment config can be, as descr
 
 Stack config supports templating in the same way Environment config can be, as described in the section in Environment Config on [Templating]({{ site.baseurl }}/docs/environment_config.html#templating).
 
+Stack config makes environment config available to template.
+
+### Environment config
+
+```yaml
+parameters:
+  Region: {{ environment_config.region }}
+```
+
+
 Environment Variables
 ---------------------
 

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -140,7 +140,7 @@ class Config(dict):
                 )
             )
 
-    def read(self, user_variables=None):
+    def read(self, user_variables=None, environment_config=None):
         """
         Reads in configuration from files.
 
@@ -177,7 +177,8 @@ class Config(dict):
                     rendered_template = template.render(
                         environment_variable=os.environ,
                         var=user_variables,
-                        environment_path=self.environment_path.split("/")
+                        environment_path=self.environment_path.split("/"),
+                        environment_config=environment_config
                     )
 
                     yaml_data = yaml.safe_load(rendered_template)

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -97,7 +97,8 @@ class Stack(object):
                     connection_manager=self.connection_manager
                 )
                 self._config.read(
-                    self.environment_config.get("user_variables")
+                    self.environment_config.get("user_variables"),
+                    self.environment_config
                 )
 
         return self._config

--- a/tests/fixtures/config/account/environment/region/security_groups.yaml
+++ b/tests/fixtures/config/account/environment/region/security_groups.yaml
@@ -4,3 +4,4 @@ parameters:
   param3: {{ environment_path.0 }}
   param4: {{ environment_path.1 }}
   param5: {{ environment_path.2 }}
+  param6: {{ environment_config.region }}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,7 +124,9 @@ class TestConfig(object):
         )
         self.config.name = "security_groups"
         os.environ["TEST_ENV_VAR"] = "environment_variable_value"
-        self.config.read({"user_variable": "user_variable_value"})
+        user_variables = {"user_variable": "user_variable_value"}
+        environment_config = {"region": "region"}
+        self.config.read(user_variables, environment_config)
 
         assert self.config == {
             "parameters": {
@@ -132,7 +134,8 @@ class TestConfig(object):
                 "param2": "environment_variable_value",
                 "param3": "account",
                 "param4": "environment",
-                "param5": "region"
+                "param5": "region",
+                "param6": "region"
             },
             'dependencies': []
         }

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -113,7 +113,8 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             environment_config=self.stack.environment_config,
             connection_manager=self.stack.connection_manager
         )
-        mock_config.read.assert_called_once_with(sentinel.user_variables)
+        mock_config.read.assert_called_once_with(sentinel.user_variables,
+                                                 self.stack.environment_config)
         assert response == mock_config
 
     def test_config_returns_config_if_it_exists(self):


### PR DESCRIPTION
It would be useful to have environment_config available in the stack
config template for access to parameters like region. It would be also
a good place to define extra attributes that could be used for default
values across environment.

Adds passing enviornment_config as "environment_config" to stack
Config read.

Fixes #150 and #119.
