### PR TITLE
Add generic fie extension for S3 upload

### DIFF
--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -135,7 +135,7 @@ class Template(object):
         Uploads the template to ``bucket_name`` and returns its URL.
 
         The template is uploaded with the key
-        ``<key_prefix>/<region>/<environment_path>/<stack_name>-<timestamp>.json``.
+        ``<key_prefix>/<region>/<environment_path>/<stack_name>-<timestamp>.template``.
 
         :param region: The AWS region to create the bucket in.
         :type region: str
@@ -169,7 +169,7 @@ class Template(object):
             key_prefix,
             region,
             environment_path,
-            "{stack_name}-{time_stamp}.json".format(
+            "{stack_name}-{time_stamp}.template".format(
                 stack_name=stack_name,
                 time_stamp=datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S-%fZ")
             )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -68,7 +68,7 @@ class TestTemplate(object):
 
         expected_template_key = (
             "prefix/eu-west-1/environment/path/"
-            "stack-name-2012-01-01-00-00-00-000000Z.json"
+            "stack-name-2012-01-01-00-00-00-000000Z.template"
         )
 
         self.connection_manager.call.assert_called_once_with(


### PR DESCRIPTION
Resolves #254

We require better support for different file types when uploading
tempaltes to S3. Prevously, only .json was supported, with this commit
a more generic .template extension is implemented.

This PR acts as a stop-gap solution for #255 until better handling of file extension is implemented. 

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
