### PR TITLE
[Resolve #272] Enable integration tests in generic AWS accounts

### DIFF
--- a/integration-tests/sceptre-project/config/1/config.yaml
+++ b/integration-tests/sceptre-project/config/1/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/2/config.yaml
+++ b/integration-tests/sceptre-project/config/2/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/3/config.yaml
+++ b/integration-tests/sceptre-project/config/3/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/4/config.yaml
+++ b/integration-tests/sceptre-project/config/4/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/5/1/config.yaml
+++ b/integration-tests/sceptre-project/config/5/1/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/5/2/config.yaml
+++ b/integration-tests/sceptre-project/config/5/2/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/5/config.yaml
+++ b/integration-tests/sceptre-project/config/5/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/6/1/config.yaml
+++ b/integration-tests/sceptre-project/config/6/1/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/6/2/config.yaml
+++ b/integration-tests/sceptre-project/config/6/2/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/6/3/config.yaml
+++ b/integration-tests/sceptre-project/config/6/3/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/6/4/1/config.yaml
+++ b/integration-tests/sceptre-project/config/6/4/1/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/6/4/2/config.yaml
+++ b/integration-tests/sceptre-project/config/6/4/2/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/6/4/config.yaml
+++ b/integration-tests/sceptre-project/config/6/4/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/6/config.yaml
+++ b/integration-tests/sceptre-project/config/6/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/7/config.yaml
+++ b/integration-tests/sceptre-project/config/7/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/8/config.yaml
+++ b/integration-tests/sceptre-project/config/8/config.yaml
@@ -1,3 +1,0 @@
-iam_role: arn:aws:iam::458947373260:role/SceptreIntegrationTestsRole
-region: eu-west-1
-template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/config.yaml
+++ b/integration-tests/sceptre-project/config/config.yaml
@@ -1,1 +1,3 @@
-project_code: sceptre-integration-tests-941d57d4a9df11e7956dacbc328d8bb1
+project_code: sceptre-integration-tests
+region: eu-west-1
+template_bucket_name: sceptre-integration-tests-templates


### PR DESCRIPTION
This PR removes the assume role for integrations tests and randomizes the bucket name. These properties were specific to the account linked to CircleCI and prevented others from running integration tests locally in other AWS accounts.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
