### PR TITLE
Support YAML extension uploads to S3

### DIFF
--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -127,6 +127,21 @@ class Template(object):
             sys.path.remove(os.path.join(os.getcwd(), directory))
         return body
 
+    def get_template_extension(self):
+        file_extension = os.path.splitext(self.path)[1]
+        if file_extension in {".json", ".yaml"}:
+            return file_extension
+        else:
+            for char in self.body:
+                if (not char.isspace()):
+                    # based on the first non-whitespace char in the rendered template
+                    if (char=="{"):
+                        return ".json"
+                    else:
+                        return ".yaml"
+
+        return ".json"
+
     def upload_to_s3(
             self, region, bucket_name, key_prefix, environment_path,
             stack_name, connection_manager
@@ -165,7 +180,7 @@ class Template(object):
         # Remove any leading or trailing slashes the user may have added.
         key_prefix = key_prefix.strip("/")
         
-        file_extension = os.path.splitext(self.path)[1]
+        file_extension = self.get_template_extension()
 
         template_key = "/".join([
             key_prefix,

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -127,7 +127,7 @@ class Template(object):
             sys.path.remove(os.path.join(os.getcwd(), directory))
         return body
 
-    def get_template_extension(self):
+    def get_rendered_template_extension(self):
         file_extension = os.path.splitext(self.path)[1]
         if file_extension in {".json", ".yaml"}:
             return file_extension
@@ -180,7 +180,7 @@ class Template(object):
         # Remove any leading or trailing slashes the user may have added.
         key_prefix = key_prefix.strip("/")
         
-        file_extension = self.get_template_extension()
+        file_extension = self.get_rendered_template_extension()
 
         template_key = "/".join([
             key_prefix,

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -135,7 +135,7 @@ class Template(object):
         Uploads the template to ``bucket_name`` and returns its URL.
 
         The template is uploaded with the key
-        ``<key_prefix>/<region>/<environment_path>/<stack_name>-<timestamp>.json``.
+        ``<key_prefix>/<region>/<environment_path>/<stack_name>-<timestamp>.<extension>``.
 
         :param region: The AWS region to create the bucket in.
         :type region: str
@@ -164,15 +164,19 @@ class Template(object):
 
         # Remove any leading or trailing slashes the user may have added.
         key_prefix = key_prefix.strip("/")
+        
+        file_extension = os.path.splitext(self.path)[1]
 
         template_key = "/".join([
             key_prefix,
             region,
             environment_path,
-            "{stack_name}-{time_stamp}.json".format(
+            "{stack_name}-{time_stamp}".format(
                 stack_name=stack_name,
                 time_stamp=datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S-%fZ")
-            )
+            ),
+            ".",
+            file_extension
         ])
 
         self.logger.debug(

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -171,12 +171,11 @@ class Template(object):
             key_prefix,
             region,
             environment_path,
-            "{stack_name}-{time_stamp}".format(
+            "{stack_name}-{time_stamp}.{extension}".format(
                 stack_name=stack_name,
-                time_stamp=datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S-%fZ")
-            ),
-            ".",
-            file_extension
+                time_stamp=datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S-%fZ"),
+                extension=file_extension
+            )
         ])
 
         self.logger.debug(

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -131,7 +131,8 @@ class Template(object):
         """
         Determine the extension of the rendered template.
         If the file extension is .json or .yaml, assume this is the value.
-        Otherwise, determine based on the first non-whitespace char in the rendered template.
+        Otherwise, determine based on the first non-whitespace char in the
+        rendered template.
 
         Used as the extension of the file to upload to S3.
         """

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -134,7 +134,7 @@ class Template(object):
         else:
             for char in self.body:
                 if (not char.isspace()):
-                    # based on the first non-whitespace char in the rendered template
+                    # determine extension based on the first non-whitespace char in the rendered template
                     if (char=="{"):
                         return ".json"
                     else:

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -128,14 +128,20 @@ class Template(object):
         return body
 
     def get_rendered_template_extension(self):
+        """
+        Determine the extension of the rendered template.
+        If the file extension is .json or .yaml, assume this is the value.
+        Otherwise, determine based on the first non-whitespace char in the rendered template.
+
+        Used as the extension of the file to upload to S3.
+        """
         file_extension = os.path.splitext(self.path)[1]
         if file_extension in {".json", ".yaml"}:
             return file_extension
         else:
             for char in self.body:
-                if (not char.isspace()):
-                    # determine extension based on the first non-whitespace char in the rendered template
-                    if (char=="{"):
+                if not char.isspace():
+                    if char == "{":
                         return ".json"
                     else:
                         return ".yaml"
@@ -179,7 +185,7 @@ class Template(object):
 
         # Remove any leading or trailing slashes the user may have added.
         key_prefix = key_prefix.strip("/")
-        
+
         file_extension = self.get_rendered_template_extension()
 
         template_key = "/".join([


### PR DESCRIPTION
Addresses Issue #254
When the template is uploaded to S3, it now uses the file extension of the template to set the S3 key name extension

-----------------

* [x] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [ ] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
