### PR TITLE
Add resolver and hook setup function

### DIFF
--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -211,3 +211,30 @@ def _detect_cycles(node, encountered_nodes, available_nodes, path):
             )
             encountered_nodes[dependency] = "DONE"
     return encountered_nodes
+
+
+def _call_func_on_values(func, attr, cls):
+    """
+    Searches through dictionary or list for objects of type `cls` and calls the
+    supplied function `func`. Supports nested dictionaries and lists.
+    Does not detect objects used as keys in dictionaries.
+
+    :param attr: A dictionary or list to search through.
+    :type attr: dict or list
+    :return: The dictionary or list structure.
+    :rtype: dict or list
+    """
+
+    def func_on_instance(key):
+        if isinstance(value, cls):
+            func(attr, key, value)
+        elif isinstance(value, list) or isinstance(value, dict):
+            _call_func_on_values(func, value, cls)
+
+    if isinstance(attr, dict):
+        for key, value in attr.items():
+            func_on_instance(key)
+    elif isinstance(attr, list):
+        for index, value in enumerate(attr):
+            func_on_instance(index)
+    return attr

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -2,6 +2,8 @@ import abc
 import logging
 from functools import wraps
 
+from sceptre.helpers import _call_func_on_values
+
 
 class Hook(object):
     """
@@ -19,6 +21,13 @@ class Hook(object):
         self.argument = argument
         self.stack = stack
 
+    def setup(self):
+        """
+        setup is a method that may be overwritten by inheriting classes. Allows
+        hooks to run so initalisation steps when config is first read.
+        """
+        pass  # pragma: no cover
+
     @abc.abstractmethod
     def run(self):
         """
@@ -26,6 +35,42 @@ class Hook(object):
         inheriting classes. Run should execute the logic of the hook.
         """
         pass  # pragma: no cover
+
+
+class HookProperty(object):
+    """
+    This is a descriptor class used to store an attribute that may contain
+    Hook objects. Used to setup Hooks when added as a attribute. Supports
+    nested dictionary and lists.
+
+    :param name: Attribute suffix used to store the property in the instance.
+    :type name: string
+    """
+    def __init__(self, name):
+        self.name = "_" + name
+        self.logger = logging.getLogger(__name__)
+
+    def __get__(self, instance, type):
+        """
+        Attribute getter for Hook containing data structure.
+
+        :return: The attribute stored with the suffix ``name`` in the instance.
+        :rtype: dict or list
+        """
+        return getattr(instance, self.name)
+
+    def __set__(self, instance, value):
+        """
+        Attribute setter which adds a stack reference to any hooks in the
+        data structure `value` and calls the setup method.
+
+        """
+        def setup(attr, key, value):
+            value.stack = instance
+            value.setup()
+
+        _call_func_on_values(setup, value, Hook)
+        setattr(instance, self.name, value)
 
 
 def execute_hooks(hooks):

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -3,6 +3,8 @@ import abc
 import six
 import logging
 
+from sceptre.helpers import _call_func_on_values
+
 
 @six.add_metaclass(abc.ABCMeta)
 class Resolver():
@@ -25,10 +27,9 @@ class Resolver():
 
     def setup(self):
         """
-        An abstract method which must be overwritten by all inheriting classes.
-        This method is called to retrieve the final desired value.
-        Implementation of this method in subclasses must return a suitable
-        object or primitive type.
+        This method is called at during stack initialisation.
+        Implementation of this method in subclasses can be used to do any
+        initial setup of the object.
         """
         pass  # pragma: no cover
 
@@ -65,41 +66,23 @@ class ResolvableProperty(object):
         :return: The attribute stored with the suffix ``name`` in the instance.
         :rtype: dict or list
         """
+        def resolve(attr, key, value):
+            attr[key] = value.resolve()
 
         if hasattr(instance, self.name):
