### PR TITLE
Revert "Add stack diff command (#212)"

### DIFF
--- a/sceptre/cli.py
+++ b/sceptre/cli.py
@@ -235,23 +235,6 @@ def describe_stack_resources(ctx, environment, stack):
     write(response, ctx.obj["output_format"])
 
 
-@cli.command(name="diff")
-@stack_options
-@click.pass_context
-@catch_exceptions
-def diff(ctx, environment, stack):
-    """
-    Prints the diff between the currently deployed stack with the local
-    version of that stack.
-
-    Diffs ENVIRONMENT/STACK.
-    """
-    env = get_env(ctx.obj["sceptre_dir"], environment, ctx.obj["options"])
-    diff = env.stacks[stack].diff()
-
-    write(diff)
-
-
 @cli.command(name="create-stack")
 @stack_options
 @click.pass_context

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -13,7 +13,6 @@ import logging
 import os
 import time
 import threading
-import difflib
 
 from dateutil.tz import tzutc
 import botocore
@@ -384,35 +383,6 @@ class Stack(object):
             command="describe_stacks",
             kwargs={"StackName": self.external_name}
         )
-
-    def diff(self):
-        """
-        Returns the diff between the template body of the currently deployed
-        stack and the local one.
-
-        :returns: differences
-        :rtype: string
-        """
-        raw_remote_template = self.connection_manager.call(
-            service="cloudformation",
-            command="get_template",
-            kwargs={"StackName": self.external_name}
-        )["TemplateBody"]
-
-        raw_local_template = self.template.body
-
-        remote_template = raw_remote_template.split("\n")
-        local_template = raw_local_template.split("\n")
-
-        differences = difflib.unified_diff(
-            remote_template, local_template, fromfile="remote_template",
-            tofile="local_template", lineterm=""
-            )
-
-        output = ""
-        for line in differences:
-            output += line+"\n"
-        return output
 
     def describe_events(self):
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,22 +120,6 @@ class TestCli(object):
 
     @patch("sceptre.cli.os.getcwd")
     @patch("sceptre.cli.get_env")
-    def test_diff_stack(self, mock_get_env, mock_getcwd):
-        mock_getcwd.return_value = sentinel.cwd
-        mock_get_env.return_value.stacks["vpc"].diff\
-            .return_value = ""
-
-        result = self.runner.invoke(
-            cli, ["diff", "dev", "vpc"]
-        )
-        mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
-        mock_get_env.return_value.stacks["vpc"].diff\
-            .assert_called_with()
-        # Assert that there is output.
-        assert result.output
-
-    @patch("sceptre.cli.os.getcwd")
-    @patch("sceptre.cli.get_env")
     def test_create_stack(self, mock_get_env, mock_getcwd):
         mock_getcwd.return_value = sentinel.cwd
         self.runner.invoke(cli, ["create-stack", "dev", "vpc"])

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -558,58 +558,6 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         response = self.stack.describe_outputs()
         assert response == []
 
-    @pytest.mark.parametrize(
-        "local_template,remote_template,diff_remote_local,diff_local_remote",
-        [
-            (
-                "local_template_content",
-                "remote_template_content",
-                "--- remote_template\n+++ local_template\n@@ -1 +1 @@\n-remote_template_content\n+local_template_content\n",  # NOQA
-                "--- remote_template\n+++ local_template\n@@ -1 +1 @@\n-local_template_content\n+remote_template_content\n"   # NOQA
-            ),
-            (
-                "template_content\nonlylocal_content",
-                "template_content",
-                "--- remote_template\n+++ local_template\n@@ -1 +1,2 @@\n template_content\n+onlylocal_content\n",  # NOQA
-                "--- remote_template\n+++ local_template\n@@ -1,2 +1 @@\n template_content\n-onlylocal_content\n"   # NOQA
-            ),
-            (
-                "onlylocal_content\ntemplate_content",
-                "template_content",
-                "--- remote_template\n+++ local_template\n@@ -1 +1,2 @@\n+onlylocal_content\n template_content\n",  # NOQA
-                "--- remote_template\n+++ local_template\n@@ -1,2 +1 @@\n-onlylocal_content\n template_content\n"   # NOQA
-            ),
-            (
-                "template_content1\nonlylocal_content\ntemplate_content2",
-                "template_content1\ntemplate_content2",
-                "--- remote_template\n+++ local_template\n@@ -1,2 +1,3 @@\n template_content1\n+onlylocal_content\n template_content2\n",  # NOQA
-                "--- remote_template\n+++ local_template\n@@ -1,3 +1,2 @@\n template_content1\n-onlylocal_content\n template_content2\n"   # NOQA
-            ),
-            (
-                "template_content1\nonlylocal_content\ntemplate_content2",
-                "template_content1\nonlyremote_content\ntemplate_content2",
-                "--- remote_template\n+++ local_template\n@@ -1,3 +1,3 @@\n template_content1\n-onlyremote_content\n+onlylocal_content\n template_content2\n",  # NOQA
-                "--- remote_template\n+++ local_template\n@@ -1,3 +1,3 @@\n template_content1\n-onlylocal_content\n+onlyremote_content\n template_content2\n"   # NOQA
-            ),
-        ]
-    )
-    def test_diff_stack_cases(self, local_template, remote_template,
-                              diff_remote_local, diff_local_remote):
-        self.stack._template = Mock(spec=Template)
-        self.stack._template.body = local_template
-        self.stack.connection_manager.call.return_value = {
-            "TemplateBody": remote_template
-            }
-        response = self.stack.diff()
-        assert response == diff_remote_local
-
-        self.stack._template.body = remote_template
-        self.stack.connection_manager.call.return_value = {
-            "TemplateBody": local_template
-            }
-        response = self.stack.diff()
-        assert response == diff_local_remote
-
     def test_continue_update_rollback_sends_correct_request(self):
         self.stack._config = {
             "template_path": sentinel.template_path,
@@ -751,20 +699,6 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack.connection_manager.call.assert_called_with(
             service="cloudformation",
             command="list_change_sets",
-            kwargs={"StackName": sentinel.external_name}
-        )
-
-    def test_diff_stack_sends_correct_request(self):
-        self.stack._template = Mock(spec=Template)
-        self.stack._template.body = "local_template_content"
-
-        self.stack.connection_manager.call.return_value = \
-            {"TemplateBody": "remote_template_content"}
-
-        self.stack.diff()
-        self.stack.connection_manager.call.assert_called_with(
-            service="cloudformation",
-            command="get_template",
             kwargs={"StackName": sentinel.external_name}
         )
 


### PR DESCRIPTION
This reverts commit 53f364aae48a312a337980be0fc7eb5c592ee7c2.

`sceptre diff` command is being removed. Diff was done comparing the string representations of the local template and the remote template. However, when you upload the template to AWS - its stored a JSON object and hence can be re-ordered, have whitespace changes etc - and you can’t retrieve the actual string you uploaded in the first place.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit