### PR TITLE
Add template to supported file extensions

### DIFF
--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -66,7 +66,7 @@ class Template(object):
         if self._body is None:
             file_extension = os.path.splitext(self.path)[1]
 
-            if file_extension in {".json", ".yaml"}:
+            if file_extension in {".json", ".yaml", ".template"}:
                 with open(self.path) as template_file:
                     self._body = template_file.read()
             elif file_extension == ".j2":
@@ -81,7 +81,7 @@ class Template(object):
             else:
                 raise UnsupportedTemplateFileTypeError(
                     "Template has file extension %s. Only .py, .yaml, "
-                    ".json and .j2 are supported.",
+                    ".template, .json and .j2 are supported.",
                     os.path.splitext(self.path)[1]
                 )
         return self._body

--- a/tests/fixtures/templates/vpc.template
+++ b/tests/fixtures/templates/vpc.template
@@ -1,0 +1,43 @@
+{
+    "Outputs": {
+        "VpcId": {
+            "Description": "New VPC ID",
+            "Value": {
+                "Ref": "VirtualPrivateCloud"
+            }
+        }
+    },
+    "Parameters": {
+        "CidrBlock": {
+            "Default": "10.0.0.0/16",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "IGWAttachment": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "VirtualPrivateCloud"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "VirtualPrivateCloud": {
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "CidrBlock"
+                },
+                "EnableDnsHostnames": "true",
+                "EnableDnsSupport": "true",
+                "InstanceTenancy": "default"
+            },
+            "Type": "AWS::EC2::VPC"
+        }
+    }
+}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -207,6 +207,18 @@ class TestTemplate(object):
             expected_output_dict = json.loads(f.read())
         assert output_dict == expected_output_dict
 
+    def test_body_with_generic_template(self):
+        self.template.name = "vpc"
+        self.template.path = os.path.join(
+            os.getcwd(),
+            "tests/fixtures/templates/vpc.template"
+        )
+        output = self.template.body
+        output_dict = json.loads(output)
+        with open("tests/fixtures/templates/compiled_vpc.json", "r") as f:
+            expected_output_dict = json.loads(f.read())
+        assert output_dict == expected_output_dict
+
     def test_body_with_missing_file(self):
         self.template.path = "incorrect/template/path.py"
         with pytest.raises(IOError):


### PR DESCRIPTION
This PR adds `.template` to the accepted extensions for template files. AWS samples [3] use this extension so I think it'd be reasonable to allow this as well. 

[3]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/sample-templates-services-us-west-2.html

-----------------

* [ ] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
