### PR TITLE
[Resolves #268] Add support for resolvers in the Stack object

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -47,6 +47,7 @@ class Stack(object):
 
     parameters = ResolvableProperty("parameters")
     sceptre_user_data = ResolvableProperty("sceptre_user_data")
+    notifications = ResolvableProperty("notifications")
 
     def __init__(
         self, name, project_code, template_path, region, iam_role=None,
@@ -67,6 +68,7 @@ class Stack(object):
         self.hooks = hooks or {}
         self.parameters = parameters or {}
         self.sceptre_user_data = sceptre_user_data or {}
+        self.notifications = notifications or []
 
         self.template_path = template_path
         self.s3_details = s3_details
@@ -75,7 +77,6 @@ class Stack(object):
         self.protected = protected
         self.role_arn = role_arn
         self.on_failure = on_failure
-        self.notifications = notifications or []
         self.dependencies = dependencies or []
         self.tags = tags or {}
 


### PR DESCRIPTION
This adds support for resolvers for notifications in Stacks. Allows notifications to be resolvable objects.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
