### PR TITLE
[Resolve #288] Fix how user variables are accessed in config templating

### DIFF
--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -91,7 +91,7 @@ def write(var, output_format="str", no_colour=True):
 
 def get_stack_or_env(ctx, path):
     """
-    Parses the path to generate relevant Envrionment and Stack object.
+    Parses the path to generate relevant Environment and Stack object.
 
     :param ctx: Cli context.
     :type ctx: click.Context
@@ -101,7 +101,9 @@ def get_stack_or_env(ctx, path):
     stack = None
     env = None
 
-    config_reader = ConfigReader(ctx.obj["sceptre_dir"], ctx.obj["options"])
+    config_reader = ConfigReader(
+        ctx.obj["sceptre_dir"], ctx.obj["user_variables"]
+    )
 
     if os.path.splitext(path)[1]:
         stack = config_reader.construct_stack(path)


### PR DESCRIPTION
Now variables supplied using the --var and --var-file command options
are available in the jinja templating as `{{ var.* }}`.

**Replace the text above the line with a summary of the changes in your PR.
The more detailed you are, the better. Before submitting the PR, make sure the following are checked.**

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
