### PR TITLE
Update dependency resolution to detect more general cycles

### DIFF
--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -339,19 +339,19 @@ class Environment(object):
         """
         self.logger.debug("Checking for circular dependencies...")
 
-        if not self.is_leaf:
-            return
-        encountered_stacks = {}
-        available_stacks = self.stacks
-        for stack in available_stacks.values():
-            encountered_stacks[stack] = "ENCOUNTERED"
-            encountered_stacks = _detect_cycles(
-                stack,
-                encountered_stacks,
-                available_stacks,
-                [stack.name]
-            )
-            encountered_stacks[stack] = "DONE"
+        if self.is_leaf:
+            encountered_stacks = {}
+            available_stacks = self.stacks
+            for stack in available_stacks.values():
+                if encountered_stacks.get(stack) is not "DONE":
+                    encountered_stacks[stack] = "ENCOUNTERED"
+                    encountered_stacks = _detect_cycles(
+                        stack,
+                        encountered_stacks,
+                        available_stacks,
+                        [stack.name]
+                    )
+                    encountered_stacks[stack] = "DONE"
         self.logger.debug("No circular dependencies found")
 
     def _get_config(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -339,6 +339,8 @@ class Environment(object):
         """
         self.logger.debug("Checking for circular dependencies...")
 
+        if not self.is_leaf:
+            return
         encountered_stacks = {}
         available_stacks = self.stacks
         for stack in available_stacks.values():

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -341,14 +341,13 @@ class Environment(object):
 
         if self.is_leaf:
             encountered_stacks = {}
-            available_stacks = self.stacks
-            for stack in available_stacks.values():
-                if encountered_stacks.get(stack) is not "DONE":
+            for stack in self.stacks.values():
+                if encountered_stacks.get(stack, "UNENCOUNTERED") != "DONE":
                     encountered_stacks[stack] = "ENCOUNTERED"
                     encountered_stacks = _detect_cycles(
                         stack,
                         encountered_stacks,
-                        available_stacks,
+                        self.stacks,
                         [stack.name]
                     )
                     encountered_stacks[stack] = "DONE"

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -22,7 +22,6 @@ from .exceptions import StackDoesNotExistError
 from .config import Config
 from .connection_manager import ConnectionManager
 from .exceptions import InvalidEnvironmentPathError
-from .exceptions import CircularDependenciesError
 from .helpers import recurse_into_sub_environments, get_name_tuple
 from .helpers import _detect_cycles
 from .stack import Stack
@@ -92,7 +91,6 @@ class Environment(object):
                 "not have leading or trailing slashes.".format(path)
             )
         return path
-
     @staticmethod
     def _detect_cycles(node, encountered_nodes, available_nodes, path):
         """
@@ -125,6 +123,7 @@ class Environment(object):
                 )
             encountered_nodes[dependency] = "DONE"
         return encountered_nodes
+
 
     @property
     def is_leaf(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -22,6 +22,7 @@ from .exceptions import StackDoesNotExistError
 from .config import Config
 from .connection_manager import ConnectionManager
 from .exceptions import InvalidEnvironmentPathError
+from .exceptions import CircularDependenciesError
 from .helpers import recurse_into_sub_environments, get_name_tuple
 from .helpers import _detect_cycles
 from .stack import Stack
@@ -91,6 +92,7 @@ class Environment(object):
                 "not have leading or trailing slashes.".format(path)
             )
         return path
+
     @staticmethod
     def _detect_cycles(node, encountered_nodes, available_nodes, path):
         """
@@ -123,7 +125,6 @@ class Environment(object):
                 )
             encountered_nodes[dependency] = "DONE"
         return encountered_nodes
-
 
     @property
     def is_leaf(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -91,6 +91,39 @@ class Environment(object):
                 "not have leading or trailing slashes.".format(path)
             )
         return path
+    @staticmethod
+    def _detect_cycles(node, encountered_nodes, available_nodes, path):
+        """
+        Use Depth-first search to detect cycles.
+        :returns: A dictionary containing all of the nodes encountered
+        during the depth first search.
+        """
+        for dependency_name in node.dependencies:
+            # The keys in _load_nodes() (where the available_nodes comes from)
+            # are prefixed with environment names separated by /, which is
+            # undesirable here, so we strip them out.
+            dependency = available_nodes[dependency_name.split("/")[-1]]
+            status = encountered_nodes.get(dependency)
+            if status == "ENCOUNTERED":
+                # Reformat path to only include the cycle
+                path.insert(0, dependency_name)
+                cycle = path[path.index(dependency_name):]
+                raise CircularDependenciesError(
+                    "Found circular dependency involving "
+                    "{0}".format(cycle)
+                )
+            elif status is None:
+                encountered_nodes[dependency] = "ENCOUNTERED"
+                path.insert(0, dependency_name)
+                _detect_cycles(
+                    dependency,
+                    encountered_nodes,
+                    available_nodes,
+                    path
+                )
+            encountered_nodes[dependency] = "DONE"
+        return encountered_nodes
+
 
     @property
     def is_leaf(self):
@@ -344,7 +377,7 @@ class Environment(object):
             for stack in self.stacks.values():
                 if encountered_stacks.get(stack, "UNENCOUNTERED") != "DONE":
                     encountered_stacks[stack] = "ENCOUNTERED"
