### PR TITLE
[Resolve #184] Add support for SNS stack notifications

### DIFF
--- a/docs/docs/stack_config.md
+++ b/docs/docs/stack_config.md
@@ -19,6 +19,7 @@ A stack config file is a yaml object of key-value pairs configuring a particular
 - [stack_name](#stack_name) *(optional)*
 - [stack_tags](#stack_tags) *(optional)*
 - [role_arn](#role_arn) *(optional)*
+- [notifications](#notifications) *(optional)*
 - [template_path](#template_path) *(required)*
 
 
@@ -116,6 +117,10 @@ A dictionary of [CloudFormation Tags](https://docs.aws.amazon.com/AWSCloudFormat
 ### role_arn
 
 The ARN of a [CloudFormation Service Role](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) that is assumed by CloudFormation to create, update or delete resources.
+
+### notifications
+
+List of SNS topic ARNs to publish stack related events to. A maximum of 5 ARNs can be specified per stack. This configuration will be used by the `create-stack`, `update-stack`, and `create-change-set` commands. More information about stack notifications can found under the relevant section in the [AWS CloudFormation API documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html).
 
 ### template_path
 

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -194,6 +194,7 @@ class Stack(object):
             "StackName": self.external_name,
             "Parameters": self._format_parameters(self.parameters),
             "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "NotificationARNs": self.config.get("notifications", []),
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
                 for k, v in self.config.get("stack_tags", {}).items()
@@ -232,6 +233,7 @@ class Stack(object):
             "StackName": self.external_name,
             "Parameters": self._format_parameters(self.parameters),
             "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "NotificationARNs": self.config.get("notifications", []),
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
                 for k, v in self.config.get("stack_tags", {}).items()
@@ -524,6 +526,7 @@ class Stack(object):
             "Parameters": self._format_parameters(self.parameters),
             "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
             "ChangeSetName": change_set_name,
+            "NotificationARNs": self.config.get("notifications", []),
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
                 for k, v in self.config.get("stack_tags", {}).items()

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -208,6 +208,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         }}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.config["notifications"] = [sentinel.notification]
         self.stack.create()
 
         self.stack.connection_manager.call.assert_called_with(
@@ -219,6 +220,46 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
                 "Parameters": sentinel.parameters,
                 "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                 "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [sentinel.notification],
+                "Tags": [
+                    {"Key": "tag1", "Value": "val1"}
+                ]
+            }
+        )
+        mock_wait_for_completion.assert_called_once_with()
+
+    @patch("sceptre.stack.Stack._format_parameters")
+    @patch("sceptre.stack.Stack._wait_for_completion")
+    @patch("sceptre.stack.Stack._get_template_details")
+    def test_create_sends_correct_request_no_notifications(
+            self, mock_get_template_details,
+            mock_wait_for_completion, mock_format_params
+    ):
+        mock_format_params.return_value = sentinel.parameters
+        mock_get_template_details.return_value = {
+            "Template": sentinel.template
+        }
+        self.stack.environment_config = {
+            "template_bucket_name": sentinel.template_bucket_name,
+            "template_key_prefix": sentinel.template_key_prefix
+        }
+        self.stack._config = {"stack_tags": {
+            "tag1": "val1"
+        }}
+        self.stack._hooks = {}
+        self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.create()
+
+        self.stack.connection_manager.call.assert_called_with(
+            service="cloudformation",
+            command="create_stack",
+            kwargs={
+                "StackName": sentinel.external_name,
+                "Template": sentinel.template,
+                "Parameters": sentinel.parameters,
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [],
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}
                 ]
@@ -246,6 +287,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         }}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.config["notifications"] = [sentinel.notification]
         self.stack.config["on_failure"] = 'DO_NOTHING'
         self.stack.create()
 
@@ -258,6 +300,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
                 "Parameters": sentinel.parameters,
                 "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                 "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [sentinel.notification],
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}
                 ],
