### PR TITLE
Add describe-env-dependencies command

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -36,6 +36,7 @@ $ sceptre delete-stack
 $ sceptre describe-change-set
 $ sceptre describe-env
 $ sceptre describe-env-resources
+$ sceptre describe-env-dependencies
 $ sceptre describe-stack-outputs
 $ sceptre describe-stack-resources
 $ sceptre diff
@@ -77,4 +78,11 @@ Note that Sceptre prepends the string `SCEPTRE_` to the name of the environment 
 ```shell
 $ env | grep SCEPTRE
 SCEPTRE_<output_name>=<output_value>
+```
+
+## Visualizing Environment Dependencies
+
+The `describe-env-dependencies` command can produce output in the DOT language. DOT can easily be converted to an image by making use of the dot command provided by GraphViz:
+```shell
+$ sceptre describe-env-dependencies ENVIRONMENT --dot | dot -Tpng > dependencies.png
 ```

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -122,7 +122,7 @@ class Environment(object):
         self.logger.debug("Launching environment '%s'", self.path)
         threading_events = self._get_threading_events()
         stack_statuses = self._get_initial_statuses()
-        launch_dependencies = self._get_launch_dependencies(self.path)
+        launch_dependencies = self.get_launch_dependencies(self.path)
 
         self._check_for_circular_dependencies(launch_dependencies)
         self._build(
@@ -139,7 +139,7 @@ class Environment(object):
         self.logger.debug("Deleting environment '%s'", self.path)
         threading_events = self._get_threading_events()
         stack_statuses = self._get_initial_statuses()
-        delete_dependencies = self._get_delete_dependencies()
+        delete_dependencies = self.get_delete_dependencies()
 
         self._check_for_circular_dependencies(delete_dependencies)
         self._build(
@@ -289,7 +289,7 @@ class Environment(object):
         }
 
     @recurse_into_sub_environments
-    def _get_launch_dependencies(self, top_level_environment_path):
+    def get_launch_dependencies(self, top_level_environment_path):
         """
         Returns a dict of each stack's launch dependencies.
 
@@ -313,7 +313,7 @@ class Environment(object):
         }
         return launch_dependencies
 
-    def _get_delete_dependencies(self):
+    def get_delete_dependencies(self):
         """
         Returns a dict of each stack's delete dependencies.
 
@@ -321,7 +321,7 @@ class Environment(object):
             while deleting, keyed by that stack's name.
         :rtype: dict
         """
-        launch_dependencies = self._get_launch_dependencies(self.path)
+        launch_dependencies = self.get_launch_dependencies(self.path)
         delete_dependencies = {
             stack_name: [] for stack_name in launch_dependencies
         }

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -133,7 +133,7 @@ class TestEnvironment(object):
 
     @patch("sceptre.environment.Environment._build")
     @patch("sceptre.environment.Environment._check_for_circular_dependencies")
-    @patch("sceptre.environment.Environment._get_launch_dependencies")
+    @patch("sceptre.environment.Environment.get_launch_dependencies")
     @patch("sceptre.environment.Environment._get_initial_statuses")
     @patch("sceptre.environment.Environment._get_threading_events")
     def test_launch_calls_build_with_correct_args(
@@ -163,7 +163,7 @@ class TestEnvironment(object):
 
     @patch("sceptre.environment.Environment._build")
     @patch("sceptre.environment.Environment._check_for_circular_dependencies")
-    @patch("sceptre.environment.Environment._get_delete_dependencies")
+    @patch("sceptre.environment.Environment.get_delete_dependencies")
     @patch("sceptre.environment.Environment._get_initial_statuses")
     @patch("sceptre.environment.Environment._get_threading_events")
     def test_delete_calls_build_with_correct_args(
@@ -379,7 +379,7 @@ class TestEnvironment(object):
 
         self.environment.stacks = {"mock_stack": mock_stack}
 
-        response = self.environment._get_launch_dependencies("dev")
+        response = self.environment.get_launch_dependencies("dev")
 
         # Note that "prod/sg" is filtered out, because it's not under the
         # top level environment path "dev".
@@ -387,7 +387,7 @@ class TestEnvironment(object):
             "dev/mock_stack": ["dev/vpc", "dev/subnets"]
         }
 
-    @patch("sceptre.environment.Environment._get_launch_dependencies")
+    @patch("sceptre.environment.Environment.get_launch_dependencies")
     def test_get_delete_dependencies(self, mock_get_launch_dependencies):
         mock_get_launch_dependencies.return_value = {
             "dev/mock_stack_1": [],
@@ -395,7 +395,7 @@ class TestEnvironment(object):
             "dev/mock_stack_3": ["dev/mock_stack_1", "dev/mock_stack_2"],
         }
 
-        dependencies = self.environment._get_delete_dependencies()
+        dependencies = self.environment.get_delete_dependencies()
         assert dependencies == {
             "dev/mock_stack_1": ["dev/mock_stack_3"],
             "dev/mock_stack_2": ["dev/mock_stack_3"],


### PR DESCRIPTION
Fix #201 Add describe-env-dependencies to expose the stack dependencies within an environment

This commit also allows users to output their dependencies using the DOT language, which can be used to graph the dependencies using programs like Graphwiz.

Couple questions:
1. Thoughts on the name of the command? Would something simpler like `graph` be more user friendly?
2. Is it possible to include a picture in the docs? Something like this is good motivation to use a command: ![dependencies](https://user-images.githubusercontent.com/6810900/30999251-cc54d12e-a488-11e7-801b-992ee22f0bf7.png)

