### PR TITLE
Hotfix for renewing assumed role sessions

### DIFF
--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -201,7 +201,7 @@ class ConnectionManager(object):
         expired.
         """
         if self.iam_role and self._boto_session_expiration:
-            if self._boto_session_expiration >= datetime.now(tz.tzutc()):
+            if datetime.now(tz.tzutc()) >= self._boto_session_expiration:
                 self.logger.debug("Boto session has expired")
                 self.clients = {}
                 self._boto_session = None


### PR DESCRIPTION
Fixes re-creation of expired STS credentials when using the `iam_role`. The logic for evaluating when a session was expired was reversed, hence causing Sceptre to recreate the session on every boto call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [ ] Added integration tests (if applicable). - Unable to at current time
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit