### PR TITLE
Hotfix for new cli not being installed correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     packages=[
         "sceptre",
         "sceptre/resolvers",
-        "sceptre/hooks"
+        "sceptre/hooks",
+        "sceptre/cli"
     ],
     package_dir={
         "sceptre": "sceptre"


### PR DESCRIPTION
Hotfix for the CLI not being able to run after pip installation. This adds the CLI module to the packages contained in the install. 

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