@@ -286,6 +329,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         }}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.config["notifications"] = [sentinel.notification]
 
         self.stack.update()
         self.stack.connection_manager.call.assert_called_with(
@@ -297,6 +341,46 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
                 "Parameters": sentinel.parameters,
                 "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                 "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [sentinel.notification],
+                "Tags": [
+                    {"Key": "tag1", "Value": "val1"}
+                ]
+            }
+        )
+        mock_wait_for_completion.assert_called_once_with()
+
+    @patch("sceptre.stack.Stack._format_parameters")
+    @patch("sceptre.stack.Stack._wait_for_completion")
+    @patch("sceptre.stack.Stack._get_template_details")
+    def test_update_sends_correct_request_no_notification(
+            self, mock_get_template_details,
+            mock_wait_for_completion, mock_format_params
+    ):
+        mock_format_params.return_value = sentinel.parameters
+        mock_get_template_details.return_value = {
+            "Template": sentinel.template
+        }
+        self.stack.environment_config = {
+            "template_bucket_name": sentinel.template_bucket_name,
+            "template_key_prefix": sentinel.template_key_prefix
+        }
+        self.stack._config = {"stack_tags": {
+            "tag1": "val1"
+        }}
+        self.stack._hooks = {}
+        self.stack.config["role_arn"] = sentinel.role_arn
+
+        self.stack.update()
+        self.stack.connection_manager.call.assert_called_with(
+            service="cloudformation",
+            command="update_stack",
+            kwargs={
+                "StackName": sentinel.external_name,
+                "Template": sentinel.template,
+                "Parameters": sentinel.parameters,
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [],
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}
                 ]
@@ -638,6 +722,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             "stack_tags": {"tag1": "val1"}
         }
         self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.config["notifications"] = [sentinel.notification]
 
         self.stack.create_change_set(sentinel.change_set_name)
         self.stack.connection_manager.call.assert_called_with(
@@ -650,6 +735,43 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
                 "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                 "ChangeSetName": sentinel.change_set_name,
                 "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [sentinel.notification],
+                "Tags": [
+                    {"Key": "tag1", "Value": "val1"}
+                ]
+            }
+        )
+
+    @patch("sceptre.stack.Stack._format_parameters")
+    @patch("sceptre.stack.Stack._get_template_details")
+    def test_create_change_set_sends_correct_request_no_notifications(
+            self, mock_get_template_details, mock_format_params
+    ):
+        mock_format_params.return_value = sentinel.parameters
+        mock_get_template_details.return_value = {
+            "Template": sentinel.template
+        }
+        self.stack.environment_config = {
+            "template_bucket_name": sentinel.template_bucket_name,
+            "template_key_prefix": sentinel.template_key_prefix
+        }
+        self.stack._config = {
+            "stack_tags": {"tag1": "val1"}
+        }
+        self.stack.config["role_arn"] = sentinel.role_arn
+
+        self.stack.create_change_set(sentinel.change_set_name)
+        self.stack.connection_manager.call.assert_called_with(
+            service="cloudformation",
+            command="create_change_set",
+            kwargs={
+                "StackName": sentinel.external_name,
+                "Template": sentinel.template,
+                "Parameters": sentinel.parameters,
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "ChangeSetName": sentinel.change_set_name,
+                "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [],
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}
                 ]


### PR DESCRIPTION
Now able to specify a list of SNS topic ARNs within a stack config using the `notifications` field. Notifications for that stack will then be sent to the specified SNS topics. This is useful for monitoring and integrating with Cloudformation.

I took a first stab at writing integration tests for this, but it raised a few questions:
- should the SNS topic be created ahead of time in the Sceptre integration account? Or should part of the setup for the integration tests be this topic creation.
- I had some trouble testing my integration tests, mainly surrounding assuming the `arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole` role. My work around was to change comment out this role in all the `config.yaml` files. Is this the correct work around?

Let me know what you think!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit