### PR TITLE
[Resolves #313] Clarify link between sceptre_user_data and stack config

### DIFF
--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -26,7 +26,7 @@ Templates with `.json` or `.yaml` extensions are treated as CloudFormation templ
 
 ## Jinja
 {% raw %}
-Templates with `.j2` extensions are treated as Jinja2 templates. These are rendered and should create a raw JSON or YAML CloudFormation template. Sceptre User Data is accessible within templates as `sceptre_user_data`. For example `{{ sceptre_user_data.some_variable }}`.
+Templates with `.j2` extensions are treated as Jinja2 templates. These are rendered and should create a raw JSON or YAML CloudFormation template. Sceptre User Data is accessible within templates as `sceptre_user_data`. For example `{{ sceptre_user_data.some_variable }}`. `sceptre_user_data` accesses the `sceptre_user_data` key in the Stack Config file.
 {% endraw %}
 
 ## Python


### PR DESCRIPTION
This adds one line to the documentation to clarify the link between `sceptre_user_data` in Jinja templates and the Stack Config.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
