### PR TITLE
Allow referencing of stack config & document string/case manipulation by jinja

### DIFF
--- a/docs/docs/environment_config.md
+++ b/docs/docs/environment_config.md
@@ -160,6 +160,16 @@ Any templated value can be supplied with a default value with the syntax:
 {% raw %}{{ var.value | default("default_value") }}{% endraw %}
 ```
 
+### String Manipulation
+
+Variables are rendered by Jinja2 and so can have their case change, can be sliced, split or combined with other strings
+
+```jinja2
+{% raw %}
+bucket_name: {{ environment_path.0.lower() }}-{{ environment_path.1.lower() }}-assets
+object_path: {{ environment_path.0.0 }}/{{ environment_path.1[-1] }}/{{ var.value.split("_")[-1] }}/dont/do/this/
+{% endraw %}
+```
 
 ## Examples
 

--- a/docs/docs/stack_config.md
+++ b/docs/docs/stack_config.md
@@ -135,13 +135,21 @@ Stack config can be cascaded in the same way Environment config can be, as descr
 
 Stack config supports templating in the same way Environment config can be, as described in the section in Environment Config on [Templating]({{ site.baseurl }}/docs/environment_config.html#templating).
 
-Stack config makes environment config available to template.
+Stack config makes environment config & stack config available to template.
 
-### Environment config
+### Environment & Stack config
 
 ```yaml
+{% raw %}
 parameters:
   Region: {{ environment_config.region }}
+{% endraw %}
+```
+
+```yaml
+{% raw %}
+stack_name: {{ environment_path.0 }}-{{ environment_path.1 }}-NET-001-SEG-{{ stack_config.name }}
+{% endraw %}
 ```
 
 

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -178,7 +178,8 @@ class Config(dict):
                         environment_variable=os.environ,
                         var=user_variables,
                         environment_path=self.environment_path.split("/"),
-                        environment_config=environment_config
+                        environment_config=environment_config,
+                        stack_config=self
                     )
 
                     yaml_data = yaml.safe_load(rendered_template)

--- a/tests/fixtures/config/account/environment/region/security_groups.yaml
+++ b/tests/fixtures/config/account/environment/region/security_groups.yaml
@@ -6,3 +6,8 @@ parameters:
   param5: {{ environment_path.2 }}
   param6: {{ environment_config.region }}
   param7: {{ stack_config.name }}
+  param8: {{ stack_config.name.upper() }}
+  param9: {{ stack_config.name.0 }}
+  param10: {{ stack_config.name[-2:] }}
+  param11: {{ stack_config.name.split("_")[-1] }}
+  param12: {{ stack_config.name }}-string

--- a/tests/fixtures/config/account/environment/region/security_groups.yaml
+++ b/tests/fixtures/config/account/environment/region/security_groups.yaml
@@ -5,3 +5,4 @@ parameters:
   param4: {{ environment_path.1 }}
   param5: {{ environment_path.2 }}
   param6: {{ environment_config.region }}
+  param7: {{ stack_config.name }}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,7 +135,8 @@ class TestConfig(object):
                 "param3": "account",
                 "param4": "environment",
                 "param5": "region",
-                "param6": "region"
+                "param6": "region",
+                "param7": "security_groups"
             },
             'dependencies': []
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,7 +136,12 @@ class TestConfig(object):
                 "param4": "environment",
                 "param5": "region",
                 "param6": "region",
-                "param7": "security_groups"
+                "param7": "security_groups",
+                "param8": "SECURITY_GROUPS",
+                "param9": "s",
+                "param10": "ps",
+                "param11": "groups",
+                "param12": "security_groups-string"
             },
             'dependencies': []
         }


### PR DESCRIPTION
* Add string manipulation examples to docs and to tests - This feature was already there and makes use of sceptre in situations with naming conventions and services that need specific cases easier (e.g s3 buckets)
* Add the ability to reference the stack config, object in the stack_config itself - This is primarily to practice DRY in configs, by allowing the stack_name (and potentially template) to be derived from the config filename - Again primarily useful in situations with naming conventions that do not match the Sceptre provided stack_name format
-----------------

* [x] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2].
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.