### PR TITLE
Add a note to squash commits after the changes have been approved.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ The more detailed you are, the better.**
 Before submitting the PR make sure the following are checked:
 
 * [ ] Wrote [good commit messages][1].
-* [ ] [Squashed related commits together][2].
+* [ ] [Squashed related commits together][2] after the changes have been approved.
 * [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
 * [ ] Added unit tests.
 * [ ] Added integration tests (if applicable).


### PR DESCRIPTION
Since it's not uncommon for us to request several changes, it may solve a lot of headaches to request contributors squash commits after approval but before it's merged.
-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2].
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [ ] All unit tests (`make test`) are passing.
* [ ] Used the same coding conventions as the rest of the project.
* [ ] The new code doesn't generate flake8 (`make lint`) offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit