### PR TITLE
Enable pypi deployments from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,25 @@ jobs:
               make docs-dev
               aws s3 sync ~/project/docs/_site s3://sceptre.cloudreach.com/dev/ --delete
             fi
+  deploy-pypi:
+    docker:
+      - image: circleci/python:2.7.13
+        environment:
+          AWS_DEFAULT_REGION: eu-west-1
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: 'Create Distributions'
+          command: |
+            . ./venv/bin/activate
+            make dist
+      - run:
+          name: 'Upload Distributions'
+          command: |
+            . ./venv/bin/activate
+            pip install twine
+            twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 workflows:
   version: 2
   build-test-and-deploy:
@@ -130,3 +149,23 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy-pypi-approval:
+          type: approval
+          requires:
+            - lint-and-unit-tests
+            - integration-tests
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+      - deploy-pypi:
+          requires:
+            - deploy-pypi-approval
+            - lint-and-unit-tests
+            - integration-tests
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,14 +3,14 @@ History
 =======
 
 1.3.1 (2017.10.23)
------------------
+------------------
 
 * Removing sceptre diff command.
 * Adding support for the stack notifications attribute in stack config.
 * Fixing bug which caused session re-creation on every boto call.
 
 1.3.0 (2017.10.16)
------------------
+------------------
 
 * Re-adding the ability to specify credential profile in the environment config.
 * Adding init project command to help initialize a new Sceptre project.

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,9 @@ serve-docs-commit: docs-commit
 	$(MAKE) -C docs serve-commit
 
 dist: clean
+	python setup.py check -r -s
 	python setup.py sdist
-	python setup.py bdist_wheel
+	python setup.py bdist_wheel --universal
 	ls -l dist
 
 install: clean

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,3 +7,4 @@ flake8==2.5.1
 tox==2.3.1
 coverage==4.0.3
 pygments==2.2.0
+readme_renderer==17.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,6 @@ current_version = 1.3.1
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
-
 [bumpversion:file:sceptre/__init__.py]
 
 [wheel]
@@ -15,4 +13,3 @@ test = pytest
 
 [pytest]
 addopts = tests/ --ignore=env/ -s -v --junitxml=test-results.xml
-

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from sceptre import __version__
 from setuptools import setup
-
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()
@@ -30,9 +30,9 @@ setup_requirements = [
 
 setup(
     name="sceptre",
-    version="1.3.1",
+    version=__version__,
     description="Cloud Provisioning Tool",
-    long_description=readme + "\n\n" + history,
+    long_description=readme,
     author="Cloudreach",
     author_email="sceptre@cloudreach.com",
     license='Apache2',


### PR DESCRIPTION
This PR adds a deployment job for PyPi to CircleCi. This automates the deployment process when a new tagged version is pushed to Github. Deployments also now upload a bdist_wheel to pypi and description is checked that it renders correctly before. Sceptre version is now only stated once in __init__.py

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