-            return self._call_func_on_values(
-                getattr(instance, self.name), "resolve"
+            return _call_func_on_values(
+                resolve, getattr(instance, self.name), Resolver
             )
 
     def __set__(self, instance, value):
-        self._call_func_on_values(
-            value, "setup", {"stack": instance}
-        )
+        """
+        Attribute setter which adds a stack reference to any resolvers in the
+        data structure `value` and calls the setup method.
+
+        """
+        def setup(attr, key, value):
+            value.stack = instance
+            value.setup()
+
+        _call_func_on_values(setup, value, Resolver)
         setattr(instance, self.name, value)
-
-    def _call_func_on_values(self, attr, func_name, kwargs=None):
-        """
-        Searches through dictionary or list for Resolver objects and replaces
-        them with the resolved value. Supports nested dictionaries and lists.
-        Does not detect Resolver objects used as keys in dictionaries.
-
-        :param attr: A complex data structure to search through.
-        :type attr: dict or list
-        :return: A complex data structure without Resolver objects.
-        :rtype: dict or list
-        """
-        kwargs = kwargs or {}
-
-        if isinstance(attr, dict):
-            for key, value in attr.items():
-                if isinstance(value, Resolver):
-                    attr[key] = getattr(value, func_name)(**kwargs)
-                elif isinstance(value, list) or isinstance(value, dict):
-                    self._call_func_on_values(value, func_name, kwargs)
-        elif isinstance(attr, list):
-            for index, value in enumerate(attr):
-                if isinstance(value, Resolver):
-                    attr[index] = getattr(value, func_name)(**kwargs)
-                elif isinstance(value, list) or isinstance(value, dict):
-                    self._call_func_on_values(value, func_name, kwargs)
-        return attr

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -96,6 +96,8 @@ class StackOutput(StackOutputBase):
 
     def __init__(self, *args, **kwargs):
         super(StackOutput, self).__init__(*args, **kwargs)
+
+    def setup(self, stack):
         self.dependency_stack_name, self.output_key = self.argument.split("::")
         if "/" not in self.dependency_stack_name:
             self.dependency_stack_name = "/".join([

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -97,7 +97,10 @@ class StackOutput(StackOutputBase):
     def __init__(self, *args, **kwargs):
         super(StackOutput, self).__init__(*args, **kwargs)
 
-    def setup(self, stack):
+    def setup(self):
+        """
+        Adds dependency to stack.
+        """
         self.dependency_stack_name, self.output_key = self.argument.split("::")
         if "/" not in self.dependency_stack_name:
             self.dependency_stack_name = "/".join([

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -65,11 +65,6 @@ class Stack(object):
 
         self.connection_manager = ConnectionManager(region, iam_role)
 
-        self.hooks = hooks or {}
-        self.parameters = parameters or {}
-        self.sceptre_user_data = sceptre_user_data or {}
-        self.notifications = notifications or []
-
         self.template_path = template_path
         self.s3_details = s3_details
         self._template = None
@@ -79,6 +74,10 @@ class Stack(object):
         self.on_failure = on_failure
         self.dependencies = dependencies or []
         self.tags = tags or {}
+
+        self.hooks = hooks or {}
+        self.parameters = parameters or {}
+        self.sceptre_user_data = sceptre_user_data or {}
 
     def __repr__(self):
         return (

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -19,6 +19,7 @@ import botocore
 from .connection_manager import ConnectionManager
 from .helpers import get_external_stack_name
 from .resolvers import ResolvableProperty
+from .hooks import HookProperty
 from .stack_status import StackStatus
 from .stack_status import StackChangeSetStatus
 from .template import Template
@@ -48,6 +49,7 @@ class Stack(object):
     parameters = ResolvableProperty("parameters")
     sceptre_user_data = ResolvableProperty("sceptre_user_data")
     notifications = ResolvableProperty("notifications")
+    hooks = HookProperty("hooks")
 
     def __init__(
         self, name, project_code, template_path, region, iam_role=None,
@@ -78,6 +80,7 @@ class Stack(object):
         self.hooks = hooks or {}
         self.parameters = parameters or {}
         self.sceptre_user_data = sceptre_user_data or {}
+        self.notifications = notifications or []
 
     def __repr__(self):
         return (

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -5,7 +5,6 @@ from mock import patch, sentinel
 import pytest
 import yaml
 import errno
-from functools import partial
 
 from sceptre.exceptions import VersionIncompatibleError
 from sceptre.exceptions import ConfigFileNotFoundError
@@ -142,28 +141,6 @@ class TestConfigReader(object):
                 "param5": "region",
                 "param6": "environment_region"
             }
-        }
-
-    def test_construct_nodes(self):
-        def add(value):
-            return 1 + value
-
-        attr = {
-            "parameters": {
-                "param1": partial(add),
-                "param2": {"param3": partial(add), "param4": partial(add)},
-                "param5": [partial(add), partial(add)]
-            },
-            "sceptre_user_data": [partial(add), [partial(add), partial(add)]]
-        }
-        ConfigReader._construct_nodes(attr, 1)
-        assert attr == {
-            "parameters": {
-                "param1": 2,
-                "param2": {"param3": 2, "param4": 2},
-                "param5": [2, 2]
-            },
-            "sceptre_user_data": [2, [2, 2]]
         }
 
     def test_aborts_on_incompatible_version_requirement(self):

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from mock import MagicMock
 
-from sceptre.hooks import Hook, add_stack_hooks, execute_hooks
+from sceptre.hooks import Hook, HookProperty, add_stack_hooks, execute_hooks
 
 
 class MockHook(Hook):
@@ -66,3 +66,24 @@ class TestHook(object):
 
     def test_hook_inheritance(self):
         assert isinstance(self.hook, Hook)
+
+
+class MockClass(object):
+    hook_property = HookProperty("hook_property")
+    config = MagicMock()
+
+
+class TestHookPropertyDescriptor(object):
+
+    def setup_method(self, test_method):
+        self.mock_object = MockClass()
+
+    def test_setting_hook_property(self):
+        mock_hook = MagicMock(spec=MockHook)
+
+        self.mock_object.hook_property = [mock_hook]
+        assert self.mock_object._hook_property == [mock_hook]
+
+    def test_getting_hook_property(self):
+        self.mock_object._hook_property = self.mock_object
+        assert self.mock_object.hook_property == self.mock_object

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -66,6 +66,7 @@ class TestResolvablePropertyDescriptor(object):
 
         self.mock_object.resolvable_property = complex_data_structure
         assert self.mock_object._resolvable_property == complex_data_structure
+        assert mock_resolver.stack == self.mock_object
 
     def test_getting_resolvable_property_with_none(self):
         self.mock_object._resolvable_property = None
@@ -116,8 +117,8 @@ class TestResolvablePropertyDescriptor(object):
         ]
 
         self.mock_object._resolvable_property = complex_data_structure
-        property = self.mock_object.resolvable_property
-        assert property == resolved_complex_data_structure
+        prop = self.mock_object.resolvable_property
+        assert prop == resolved_complex_data_structure
 
     def test_getting_resolvable_property_with_nested_dictionaries_and_lists(
         self
@@ -212,8 +213,8 @@ class TestResolvablePropertyDescriptor(object):
         }
 
         self.mock_object._resolvable_property = complex_data_structure
-        property = self.mock_object.resolvable_property
-        assert property == resolved_complex_data_structure
+        prop = self.mock_object.resolvable_property
+        assert prop == resolved_complex_data_structure
 
     def test_getting_resolvable_property_with_nested_dictionaries(self):
         mock_resolver = MagicMock(spec=MockResolver)
@@ -254,5 +255,5 @@ class TestResolvablePropertyDescriptor(object):
         }
 
         self.mock_object._resolvable_property = complex_data_structure
-        property = self.mock_object.resolvable_property
-        assert property == resolved_complex_data_structure
+        prop = self.mock_object.resolvable_property
+        assert prop == resolved_complex_data_structure

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -27,7 +27,7 @@ class TestStackOutputResolver(object):
             "account/dev/vpc::VpcId", stack
         )
         mock_get_output_value.return_value = "output_value"
-
+        stack_output_resolver.setup()
         result = stack_output_resolver.resolve()
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
@@ -48,7 +48,9 @@ class TestStackOutputResolver(object):
         )
         mock_get_output_value.return_value = "output_value"
 
+        stack_output_resolver.setup()
         result = stack_output_resolver.resolve()
+
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
             "project-code-account-dev-vpc", "VpcId"
@@ -69,7 +71,9 @@ class TestStackOutputResolver(object):
         stack_output_resolver = StackOutput("vpc::VpcId", stack)
         mock_get_output_value.return_value = "output_value"
 
+        stack_output_resolver.setup()
         result = stack_output_resolver.resolve()
+
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
             "project-code-account-dev-vpc", "VpcId"


### PR DESCRIPTION
This PR adds a setup function to Hooks and Resolvers. This is to define a clearer lifecycle for these objects. Not explicit change to current functionality. Removes not so nice use of partials when reading config.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