-                    encountered_stacks = _detect_cycles(
+                    encountered_stacks = Environment._detect_cycles(
                         stack,
                         encountered_stacks,
                         self.stacks,

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -17,13 +17,13 @@ import botocore
 
 from concurrent.futures import ThreadPoolExecutor, wait
 
-from .exceptions import CircularDependenciesError
 from .exceptions import StackDoesNotExistError
 
 from .config import Config
 from .connection_manager import ConnectionManager
 from .exceptions import InvalidEnvironmentPathError
 from .helpers import recurse_into_sub_environments, get_name_tuple
+from .helpers import _detect_cycles
 from .stack import Stack
 from .stack_status import StackStatus
 
@@ -124,7 +124,7 @@ class Environment(object):
         stack_statuses = self._get_initial_statuses()
         launch_dependencies = self._get_launch_dependencies(self.path)
 
-        self._check_for_circular_dependencies(launch_dependencies)
+        self._check_for_circular_dependencies()
         self._build(
             "launch", threading_events, stack_statuses, launch_dependencies
         )
@@ -141,7 +141,7 @@ class Environment(object):
         stack_statuses = self._get_initial_statuses()
         delete_dependencies = self._get_delete_dependencies()
 
-        self._check_for_circular_dependencies(delete_dependencies)
+        self._check_for_circular_dependencies()
         self._build(
             "delete", threading_events, stack_statuses, delete_dependencies
         )
@@ -330,7 +330,7 @@ class Environment(object):
                 delete_dependencies[dependency].append(stack_name)
         return delete_dependencies
 
-    def _check_for_circular_dependencies(self, dependencies):
+    def _check_for_circular_dependencies(self):
         """
         Checks to make sure that no stacks are dependent on stacks which are
         dependent on the first stack.
@@ -338,14 +338,10 @@ class Environment(object):
         :raises: sceptre.workplan.CircularDependenciesException
         """
         self.logger.debug("Checking for circular dependencies...")
-        for stack_name, stack_dependencies in dependencies.items():
-            for dependency in stack_dependencies:
-                if stack_name in dependencies[dependency]:
-                    raise CircularDependenciesError(
-                        "The {0} stack is dependent on the {1} stack, which "
-                        "is in turn dependent on the {0} "
-                        "stack.".format(stack_name, dependency)
-                    )
+
+        encountered_stacks = {}
+        for stack in self.stacks.values():
+            encountered_stacks = _detect_cycles(stack, encountered_stacks)
         self.logger.debug("No circular dependencies found")
 
     def _get_config(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -344,11 +344,14 @@ class Environment(object):
         encountered_stacks = {}
         available_stacks = self.stacks
         for stack in available_stacks.values():
+            encountered_stacks[stack] = "ENCOUNTERED"
             encountered_stacks = _detect_cycles(
                 stack,
                 encountered_stacks,
-                available_stacks
+                available_stacks,
+                [stack.name]
             )
+            encountered_stacks[stack] = "DONE"
         self.logger.debug("No circular dependencies found")
 
     def _get_config(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -340,8 +340,13 @@ class Environment(object):
         self.logger.debug("Checking for circular dependencies...")
 
         encountered_stacks = {}
-        for stack in self.stacks.values():
-            encountered_stacks = _detect_cycles(stack, encountered_stacks)
+        available_stacks = self.stacks
+        for stack in available_stacks.values():
+            encountered_stacks = _detect_cycles(
+                stack,
+                encountered_stacks,
+                available_stacks
+            )
         self.logger.debug("No circular dependencies found")
 
     def _get_config(self):

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -186,7 +186,7 @@ def _detect_cycles(stack, encountered_stacks):
     :returns: A dictionary containing all of the nodes encountered
     during the depth first search.
     """
-    for dependency in stack._get_launch_dependencies(stack.path):
+    for dependency in stack.dependencies:
         status = encountered_stacks.get(dependency, None)
         if status is "ENCOUNTERED":
             raise CircularDependenciesError(

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -187,7 +187,7 @@ def _detect_cycles(stack, encountered_stacks, available_stacks):
     during the depth first search.
     """
     for dependency_name in stack.dependencies:
-        dependency = available_stacks[dependency_name]
+        dependency = available_stacks[dependency_name.split("/")[-1]]
         status = encountered_stacks.get(dependency, None)
         if status is "ENCOUNTERED":
             raise CircularDependenciesError(

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -189,8 +189,8 @@ def _detect_cycles(stack, encountered_stacks):
         if status is "ENCOUNTERED":
             raise CircularDependenciesError(
                 "Found circular dependency involving "
-                "{0}"
-            ).format(dependency.stack_name)
+                "{0}".format(dependency.stack_name)
+            )
         elif status is None:
             encountered_stacks[dependency] = "ENCOUNTERED"
         else:

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -193,13 +193,17 @@ def _detect_cycles(stack, encountered_stacks, available_stacks, path):
         dependency = available_stacks[dependency_name.split("/")[-1]]
         status = encountered_stacks.get(dependency)
         if status == "ENCOUNTERED":
+            # Reformat path to only include the cycle
+            path.insert(0, dependency_name)
+            cycle = path[path.index(dependency_name):]
+            print cycle
             raise CircularDependenciesError(
                 "Found circular dependency involving "
-                "{0}".format(path)
+                "{0}".format(cycle)
             )
         elif status is None:
             encountered_stacks[dependency] = "ENCOUNTERED"
-            path.append(dependency_name)
+            path.insert(0, dependency_name)
             _detect_cycles(
                 dependency,
                 encountered_stacks,

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -13,6 +13,7 @@ from concurrent.futures import as_completed
 
 from .exceptions import CircularDependenciesError
 
+
 def camel_to_snake_case(string):
     """
     Converts a string from camel case to snake case.
@@ -177,6 +178,7 @@ def get_subclasses(class_type, directory=None):
                         classes[camel_to_snake_case(attr.__name__)] = attr
 
     return classes
+
 
 def _detect_cycles(stack, encountered_stacks):
     """

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -180,35 +180,34 @@ def get_subclasses(class_type, directory=None):
     return classes
 
 
-def _detect_cycles(stack, encountered_stacks, available_stacks, path):
+def _detect_cycles(node, encountered_nodes, available_nodes, path):
     """
     Use Depth-first search to detect cycles.
     :returns: A dictionary containing all of the nodes encountered
     during the depth first search.
     """
-    for dependency_name in stack.dependencies:
-        # The keys in _load_stacks() (where the available_stacks comes from)
+    for dependency_name in node.dependencies:
+        # The keys in _load_nodes() (where the available_nodes comes from)
         # are prefixed with environment names separated by /, which is
         # undesirable here, so we strip them out.
-        dependency = available_stacks[dependency_name.split("/")[-1]]
-        status = encountered_stacks.get(dependency)
+        dependency = available_nodes[dependency_name.split("/")[-1]]
+        status = encountered_nodes.get(dependency)
         if status == "ENCOUNTERED":
             # Reformat path to only include the cycle
             path.insert(0, dependency_name)
             cycle = path[path.index(dependency_name):]
-            print cycle
             raise CircularDependenciesError(
                 "Found circular dependency involving "
                 "{0}".format(cycle)
             )
         elif status is None:
-            encountered_stacks[dependency] = "ENCOUNTERED"
+            encountered_nodes[dependency] = "ENCOUNTERED"
             path.insert(0, dependency_name)
             _detect_cycles(
                 dependency,
-                encountered_stacks,
-                available_stacks,
+                encountered_nodes,
+                available_nodes,
                 path
             )
-            encountered_stacks[dependency] = "DONE"
-    return encountered_stacks
+            encountered_nodes[dependency] = "DONE"
+    return encountered_nodes

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -180,13 +180,14 @@ def get_subclasses(class_type, directory=None):
     return classes
 
 
-def _detect_cycles(stack, encountered_stacks):
+def _detect_cycles(stack, encountered_stacks, available_stacks):
     """
     Use Depth-first search to detect cycles.
     :returns: A dictionary containing all of the nodes encountered
     during the depth first search.
     """
-    for dependency in stack.dependencies:
+    for dependency_name in stack.dependencies:
+        dependency = available_stacks[dependency_name]
         status = encountered_stacks.get(dependency, None)
         if status is "ENCOUNTERED":
             raise CircularDependenciesError(
@@ -197,6 +198,6 @@ def _detect_cycles(stack, encountered_stacks):
             encountered_stacks[dependency] = "ENCOUNTERED"
         else:
             return encountered_stacks
-        _detect_cycles(dependency, encountered_stacks)
+        _detect_cycles(dependency, encountered_stacks, available_stacks)
         encountered_stacks[dependency] = "DONE"
     return encountered_stacks

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -191,22 +191,20 @@ def _detect_cycles(stack, encountered_stacks, available_stacks, path):
         # are prefixed with environment names separated by /, which is
         # undesirable here, so we strip them out.
         dependency = available_stacks[dependency_name.split("/")[-1]]
-        status = encountered_stacks.get(dependency, None)
-        if status is "ENCOUNTERED":
+        status = encountered_stacks.get(dependency)
+        if status == "ENCOUNTERED":
             raise CircularDependenciesError(
                 "Found circular dependency involving "
                 "{0}".format(path)
             )
         elif status is None:
             encountered_stacks[dependency] = "ENCOUNTERED"
-        else:
-            return encountered_stacks
-        path.append(dependency_name)
-        _detect_cycles(
-            dependency,
-            encountered_stacks,
-            available_stacks,
-            path
-        )
-        encountered_stacks[dependency] = "DONE"
+            path.append(dependency_name)
+            _detect_cycles(
+                dependency,
+                encountered_stacks,
+                available_stacks,
+                path
+            )
+            encountered_stacks[dependency] = "DONE"
     return encountered_stacks

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -516,7 +516,7 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         self.environment._check_for_circular_dependencies()
 
-    def test_modified_DAG_diamond_throws_no_circ_dependencies_error(self):
+    def test_modified_DAG_diamond_throws_circ_dependencies_error(self):
         """
         Ensures
             o
@@ -580,9 +580,10 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2', 'stack1'])
+        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2',
+                                          'stack1'])
 
-    def test_4_cycle_throws_circ_dependencies_error(self):
+    def test_modified_3_cycle_throws_circ_dependencies_error(self):
         """
         Ensures
             o   o

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -535,7 +535,7 @@ class TestEnvironment(object):
         stack1.name = "stack1"
         stack2.dependencies = ["stack4"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack5"]
+        stack3.dependencies = ["stack4", "stack5"]
         stack3.name = "stack3"
         stack4.dependencies = ["stack5"]
         stack4.name = "stack4"

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -406,8 +406,9 @@ class TestEnvironment(object):
         stack1.name = "stack1"
         stack2._get_launch_dependencies.return_value = [stack1]
         stack2.name = "stack2"
-        stacks = {"stack1": stack1,
-                  "stack2": stack2
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2
         }
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError):
@@ -423,29 +424,25 @@ class TestEnvironment(object):
         stack2.name = "stack2"
         stack3._get_launch_dependencies.return_value = [stack1]
         stack3.name = "stack3"
-        stacks = {"stack1": stack1,
-                  "stack2": stack2,
-                  "stack3": stack3
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2,
+            "stack3": stack3
         }
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError):
             self.environment._check_for_circular_dependencies()
 
-
     def test_check_for_circular_dependencies_without_find_dependencies(self):
-        dependencies = {
-            "stack-1": ["stack-2"],
-            "stack-2": []
-        }
-
         stack1 = MagicMock(Spec=Stack)
-        stack2 = Mock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
         stack1._get_launch_dependencies.return_value = [stack2]
         stack1.name = "stack1"
         stack2._get_launch_dependencies.return_value = []
         stack2.name = "stack2"
-        stacks = {"stack1": stack1,
-                  "stack2": stack2
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2
         }
         self.environment.stacks = stacks
         # Check this runs without throwing an exception

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -399,13 +399,9 @@ class TestEnvironment(object):
             "dev/mock_stack_3": [],
         }
 
-    @patch("sceptre.environment.Environment._get_launch_dependencies")
-    def test_check_for_circular_dependencies_with_circular_dependencies(
-            self,
-            mock_get_launch_dependencies
-    ):
+    def test_check_for_circular_dependencies_with_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
-        stack2 = Mock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
         stack1._get_launch_dependencies.return_value = [stack2]
         stack1.name = "stack1"
         stack2._get_launch_dependencies.return_value = [stack1]
@@ -416,6 +412,25 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError):
             self.environment._check_for_circular_dependencies()
+
+    def test_circular_dependencies_with_3_circular_dependencies(self):
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack3 = MagicMock(Spec=Stack)
+        stack1._get_launch_dependencies.return_value = [stack2]
+        stack1.name = "stack1"
+        stack2._get_launch_dependencies.return_value = [stack3]
+        stack2.name = "stack2"
+        stack3._get_launch_dependencies.return_value = [stack1]
+        stack3.name = "stack3"
+        stacks = {"stack1": stack1,
+                  "stack2": stack2,
+                  "stack3": stack3
+        }
+        self.environment.stacks = stacks
+        with pytest.raises(CircularDependenciesError):
+            self.environment._check_for_circular_dependencies()
+
 
     def test_check_for_circular_dependencies_without_find_dependencies(self):
         dependencies = {

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -413,7 +413,7 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert "['stack2', 'stack1']" in str(ex)
+        assert all(x in str(ex) for x in ['stack2', 'stack1'])
 
     def test_circular_dependencies_with_3_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
@@ -433,9 +433,9 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert "['stack2', 'stack3', 'stack1']" in str(ex)
+        assert all(x in str(ex) for x in ['stack3', 'stack2', 'stack1'])
 
-    def test_check_for_circular_dependencies_without_find_dependencies(self):
+    def test_no_circular_dependencies_throws_no_error(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
         stack1.dependencies = ["stack2"]
@@ -449,6 +449,170 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         # Check this runs without throwing an exception
         self.environment._check_for_circular_dependencies()
+
+    def test_DAG_diamond_throws_no_circ_dependencies_error(self):
+        """
+        Ensures
+            o
+           / \
+          o   o
+           \ /
+            o
+        throws no circular dependency error
+        """
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack3 = MagicMock(Spec=Stack)
+        stack4 = MagicMock(Spec=Stack)
+        stack1.dependencies = []
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1"]
+        stack2.name = "stack2"
+        stack3.dependencies = ["stack1"]
+        stack3.name = "stack3"
+        stack4.dependencies = ["stack2", "stack3"]
+        stack4.name = "stack4"
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2,
+            "stack3": stack3,
+            "stack4": stack4
+        }
+        self.environment.stacks = stacks
+        self.environment._check_for_circular_dependencies()
+
+    def test_modified_DAG_diamond_throws_no_circ_dependencies_error(self):
+        """
+        Ensures
+            o
+           / \
+          o   o
+           \ / \
+            o   o
+        throws no circular dependency error
+        """
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack3 = MagicMock(Spec=Stack)
+        stack4 = MagicMock(Spec=Stack)
+        stack5 = MagicMock(Spec=Stack)
+        stack1.dependencies = []
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1"]
+        stack2.name = "stack2"
+        stack3.dependencies = ["stack1"]
+        stack3.name = "stack3"
+        stack4.dependencies = ["stack2", "stack3"]
+        stack4.name = "stack4"
+        stack5.dependencies = ["stack3"]
+        stack5.name = "stack5"
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2,
+            "stack3": stack3,
+            "stack4": stack4,
+            "stack5": stack5
+        }
+        self.environment.stacks = stacks
+        self.environment._check_for_circular_dependencies()
+
+    def test_modified_DAG_diamond_throws_no_circ_dependencies_error(self):
+        """
+        Ensures
+            o
+           / \
+          o   o
+           \ / \
+            o ->o
+        throws no circular dependency error
+        """
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack3 = MagicMock(Spec=Stack)
+        stack4 = MagicMock(Spec=Stack)
+        stack5 = MagicMock(Spec=Stack)
+        stack1.dependencies = []
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1"]
+        stack2.name = "stack2"
+        stack3.dependencies = ["stack1"]
+        stack3.name = "stack3"
+        stack4.dependencies = ["stack2", "stack3"]
+        stack4.name = "stack4"
+        stack5.dependencies = ["stack3", "stack4"]
+        stack5.name = "stack5"
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2,
+            "stack3": stack3,
+            "stack4": stack4,
+            "stack5": stack5
+        }
+        self.environment.stacks = stacks
+        self.environment._check_for_circular_dependencies()
+
+    def test_4_cycle_throws_circ_dependencies_error(self):
+        """
+        Ensures
+            o - o
+            |   |
+            o - o
+        throws circular dependency error
+        """
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack3 = MagicMock(Spec=Stack)
+        stack4 = MagicMock(Spec=Stack)
+        stack1.dependencies = ["stack4"]
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1"]
+        stack2.name = "stack2"
+        stack3.dependencies = ["stack2"]
+        stack3.name = "stack3"
+        stack4.dependencies = ["stack3"]
+        stack4.name = "stack4"
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2,
+            "stack3": stack3,
+            "stack4": stack4
+        }
+        self.environment.stacks = stacks
+        with pytest.raises(CircularDependenciesError) as ex:
+            self.environment._check_for_circular_dependencies()
+        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2', 'stack1'])
+
+    def test_4_cycle_throws_circ_dependencies_error(self):
+        """
+        Ensures
+            o   o
+             \ / \
+              o - o
+              (right triangle is a 3 cycle)
+        throws circular dependency error
+        """
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack3 = MagicMock(Spec=Stack)
+        stack4 = MagicMock(Spec=Stack)
+        stack1.dependencies = []
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1", "stack4"]
+        stack2.name = "stack2"
+        stack3.dependencies = ["stack2"]
+        stack3.name = "stack3"
+        stack4.dependencies = ["stack3"]
+        stack4.name = "stack4"
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2,
+            "stack3": stack3,
+            "stack4": stack4
+        }
+        self.environment.stacks = stacks
+        with pytest.raises(CircularDependenciesError) as ex:
+            self.environment._check_for_circular_dependencies()
+        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2'])
 
     @patch("sceptre.environment.Config")
     def test_get_config(self, mock_Config):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -148,9 +148,7 @@ class TestEnvironment(object):
 
         self.environment.launch()
 
