### PR TITLE
[Resolve #143] Add iam_profile env config option

### DIFF
--- a/docs/docs/environment_config.md
+++ b/docs/docs/environment_config.md
@@ -11,7 +11,7 @@ Environment config stores information related to the environment, such as a part
 An environment config file is a yaml object of key-value pairs configuring Sceptre. The available keys are listed below.
 
 - [iam_role](#iam_role) *(optional)*
-- [iam_profile](#iam_profile) *optional*
+- [profile](#profile) *optional*
 - [project_code](#project_code) *(required)*
 - [region](#region) *(required)*
 - [template_bucket_name](#template_bucket_name) *(optional)*
@@ -25,9 +25,9 @@ Sceptre only checks for and uses the above keys in environment config files, but
 
 The ARN of a role for Sceptre to assume before interacting with the environment. If not supplied, Sceptre uses the user's AWS CLI credentials.
 
-### iam_profile
+### profile
 
-The name of the local role as defined in ~/.aws/config and ~/.aws/credentials. If `iam_role` is also provided, Sceptre will use `iam_profile` to assume the `iam_role`. If `iam_role` is not provided, Sceptre will use `iam_profile` to interact with the environment.
+The name of the profile as defined in ~/.aws/config and ~/.aws/credentials. If `iam_role` is also provided, Sceptre will use `profile` to assume the `iam_role`. If `iam_role` is not provided, Sceptre will use `profile` to interact with the environment.
 
 ### project_code
 

--- a/docs/docs/environment_config.md
+++ b/docs/docs/environment_config.md
@@ -11,6 +11,7 @@ Environment config stores information related to the environment, such as a part
 An environment config file is a yaml object of key-value pairs configuring Sceptre. The available keys are listed below.
 
 - [iam_role](#iam_role) *(optional)*
+- [iam_profile](#iam_profile) *optional*
 - [project_code](#project_code) *(required)*
 - [region](#region) *(required)*
 - [template_bucket_name](#template_bucket_name) *(optional)*
@@ -24,6 +25,9 @@ Sceptre only checks for and uses the above keys in environment config files, but
 
 The ARN of a role for Sceptre to assume before interacting with the environment. If not supplied, Sceptre uses the user's AWS CLI credentials.
 
+### iam_profile
+
+The name of the local role as defined in ~/.aws/config and ~/.aws/credentials. If `iam_role` is also provided, Sceptre will use `iam_profile` to assume the `iam_role`. If `iam_role` is not provided, Sceptre will use `iam_profile` to interact with the environment.
 
 ### project_code
 

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -63,8 +63,8 @@ class ConnectionManager(object):
     The Connection Manager should be used to create boto3 clients for
     the various AWS services that we need to interact with.
 
-    :param iam_profile: The aws credential profile that should be used.
-    :type iam_profile: str
+    :param profile: The aws credential profile that should be used.
+    :type profile: str
     :param iam_role: The iam_role that should be assumed in the account.
     :type iam_role: str
     :param region: The region to use.
@@ -74,12 +74,12 @@ class ConnectionManager(object):
     _session_lock = threading.Lock()
     _client_lock = threading.Lock()
 
-    def __init__(self, region, iam_role=None, iam_profile=None):
+    def __init__(self, region, iam_role=None, profile=None):
         self.logger = logging.getLogger(__name__)
 
         self.region = region
         self.iam_role = iam_role
-        self.iam_profile = iam_profile
+        self.profile = profile
         self._boto_session = None
 
         self.clients = {}
@@ -87,8 +87,8 @@ class ConnectionManager(object):
     def __repr__(self):
         return (
             "sceptre.connection_manager.ConnectionManager(region='{0}', "
-            "iam_role='{1}', iam_profile='{2}')".format(
-                self.region, self.iam_role, self.iam_profile
+            "iam_role='{1}', profile='{2}')".format(
+                self.region, self.iam_role, self.profile
             )
         )
 
@@ -115,7 +115,7 @@ class ConnectionManager(object):
                 if self.iam_role:
                     self.logger.debug("Assuming role '%s'...", self.iam_role)
                     sts_session = boto3.session.Session(
-                        profile_name=self.iam_profile,
+                        profile_name=self.profile,
                         region_name=self.region
                     )
                     sts_client = sts_session.client("sts")
@@ -146,7 +146,7 @@ class ConnectionManager(object):
                 else:
                     self.logger.debug("Using cli credentials...")
                     self._boto_session = boto3.session.Session(
-                        profile_name=self.iam_profile,
+                        profile_name=self.profile,
                         region_name=self.region
                     )
                     self.logger.debug(

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -401,7 +401,7 @@ class Environment(object):
         connection_manager = ConnectionManager(
             region=config["region"],
             iam_role=config.get("iam_role"),
-            iam_profile=config.get("iam_profile")
+            profile=config.get("profile")
         )
         stacks = {}
         for stack_name in self._get_available_stacks():

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -400,7 +400,8 @@ class Environment(object):
         config = self._get_config()
         connection_manager = ConnectionManager(
             region=config["region"],
-            iam_role=config.get("iam_role")
+            iam_role=config.get("iam_role"),
+            iam_profile=config.get("iam_profile")
         )
         stacks = {}
         for stack_name in self._get_available_stacks():

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -14,17 +14,24 @@ class TestConnectionManager(object):
 
     def setup_method(self, test_method):
         self.iam_role = None
+        self.iam_profile = None
         self.region = "eu-west-1"
 
         self.connection_manager = ConnectionManager(
-            region=self.region, iam_role=self.iam_role
+            region=self.region,
+            iam_role=self.iam_role,
+            iam_profile=self.iam_profile
         )
 
     def test_connection_manager_initialised_with_all_parameters(self):
         connection_manager = ConnectionManager(
-            region=self.region, iam_role=self.iam_role
+            region=self.region,
+            iam_role="role",
+            iam_profile="profile"
+
         )
-        assert connection_manager.iam_role == self.iam_role
+        assert connection_manager.iam_role == "role"
+        assert connection_manager.iam_profile == "profile"
         assert connection_manager.region == self.region
         assert connection_manager._boto_session is None
         assert connection_manager.clients == {}
@@ -33,23 +40,27 @@ class TestConnectionManager(object):
         connection_manager = ConnectionManager(region=sentinel.region)
 
         assert connection_manager.iam_role is None
+        assert connection_manager.iam_profile is None
         assert connection_manager.region == sentinel.region
         assert connection_manager._boto_session is None
         assert connection_manager.clients == {}
 
     def test_repr(self):
         self.connection_manager.iam_role = "role"
+        self.connection_manager.iam_profile = "profile"
         self.connection_manager.region = "region"
         response = self.connection_manager.__repr__()
         assert response == "sceptre.connection_manager.ConnectionManager(" \
-            "region='region', iam_role='role')"
+            "region='region', iam_role='role', iam_profile='profile')"
 
     def test_boto_session_with_cache(self):
         self.connection_manager._boto_session = sentinel.boto_session
         assert self.connection_manager.boto_session == sentinel.boto_session
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_no_iam_role_and_no_cache(self, mock_Session):
+    def test_boto_session_with_no_iam_role_and_no_iam_profile(
+            self, mock_Session
+    ):
         mock_Session = MagicMock(name='Session', return_value=sentinel.session)
         mock_Session.get_credentials.access_key.return_value = \
             sentinel.access_key
@@ -60,22 +71,48 @@ class TestConnectionManager(object):
 
         self.connection_manager._boto_session = None
         self.connection_manager.iam_role = None
+        self.connection_manager.iam_profile = None
 
         boto_session = self.connection_manager.boto_session
         assert boto_session.isinstance(mock_Session(
-            region_name="eu-west-1"
+            region_name="eu-west-1",
+            iam_profile=None
         ))
         mock_Session.assert_called_once_with(
-            region_name="eu-west-1"
+            region_name="eu-west-1",
+            iam_profile=None
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    @patch("sceptre.connection_manager.boto3.client")
-    def test_boto_session_with_iam_role_and_no_cache(
-            self, mock_client, mock_Session
-    ):
-        mock_Session.return_value = sentinel.session
+    def test_boto_session_with_no_iam_role_and_iam_profile(self, mock_Session):
+        mock_Session = MagicMock(name='Session', return_value=sentinel.session)
+        mock_Session.get_credentials.access_key.return_value = \
+            sentinel.access_key
+        mock_Session.get_credentials.secret_key.return_value = \
+            sentinel.secret_key
+        mock_Session.get_credentials.method.return_value = \
+            sentinel.method
+
+        self.connection_manager._boto_session = None
+        self.connection_manager.iam_role = None
+        self.connection_manager.iam_profile = "profile"
+
+        boto_session = self.connection_manager.boto_session
+        assert boto_session.isinstance(mock_Session(
+            region_name="eu-west-1",
+            iam_profile="profile"
+        ))
+        mock_Session.assert_called_once_with(
+            region_name="eu-west-1",
+            iam_profile="profile"
+        )
+
+    @patch("sceptre.connection_manager.boto3.session.Session")
+    def test_boto_session_with_iam_role_and_no_iam_profile(self, mock_Session):
+        self.connection_manager._boto_session = None
         self.connection_manager.iam_role = "non-default"
+        self.connection_manager.iam_profile = None
+
         mock_credentials = {
             "Credentials": {
                 "AccessKeyId": "id",
@@ -83,14 +120,49 @@ class TestConnectionManager(object):
                 "SessionToken": "token"
             }
         }
-        mock_sts_client = Mock()
-        mock_sts_client.assume_role.return_value = mock_credentials
-        mock_client.return_value = mock_sts_client
+
+        mock_Session.return_value.client.return_value.\
+            assume_role.return_value = mock_credentials
 
         boto_session = self.connection_manager.boto_session
+        assert boto_session.isinstance(mock_Session)
 
-        assert boto_session == sentinel.session
-        mock_Session.assert_called_once_with(
+        mock_Session.assert_any_call(
+            profile_name=None,
+            region_name=self.region
+        )
+        mock_Session.assert_any_call(
+            aws_access_key_id="id",
+            aws_secret_access_key="key",
+            aws_session_token="token",
+            region_name=self.region
+        )
+
+    @patch("sceptre.connection_manager.boto3.session.Session")
+    def test_boto_session_with_iam_role_and_iam_profile(self, mock_Session):
+        self.connection_manager._boto_session = None
+        self.connection_manager.iam_role = "non-default"
+        self.connection_manager.iam_profile = "profile"
+
+        mock_credentials = {
+            "Credentials": {
+                "AccessKeyId": "id",
+                "SecretAccessKey": "key",
+                "SessionToken": "token"
+            }
+        }
+
+        mock_Session.return_value.client.return_value. \
+            assume_role.return_value = mock_credentials
+
+        boto_session = self.connection_manager.boto_session
+        assert boto_session.isinstance(mock_Session)
+
+        mock_Session.assert_any_call(
+            profile_name="profile",
+            region_name=self.region
+        )
+        mock_Session.assert_any_call(
             aws_access_key_id="id",
             aws_secret_access_key="key",
             aws_session_token="token",

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -14,24 +14,24 @@ class TestConnectionManager(object):
 
     def setup_method(self, test_method):
         self.iam_role = None
-        self.iam_profile = None
+        self.profile = None
         self.region = "eu-west-1"
 
         self.connection_manager = ConnectionManager(
             region=self.region,
             iam_role=self.iam_role,
-            iam_profile=self.iam_profile
+            profile=self.profile
         )
 
     def test_connection_manager_initialised_with_all_parameters(self):
         connection_manager = ConnectionManager(
             region=self.region,
             iam_role="role",
-            iam_profile="profile"
+            profile="profile"
 
         )
         assert connection_manager.iam_role == "role"
-        assert connection_manager.iam_profile == "profile"
+        assert connection_manager.profile == "profile"
         assert connection_manager.region == self.region
         assert connection_manager._boto_session is None
         assert connection_manager.clients == {}
@@ -40,25 +40,25 @@ class TestConnectionManager(object):
         connection_manager = ConnectionManager(region=sentinel.region)
 
         assert connection_manager.iam_role is None
-        assert connection_manager.iam_profile is None
+        assert connection_manager.profile is None
         assert connection_manager.region == sentinel.region
         assert connection_manager._boto_session is None
         assert connection_manager.clients == {}
 
     def test_repr(self):
         self.connection_manager.iam_role = "role"
-        self.connection_manager.iam_profile = "profile"
+        self.connection_manager.profile = "profile"
         self.connection_manager.region = "region"
         response = self.connection_manager.__repr__()
         assert response == "sceptre.connection_manager.ConnectionManager(" \
-            "region='region', iam_role='role', iam_profile='profile')"
+            "region='region', iam_role='role', profile='profile')"
 
     def test_boto_session_with_cache(self):
         self.connection_manager._boto_session = sentinel.boto_session
         assert self.connection_manager.boto_session == sentinel.boto_session
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_no_iam_role_and_no_iam_profile(
+    def test_boto_session_with_no_iam_role_and_no_profile(
             self, mock_Session
     ):
         mock_Session = MagicMock(name='Session', return_value=sentinel.session)
@@ -71,20 +71,20 @@ class TestConnectionManager(object):
 
         self.connection_manager._boto_session = None
         self.connection_manager.iam_role = None
-        self.connection_manager.iam_profile = None
+        self.connection_manager.profile = None
 
         boto_session = self.connection_manager.boto_session
         assert boto_session.isinstance(mock_Session(
             region_name="eu-west-1",
-            iam_profile=None
+            profile=None
         ))
         mock_Session.assert_called_once_with(
             region_name="eu-west-1",
-            iam_profile=None
+            profile=None
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_no_iam_role_and_iam_profile(self, mock_Session):
+    def test_boto_session_with_no_iam_role_and_profile(self, mock_Session):
         mock_Session = MagicMock(name='Session', return_value=sentinel.session)
         mock_Session.get_credentials.access_key.return_value = \
             sentinel.access_key
@@ -95,23 +95,23 @@ class TestConnectionManager(object):
 
         self.connection_manager._boto_session = None
         self.connection_manager.iam_role = None
-        self.connection_manager.iam_profile = "profile"
+        self.connection_manager.profile = "profile"
 
         boto_session = self.connection_manager.boto_session
         assert boto_session.isinstance(mock_Session(
             region_name="eu-west-1",
-            iam_profile="profile"
+            profile="profile"
         ))
         mock_Session.assert_called_once_with(
             region_name="eu-west-1",
-            iam_profile="profile"
+            profile="profile"
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_iam_role_and_no_iam_profile(self, mock_Session):
+    def test_boto_session_with_iam_role_and_no_profile(self, mock_Session):
         self.connection_manager._boto_session = None
         self.connection_manager.iam_role = "non-default"
-        self.connection_manager.iam_profile = None
+        self.connection_manager.profile = None
 
         mock_credentials = {
             "Credentials": {
@@ -139,10 +139,10 @@ class TestConnectionManager(object):
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_iam_role_and_iam_profile(self, mock_Session):
+    def test_boto_session_with_iam_role_and_profile(self, mock_Session):
         self.connection_manager._boto_session = None
         self.connection_manager.iam_role = "non-default"
-        self.connection_manager.iam_profile = "profile"
+        self.connection_manager.profile = "profile"
 
         mock_credentials = {
             "Credentials": {

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock, patch, sentinel, MagicMock
+from mock import Mock, patch, sentinel
 from moto import mock_s3
 
 from sceptre.connection_manager import ConnectionManager, _retry_boto_call
@@ -28,7 +28,6 @@ class TestConnectionManager(object):
             region=self.region,
             iam_role="role",
             profile="profile"
-
         )
         assert connection_manager.iam_role == "role"
         assert connection_manager.profile == "profile"
@@ -61,50 +60,28 @@ class TestConnectionManager(object):
     def test_boto_session_with_no_iam_role_and_no_profile(
             self, mock_Session
     ):
-        mock_Session = MagicMock(name='Session', return_value=sentinel.session)
-        mock_Session.get_credentials.access_key.return_value = \
-            sentinel.access_key
-        mock_Session.get_credentials.secret_key.return_value = \
-            sentinel.secret_key
-        mock_Session.get_credentials.method.return_value = \
-            sentinel.method
-
         self.connection_manager._boto_session = None
         self.connection_manager.iam_role = None
         self.connection_manager.profile = None
 
         boto_session = self.connection_manager.boto_session
-        assert boto_session.isinstance(mock_Session(
-            region_name="eu-west-1",
-            profile=None
-        ))
+        assert boto_session.isinstance(mock_Session)
         mock_Session.assert_called_once_with(
             region_name="eu-west-1",
-            profile=None
+            profile_name=None
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
     def test_boto_session_with_no_iam_role_and_profile(self, mock_Session):
-        mock_Session = MagicMock(name='Session', return_value=sentinel.session)
-        mock_Session.get_credentials.access_key.return_value = \
-            sentinel.access_key
-        mock_Session.get_credentials.secret_key.return_value = \
-            sentinel.secret_key
-        mock_Session.get_credentials.method.return_value = \
-            sentinel.method
-
         self.connection_manager._boto_session = None
         self.connection_manager.iam_role = None
         self.connection_manager.profile = "profile"
 
         boto_session = self.connection_manager.boto_session
-        assert boto_session.isinstance(mock_Session(
-            region_name="eu-west-1",
-            profile="profile"
-        ))
+        assert boto_session.isinstance(mock_Session)
         mock_Session.assert_called_once_with(
             region_name="eu-west-1",
-            profile="profile"
+            profile_name="profile"
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -465,7 +465,8 @@ class TestEnvironment(object):
     ):
         mock_config = {
             "region": sentinel.region,
-            "iam_role": sentinel.iam_role
+            "iam_role": sentinel.iam_role,
+            "iam_profile": sentinel.iam_profile
         }
         mock_get_config.return_value = mock_config
         mock_ConnectionManager.return_value = sentinel.connection_manager
@@ -477,7 +478,8 @@ class TestEnvironment(object):
         # Check ConnectionManager() is called with correct arguments
         mock_ConnectionManager.assert_called_once_with(
             region=sentinel.region,
-            iam_role=sentinel.iam_role
+            iam_role=sentinel.iam_role,
+            iam_profile=sentinel.iam_profile
         )
 
         # Check Stack() is called with correct arguments

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -466,7 +466,7 @@ class TestEnvironment(object):
         mock_config = {
             "region": sentinel.region,
             "iam_role": sentinel.iam_role,
-            "iam_profile": sentinel.iam_profile
+            "profile": sentinel.profile
         }
         mock_get_config.return_value = mock_config
         mock_ConnectionManager.return_value = sentinel.connection_manager
@@ -479,7 +479,7 @@ class TestEnvironment(object):
         mock_ConnectionManager.assert_called_once_with(
             region=sentinel.region,
             iam_role=sentinel.iam_role,
-            iam_profile=sentinel.iam_profile
+            profile=sentinel.profile
         )
 
         # Check Stack() is called with correct arguments


### PR DESCRIPTION
Now able to specify which iam_profile for boto3 to use, either when
assuming an iam_role, or when interacting with the environment. This is
useful when managing multiple AWS account and credentials.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2].
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit