### PR TITLE
Fix description of custom resolver syntax

### DIFF
--- a/docs/docs/resolvers.md
+++ b/docs/docs/resolvers.md
@@ -178,13 +178,10 @@ class CustomResolver(Resolver):
         return self.argument
 ```
 
-This resolver can be used in a stack config file with the following syntax:
+The resolver name is the lower snake-case version of the class name. The argument of the resolver (`<value>`) will be available inside the resolver as `self.argument`. The resolver subclass above can be used in a stack config file with the following syntax:
 
 ```yaml
 template_path: <...>
 parameters:
-    # <your resolver name> is the lower snake case version of your class name,
-    # e.g `custom_resolver` <value> will be passed to the resolver's resolve()
-    # method.
     param1: !<your_resolver_name> <value>
 ```


### PR DESCRIPTION
Updated to accurately say the resolver name is snake-class and clarified how the resolver value is accessible in within the class.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
