### PR TITLE
Fix path creation when encountering stacks.

### DIFF
--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -194,7 +194,7 @@ def _detect_cycles(node, encountered_nodes, available_nodes, path):
         status = encountered_nodes.get(dependency)
         if status == "ENCOUNTERED":
             # Reformat path to only include the cycle
-            path.insert(0, dependency_name)
+            path.append(dependency_name)
             cycle = path[path.index(dependency_name):]
             raise CircularDependenciesError(
                 "Found circular dependency involving "
@@ -202,7 +202,7 @@ def _detect_cycles(node, encountered_nodes, available_nodes, path):
             )
         elif status is None:
             encountered_nodes[dependency] = "ENCOUNTERED"
-            path.insert(0, dependency_name)
+            path.append(dependency_name)
             _detect_cycles(
                 dependency,
                 encountered_nodes,


### PR DESCRIPTION
When constructing the path of encountered nodes, they were inserted
at the beginning of the list. However, when that list is trimmed
down upon finding a cycle, the logic suggested that the nodes
should have instead be added to the end.

This commits now adds nodes to the end when constructing a path.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
