### PR TITLE
[Resolve #283] Add Support for Multiple --var-file Options

### DIFF
--- a/docs/docs/environment_config.md
+++ b/docs/docs/environment_config.md
@@ -121,7 +121,33 @@ where `variables.yaml` contains::
 iam_role: <your iam role>
 ```
 
-The `--var` flag can be used multiple times to supply multiple variables. If both `--var` and `--var-file` are supplied, `--var` overwrites any common values in `--var-file`.
+Both the `--var` and `--var-file` flags can be used multiple times. If multiple `--var-file` options are supplied, the variables from these files will be merged, with a higher precedence given to options specified later in the command. Values supplied using `--var` take the highest precedence and will overwrite any value defined in the variable files. 
+
+For example if we have the following variable files:
+
+```yaml
+---- default.yaml
+region: eu-west-1
+profile: dev
+project_code: api
+
+---- prod.yaml
+profile: prod
+```
+
+The following sceptre command: 
+ 
+```shell 
+sceptre --var-file=default.yaml --var-file=prod.yaml --var region=us-east-1 <COMMAND>
+```
+
+Will result in the following variables being available to the jinja templating:
+
+```yaml
+region: us-east-1
+profile: prod
+project_code: api
+```
 
 For command line flags, Sceptre splits the string on the first equals sign "=", and sets the key to be the first substring, and the value to be the second. Due to the large number of possible user inputs, no error checking is performed on the value of the --var flag, and it is the user's responsibility to make sure that the value is correctly formatted.
 


### PR DESCRIPTION
Now able to specify multiple --var-file options when running
sceptre from the CLI. The dictionaries from these files will
be merged and exposed to the jinja templating. This allows
users to break a monolithic variable file into composable
pieces.

**Replace the text above the line with a summary of the changes in your PR.
The more detailed you are, the better. Before submitting the PR, make sure the following are checked.**

-----------------

* [x] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