-        mock_check_for_circular_dependencies.assert_called_once_with(
-            sentinel.dependencies
-        )
+        mock_check_for_circular_dependencies.assert_called_once_with()
         mock_build.assert_called_once_with(
             "launch", sentinel.threading_events,
             sentinel.stack_statuses, sentinel.dependencies
@@ -178,9 +176,7 @@ class TestEnvironment(object):
 
         self.environment.delete()
 
-        mock_check_for_circular_dependencies.assert_called_once_with(
-            sentinel.dependencies
-        )
+        mock_check_for_circular_dependencies.assert_called_once_with()
         mock_build.assert_called_once_with(
             "delete", sentinel.threading_events,
             sentinel.stack_statuses, sentinel.dependencies
@@ -409,7 +405,7 @@ class TestEnvironment(object):
         }
 
         with pytest.raises(CircularDependenciesError):
-            self.environment._check_for_circular_dependencies(dependencies)
+            self.environment._check_for_circular_dependencies()
 
     def test_check_for_circular_dependencies_without_find_dependencies(self):
         dependencies = {
@@ -418,7 +414,7 @@ class TestEnvironment(object):
         }
 
         # Check this runs without throwing an exception
-        self.environment._check_for_circular_dependencies(dependencies)
+        self.environment._check_for_circular_dependencies()
 
     @patch("sceptre.environment.Config")
     def test_get_config(self, mock_Config):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -402,9 +402,9 @@ class TestEnvironment(object):
     def test_check_for_circular_dependencies_with_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1._get_launch_dependencies.return_value = [stack2]
+        stack1.dependencies = [stack2]
         stack1.name = "stack1"
-        stack2._get_launch_dependencies.return_value = [stack1]
+        stack2.dependencies = [stack1]
         stack2.name = "stack2"
         stacks = {
             "stack1": stack1,
@@ -418,11 +418,11 @@ class TestEnvironment(object):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
-        stack1._get_launch_dependencies.return_value = [stack2]
+        stack1.dependencies = [stack2]
         stack1.name = "stack1"
-        stack2._get_launch_dependencies.return_value = [stack3]
+        stack2.dependencies = [stack3]
         stack2.name = "stack2"
-        stack3._get_launch_dependencies.return_value = [stack1]
+        stack3.dependencies = [stack1]
         stack3.name = "stack3"
         stacks = {
             "stack1": stack1,
@@ -436,9 +436,9 @@ class TestEnvironment(object):
     def test_check_for_circular_dependencies_without_find_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1._get_launch_dependencies.return_value = [stack2]
+        stack1.dependencies = [stack2]
         stack1.name = "stack1"
-        stack2._get_launch_dependencies.return_value = []
+        stack2.dependencies = []
         stack2.name = "stack2"
         stacks = {
             "stack1": stack1,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -411,8 +411,9 @@ class TestEnvironment(object):
             "stack2": stack2
         }
         self.environment.stacks = stacks
-        with pytest.raises(CircularDependenciesError):
+        with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
+        assert "['stack2', 'stack1']" in str(ex)
 
     def test_circular_dependencies_with_3_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
@@ -430,8 +431,9 @@ class TestEnvironment(object):
             "stack3": stack3
         }
         self.environment.stacks = stacks
-        with pytest.raises(CircularDependenciesError):
+        with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
+        assert "['stack2', 'stack3', 'stack1']" in str(ex)
 
     def test_check_for_circular_dependencies_without_find_dependencies(self):
         stack1 = MagicMock(Spec=Stack)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -613,7 +613,8 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2']) and 'stack1' not in str(ex)
+        assert (all(x in str(ex) for x in ['stack4', 'stack3', 'stack2']) and
+                'stack1' not in str(ex))
 
     @patch("sceptre.environment.Config")
     def test_get_config(self, mock_Config):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -464,13 +464,13 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = []
+        stack1.dependencies = ["stack2", "stack3"]
         stack1.name = "stack1"
-        stack2.dependencies = ["stack1"]
+        stack2.dependencies = ["stack4"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack1"]
+        stack3.dependencies = ["stack4"]
         stack3.name = "stack3"
-        stack4.dependencies = ["stack2", "stack3"]
+        stack4.dependencies = []
         stack4.name = "stack4"
         stacks = {
             "stack1": stack1,
@@ -496,15 +496,15 @@ class TestEnvironment(object):
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
         stack5 = MagicMock(Spec=Stack)
-        stack1.dependencies = []
+        stack1.dependencies = ["stack2", "stack3"]
         stack1.name = "stack1"
-        stack2.dependencies = ["stack1"]
+        stack2.dependencies = ["stack4"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack1"]
+        stack3.dependencies = ["stack4", "stack5"]
         stack3.name = "stack3"
-        stack4.dependencies = ["stack2", "stack3"]
+        stack4.dependencies = []
         stack4.name = "stack4"
-        stack5.dependencies = ["stack3"]
+        stack5.dependencies = []
         stack5.name = "stack5"
         stacks = {
             "stack1": stack1,
@@ -516,7 +516,7 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         self.environment._check_for_circular_dependencies()
 
-    def test_modified_DAG_diamond_throws_circ_dependencies_error(self):
+    def test_DAG_diamond_with_triangle_throws_no_circ_dependencies_error(self):
         """
         Ensures
             o
@@ -531,15 +531,15 @@ class TestEnvironment(object):
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
         stack5 = MagicMock(Spec=Stack)
-        stack1.dependencies = []
+        stack1.dependencies = ["stack2", "stack3"]
         stack1.name = "stack1"
-        stack2.dependencies = ["stack1"]
+        stack2.dependencies = ["stack4"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack1"]
+        stack3.dependencies = ["stack5"]
         stack3.name = "stack3"
-        stack4.dependencies = ["stack2", "stack3"]
+        stack4.dependencies = ["stack5"]
         stack4.name = "stack4"
-        stack5.dependencies = ["stack3", "stack4"]
+        stack5.dependencies = []
         stack5.name = "stack5"
         stacks = {
             "stack1": stack1,
@@ -596,13 +596,13 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = []
+        stack1.dependencies = ["stack2"]
         stack1.name = "stack1"
-        stack2.dependencies = ["stack1", "stack4"]
+        stack2.dependencies = ["stack3"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack2"]
+        stack3.dependencies = ["stack4"]
         stack3.name = "stack3"
-        stack4.dependencies = ["stack3"]
+        stack4.dependencies = ["stack2"]
         stack4.name = "stack4"
         stacks = {
             "stack1": stack1,
@@ -613,7 +613,7 @@ class TestEnvironment(object):
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2'])
+        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2']) and 'stack1' not in str(ex)
 
     @patch("sceptre.environment.Config")
     def test_get_config(self, mock_Config):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -402,9 +402,9 @@ class TestEnvironment(object):
     def test_check_for_circular_dependencies_with_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1.dependencies = [stack2]
+        stack1.dependencies = ["stack2"]
         stack1.name = "stack1"
-        stack2.dependencies = [stack1]
+        stack2.dependencies = ["stack1"]
         stack2.name = "stack2"
         stacks = {
             "stack1": stack1,
@@ -418,11 +418,11 @@ class TestEnvironment(object):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
-        stack1.dependencies = [stack2]
+        stack1.dependencies = ["stack2"]
         stack1.name = "stack1"
-        stack2.dependencies = [stack3]
+        stack2.dependencies = ["stack3"]
         stack2.name = "stack2"
-        stack3.dependencies = [stack1]
+        stack3.dependencies = ["stack1"]
         stack3.name = "stack3"
         stacks = {
             "stack1": stack1,
@@ -436,7 +436,7 @@ class TestEnvironment(object):
     def test_check_for_circular_dependencies_without_find_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1.dependencies = [stack2]
+        stack1.dependencies = ["stack2"]
         stack1.name = "stack1"
         stack2.dependencies = []
         stack2.name = "stack2"


### PR DESCRIPTION
As discussed in #234, a cycle of dependencies with more than two nodes fails to be caught by _check_for_circular_dependencies. This PR updates the algorithm to a depth-first search based approach, providing a more robust circular dependency detection.

The tests, I'd imagine will need some work, as I'm new to the terrifying world of Python mocking libraries.

Additionally, I thought integration tests would be helpful, but there were no such tests for detecting circular dependencies; was this a conscious decision?

-----------------

* [x] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [?] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
