### PR TITLE
Generate .gitignore file when creating a new project with init command

### DIFF
--- a/sceptre/cli.py
+++ b/sceptre/cli.py
@@ -630,6 +630,11 @@ def init_project(ctx, project_name):
         folder_path = os.path.join(project_folder, folder)
         os.makedirs(folder_path)
 
+    # Create .gitignore file in project
+    gitignore_path = os.path.join(project_folder, ".gitignore")
+    with open(gitignore_path, "wt") as gitignore_file:
+        gitignore_file.write("*.pyc")
+
     defaults = {
         "project_code": project_name,
         "region": os.environ.get("AWS_DEFAULT_REGION", "")


### PR DESCRIPTION
When using the `init` command to create a new sceptre project, a `.gitignore` file is generated at the root of the project in order to ignore `.pyc` files.

This avoids committing a bunch of binary files to a repository in the first commit.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
