### PR TITLE
Deprecate asg-scheduled-actions hook

### DIFF
--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -78,6 +78,9 @@ before_create:
 
 ### asg\_scheduled\_actions
 
+<div class="alert alert-warning">
+The asg_scheduled_actions hook has been deprecated and will be removed in a later version of Sceptre. We recommend using the asg_scaling_processes hook instead.
+</div>
 Pauses or resumes autoscaling scheduled actions.
 
 Syntax:

--- a/sceptre/hooks/asg_scheduled_actions.py
+++ b/sceptre/hooks/asg_scheduled_actions.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import warnings
+
+from colorama import Fore, Style
 
 from sceptre.hooks import Hook
 from sceptre.exceptions import InvalidHookArgumentValueError
@@ -7,6 +10,8 @@ from sceptre.exceptions import InvalidHookArgumentTypeError
 
 class ASGScheduledActions(Hook):
     """
+    This hook has been deprecated in favor of the asg_scaling_processes hook.
+
     A command to resume or suspend autoscaling group scheduled actions. This is
     useful as schedule actions must be suspended when updating stacks with
     on autoscaling groups.
@@ -20,6 +25,14 @@ class ASGScheduledActions(Hook):
         Either suspends or resumes any scheduled actions on all autoscaling
         groups with in the current stack.
         """
+        warnings.warn(
+            "{0}The asg_scheduled_actions hook has been deprecated and will "
+            "be removed in a later version of Sceptre. Use the "
+            "asg_scaling_processes hook instead. Example: "
+            "!asg_scaling_processes <suspend|resume>::ScheduledActions{1}"
+            .format(Fore.YELLOW, Style.RESET_ALL),
+            DeprecationWarning
+        )
         if not isinstance(self.argument, basestring):
             raise InvalidHookArgumentTypeError(
                 'The argument "{0}" is the wrong type - asg_scheduled_actions '

--- a/tests/test_hooks/test_asg_scheduled_actions.py
+++ b/tests/test_hooks/test_asg_scheduled_actions.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-
+from colorama import Fore, Style
 from mock import Mock,  patch, MagicMock
 import pytest
+
 from sceptre.config import Config
 from sceptre.hooks.asg_scheduled_actions import ASGScheduledActions
 from sceptre.exceptions import InvalidHookArgumentValueError
@@ -10,6 +11,13 @@ from sceptre.exceptions import InvalidHookArgumentTypeError
 
 class TestASGScheduledActions(object):
     def setup_method(self, test_method):
+        self.deprecation_notice = (
+            "{0}The asg_scheduled_actions hook has been "
+            "deprecated and will be removed in a later version of Sceptre. "
+            "Use the asg_scaling_processes hook instead. Example: "
+            "!asg_scaling_processes <suspend|resume>::ScheduledActions{1}"
+        ).format(Fore.YELLOW, Style.RESET_ALL)
+
         self.mock_asg_scheduled_actions = ASGScheduledActions()
 
     def test_get_stack_resources_sends_correct_request(self):
@@ -76,11 +84,14 @@ class TestASGScheduledActions(object):
 
         assert response == []
 
+    @patch('warnings.warn')
     @patch(
         "sceptre.hooks.asg_scheduled_actions"
         ".ASGScheduledActions._find_autoscaling_groups"
     )
-    def test_run_with_resume_argument(self, mock_find_autoscaling_groups):
+    def test_run_with_resume_argument(
+        self, mock_find_autoscaling_groups, mock_warn
+    ):
         self.mock_asg_scheduled_actions.argument = u"resume"
         mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
         self.mock_asg_scheduled_actions.connection_manager = Mock()
@@ -96,12 +107,19 @@ class TestASGScheduledActions(object):
                     ]
                 }
             )
+        mock_warn.assert_called_once_with(
+            self.deprecation_notice,
+            DeprecationWarning
+        )
 
+    @patch('warnings.warn')
     @patch(
         "sceptre.hooks.asg_scheduled_actions"
         ".ASGScheduledActions._find_autoscaling_groups"
     )
-    def test_run_with_suspend_argument(self, mock_find_autoscaling_groups):
+    def test_run_with_suspend_argument(
+        self, mock_find_autoscaling_groups, mock_warn
+    ):
         self.mock_asg_scheduled_actions.argument = u"suspend"
         mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
         self.mock_asg_scheduled_actions.connection_manager = Mock()
@@ -117,27 +135,43 @@ class TestASGScheduledActions(object):
                     ]
                 }
             )
+        mock_warn.assert_called_once_with(
+            self.deprecation_notice,
+            DeprecationWarning
+        )
 
+    @patch('warnings.warn')
     @patch(
         "sceptre.hooks.asg_scheduled_actions"
         ".ASGScheduledActions._find_autoscaling_groups"
     )
     def test_run_with_invalid_string_argument(
-        self, mock_find_autoscaling_groups
+        self, mock_find_autoscaling_groups, mock_warn
     ):
         self.mock_asg_scheduled_actions.argument = u"invalid_string"
         mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
         self.mock_asg_scheduled_actions.connection_manager = Mock()
         with pytest.raises(InvalidHookArgumentValueError):
             self.mock_asg_scheduled_actions.run()
+        mock_warn.assert_called_once_with(
+            self.deprecation_notice,
+            DeprecationWarning
+        )
 
+    @patch('warnings.warn')
     @patch(
         "sceptre.hooks.asg_scheduled_actions"
         ".ASGScheduledActions._find_autoscaling_groups"
     )
-    def test_run_with_non_string_argument(self, mock_find_autoscaling_groups):
+    def test_run_with_non_string_argument(
+        self, mock_find_autoscaling_groups, mock_warn
+    ):
         self.mock_asg_scheduled_actions.argument = 10
         mock_find_autoscaling_groups.return_value = ["autoscaling_group_1"]
         self.mock_asg_scheduled_actions.connection_manager = Mock()
         with pytest.raises(InvalidHookArgumentTypeError):
             self.mock_asg_scheduled_actions.run()
+        mock_warn.assert_called_once_with(
+            self.deprecation_notice,
+            DeprecationWarning
+        )


### PR DESCRIPTION
Deprecating asg_scheduled_actions hook in favor of asg_scaling_processes hook as it covers the same functionality. This PR add deprecation notices into the documentation and code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2].
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit