### PR TITLE
Compatibility fix for the new config reader api

### DIFF
--- a/sceptre/config_reader.py
+++ b/sceptre/config_reader.py
@@ -363,7 +363,9 @@ class ConfigReader(object):
                 role_arn=config.get("role_arn"),
                 protected=config.get("protect", False),
                 tags=config.get("stack_tags", {}),
-                external_name=config.get("external_name")
+                external_name=config.get("external_name"),
+                notifications=config.get("notifications"),
+                on_failure=config.get("on_failure")
             )
 
             self._construct_nodes(config, stack)

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -185,14 +185,12 @@ def get_subclasses(class_type, directory=None):
 def _detect_cycles(node, encountered_nodes, available_nodes, path):
     """
     Use Depth-first search to detect cycles.
+
     :returns: A dictionary containing all of the nodes encountered
     during the depth first search.
     """
     for dependency_name in node.dependencies:
-        # The keys in _load_nodes() (where the available_nodes comes from)
-        # are prefixed with environment names separated by /, which is
-        # undesirable here, so we strip them out.
-        dependency = available_nodes[dependency_name.split("/")[-1]]
+        dependency = available_nodes[dependency_name]
         status = encountered_nodes.get(dependency)
         if status == "ENCOUNTERED":
             # Reformat path to only include the cycle

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -232,7 +232,9 @@ class TestConfigReader(object):
                 role_arn=None,
                 protected=False,
                 tags={},
-                external_name=None
+                external_name=None,
+                notifications=None,
+                on_failure=None
         )
         assert stack == sentinel.stack
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -356,6 +356,19 @@ class TestEnvironment(object):
         # Check this runs without throwing an exception
         self.environment._check_for_circular_dependencies()
 
+    def test_no_circular_dependencies_with_nested_stacks(self):
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack1.dependencies = ["env1/stack2"]
+        stack1.name = "stack1"
+        stack2.dependencies = []
+        stack2.name = "env1/stack2"
+        stacks = [stack1, stack2]
+
+        self.environment.stacks = stacks
+        # Check this runs without throwing an exception
+        self.environment._check_for_circular_dependencies()
+
     def test_DAG_diamond_throws_no_circ_dependencies_error(self):
         """
         Ensures


### PR DESCRIPTION
This PR fixes a couple issue migrating to the new config reader API. Firstly stack names now reference the full path including environment - which broke dependency resolution. On_failure and notification parameters from stack config now are used to construct Stack objects. 

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
