### PR TITLE
Allow newer boto versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 behave==1.2.5
-boto3>=1.3.0,<1.5.0
+boto3>=1.3.0,<2
 bumpversion==0.5.3
 click==6.6
 colorama==0.3.7

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 install_requirements = [
-    "boto3>=1.3.0,<1.5.0",
+    "boto3>=1.3.0,<2",
     "click==6.6",
     "PyYaml==3.12",
     "Jinja2==2.8",


### PR DESCRIPTION
The restriction on Boto < 1.5.0 is starting to get really annoying due to Python's lack of isolated dependencies between versions. We want to use new versions of botocore in other projects as they have support for profile better role assumption (`source_profile` in `~/.aws/config` stuff), but we can't make other projects require new boto versions as their installation then conflicts with Sceptre.