### PR TITLE
Add Estimate Template Cost Functionality

### DIFF
--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -25,7 +25,8 @@ from sceptre.cli.describe import describe_group
 from sceptre.cli.list import list_group
 from sceptre.cli.policy import set_policy_command
 from sceptre.cli.status import status_command
-from sceptre.cli.template import validate_command, generate_command
+from sceptre.cli.template import (validate_command, generate_command,
+                                  estimate_cost_command)
 from sceptre.cli.helpers import setup_logging, catch_exceptions
 
 
@@ -97,6 +98,7 @@ cli.add_command(delete_command)
 cli.add_command(launch_command)
 cli.add_command(execute_command)
 cli.add_command(validate_command)
+cli.add_command(estimate_cost_command)
 cli.add_command(generate_command)
 cli.add_command(set_policy_command)
 cli.add_command(status_command)

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -1,4 +1,5 @@
 import click
+import webbrowser
 
 from sceptre.cli.helpers import catch_exceptions, get_stack_or_env, write
 
@@ -33,3 +34,25 @@ def generate_command(ctx, path):
     """
     stack, _ = get_stack_or_env(ctx, path)
     write(stack.template.body)
+
+
+@click.command(name="estimate-cost")
+@click.argument("path")
+@click.pass_context
+@catch_exceptions
+def estimate_cost_command(ctx, path):
+    """
+    Estimates the cost of the template.
+    Prints a URI to STOUT that provides an estimated cost based on the
+    resources in the stack. This command will also attempt to open a web
+    browser with the returned URI.
+    """
+    stack, _ = get_stack_or_env(ctx, path)
+    response = stack.template.estimate_cost()
+
+    if response['ResponseMetadata']['HTTPStatusCode'] == 200:
+        del response['ResponseMetadata']
+        click.echo("View the estimated cost at:")
+        response = response["Url"]
+        webbrowser.open(response, new=2)
+    write(response + "\n", 'str')

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -276,6 +276,25 @@ class Template(object):
         )
         return response
 
+    def estimate_cost(self):
+        """
+        Estimates a stack's cost.
+
+        :returns: An estimate of the stack's cost.
+        :rtype: dict
+        :raises: botocore.exceptions.ClientError
+        """
+        self.logger.debug("%s - Estimating template cost", self.name)
+        response = self.connection_manager.call(
+            service="cloudformation",
+            command="estimate_template_cost",
+            kwargs=self.get_boto_call_parameter()
+        )
+        self.logger.debug(
+            "%s - Estimate stack cost response: %s", self.name, response
+        )
+        return response
+
     @staticmethod
     def _render_jinja_template(template_dir, filename, jinja_vars):
         """

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -183,6 +183,22 @@ class TestTemplate(object):
             kwargs={"Template": sentinel.template}
         )
 
+    @patch("sceptre.template.Template.get_boto_call_parameter")
+    def test_estimate_cost_sends_correct_request(
+        self, mock_get_boto_call_parameter
+    ):
+        mock_get_boto_call_parameter.return_value = {
+            "Template": sentinel.template
+        }
+        self.template.estimate_cost()
+        self.template.connection_manager.call.assert_called_with(
+            service="cloudformation",
+            command="estimate_template_cost",
+            kwargs={
+                "Template": sentinel.template,
+            }
+        )
+
     def test_body_with_json_template(self):
         self.template.name = "vpc"
         self.template.path = os.path.join(


### PR DESCRIPTION
Resolves #106

We need to be able to estimate the cost of our Cloudformation templates
before creating them. AWS provides a convenient API to make this happen.
This API has been implemented in Stack and the Cli to enable the use
within python modules and the CLI.

If called from the CLI, a unique URL containing the estimated cost
will be printed to stout and will attempt to open a web browser with
that URL.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
