### PR TITLE
Remove get_stack from cli helpers

### DIFF
--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -1,6 +1,7 @@
 import click
 
-from sceptre.cli.helpers import catch_exceptions, confirmation, get_stack
+from sceptre.cli.helpers import catch_exceptions, confirmation
+from sceptre.cli.helpers import get_stack_or_env
 from sceptre.stack_status import StackStatus
 
 
@@ -21,7 +22,7 @@ def create_command(ctx, path, change_set_name, yes):
     """
     action = "create"
 
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     if change_set_name:
         confirmation(action, yes, change_set=change_set_name, stack=path)
         stack.create_change_set(change_set_name)

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -1,6 +1,6 @@
 import click
 
-from sceptre.cli.helpers import catch_exceptions, get_stack, write
+from sceptre.cli.helpers import catch_exceptions, get_stack_or_env, write
 from sceptre.cli.helpers import simplify_change_set_description
 
 
@@ -26,7 +26,7 @@ def describe_change_set(ctx, path, change_set_name, verbose):
     Describes the change set.
 
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     description = stack.describe_change_set(change_set_name)
     if not verbose:
         description = simplify_change_set_description(description)
@@ -42,6 +42,6 @@ def describe_policy(ctx, path):
     Displays the stack policy used.
 
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     response = stack.get_policy()
     write(response.get('StackPolicyBody', {}))

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -1,6 +1,7 @@
 import click
 
-from sceptre.cli.helpers import catch_exceptions, confirmation, get_stack
+from sceptre.cli.helpers import catch_exceptions, confirmation
+from sceptre.cli.helpers import get_stack_or_env
 
 
 @click.command(name="execute")
@@ -16,6 +17,6 @@ def execute_command(ctx, path, change_set_name, yes):
     Executes a change set.
 
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     confirmation("execute", yes, change_set=change_set_name, stack=path)
     stack.execute_change_set(change_set_name)

--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -111,20 +111,6 @@ def get_stack_or_env(ctx, path):
     return (stack, env)
 
 
-def get_stack(ctx, path):
-    """
-    Parses the path to generate relevant Envrionment and Stack object.
-
-    :param ctx: Cli context.
-    :type ctx: click.Context
-    :param path: Path to either stack config or environment folder.
-    :type path: str
-    """
-    return ConfigReader(
-        ctx.obj["sceptre_dir"], ctx.obj["options"]
-    ).construct_stack(path)
-
-
 def setup_logging(debug, no_colour):
     """
     Sets up logging.

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -1,7 +1,6 @@
 import click
 
-from sceptre.cli.helpers import catch_exceptions, get_stack
-from sceptre.cli.helpers import get_stack_or_env, write
+from sceptre.cli.helpers import catch_exceptions, get_stack_or_env, write
 
 
 @click.group(name="list")
@@ -44,7 +43,7 @@ def list_outputs(ctx, path, export):
     List outputs for stack.
 
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     response = stack.describe_outputs()
 
     if export == "envvar":
@@ -69,7 +68,7 @@ def list_change_sets(ctx, path):
     List change sets for stack.
 
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     response = stack.list_change_sets()
     if response['ResponseMetadata']['HTTPStatusCode'] == 200:
         del response['ResponseMetadata']

--- a/sceptre/cli/policy.py
+++ b/sceptre/cli/policy.py
@@ -1,6 +1,6 @@
 import click
 
-from sceptre.cli.helpers import catch_exceptions, get_stack
+from sceptre.cli.helpers import catch_exceptions, get_stack_or_env
 
 
 @click.command(name="set-policy")
@@ -18,7 +18,7 @@ def set_policy_command(ctx, path, policy_file, built_in):
 
     Sets a specific stack policy for either a file or using a built-in policy.
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
 
     if built_in == 'deny-all':
         stack.lock()

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -1,6 +1,6 @@
 import click
 
-from sceptre.cli.helpers import catch_exceptions, get_stack, write
+from sceptre.cli.helpers import catch_exceptions, get_stack_or_env, write
 
 
 @click.command(name="validate")
@@ -13,7 +13,7 @@ def validate_command(ctx, path):
 
     Validates the template used for stack in PATH.
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     response = stack.template.validate()
     if response['ResponseMetadata']['HTTPStatusCode'] == 200:
         del response['ResponseMetadata']
@@ -31,5 +31,5 @@ def generate_command(ctx, path):
 
     Prints the template used for stack in PATH.
     """
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     write(stack.template.body)

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -2,8 +2,8 @@ from uuid import uuid1
 
 import click
 
-from sceptre.cli.helpers import catch_exceptions, confirmation, get_stack
-from sceptre.cli.helpers import write
+from sceptre.cli.helpers import catch_exceptions, confirmation
+from sceptre.cli.helpers import write, get_stack_or_env
 from sceptre.cli.helpers import simplify_change_set_description
 from sceptre.stack_status import StackStatus, StackChangeSetStatus
 
@@ -30,7 +30,7 @@ def update_command(ctx, path, change_set, verbose, yes):
     change-set when the change-set flag is set.
     """
 
-    stack = get_stack(ctx, path)
+    stack, _ = get_stack_or_env(ctx, path)
     if change_set:
         change_set_name = "-".join(["change-set", uuid1().hex])
         stack.create_change_set(change_set_name)


### PR DESCRIPTION
This stack removes a redundant `get_stack` function from the CLI helpers class - as the `get_stack_or_env` function provides the same functionality. 

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
