### PR TITLE
[Resolves #330] `profile` added to stack's connection manager

### DIFF
--- a/integration-tests/sceptre-project/config/config.yaml
+++ b/integration-tests/sceptre-project/config/config.yaml
@@ -1,4 +1,4 @@
-profile: test_sceptre-profile
+profile: test_sceptre_profile
 project_code: sceptre-integration-tests
 region: eu-west-1
 template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/config/config.yaml
+++ b/integration-tests/sceptre-project/config/config.yaml
@@ -1,3 +1,4 @@
+profile: test_sceptre-profile
 project_code: sceptre-integration-tests
 region: eu-west-1
 template_bucket_name: sceptre-integration-tests-templates

--- a/sceptre/config_reader.py
+++ b/sceptre/config_reader.py
@@ -325,6 +325,7 @@ class ConfigReader(object):
                 template_path=abs_template_path,
                 region=config["region"],
                 iam_role=config.get("iam_role"),
+                profile=config.get("profile", ""),
                 parameters=config.get("parameters", {}),
                 sceptre_user_data=config.get("sceptre_user_data", {}),
                 hooks=config.get("hooks", {}),

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -53,9 +53,9 @@ class Stack(object):
 
     def __init__(
         self, name, project_code, template_path, region, iam_role=None,
-        parameters=None, sceptre_user_data=None, hooks=None, s3_details=None,
-        dependencies=None, role_arn=None, protected=False, tags=None,
-        external_name=None, notifications=None, on_failure=None
+        profile=None, parameters=None, sceptre_user_data=None, hooks=None,
+        s3_details=None, dependencies=None, role_arn=None, protected=False,
+        tags=None, external_name=None, notifications=None, on_failure=None
     ):
         self.logger = logging.getLogger(__name__)
 
@@ -65,7 +65,11 @@ class Stack(object):
         self.external_name = external_name or \
             get_external_stack_name(self.project_code, self.name)
 
-        self.connection_manager = ConnectionManager(region, iam_role)
+        self.connection_manager = ConnectionManager(
+            region,
+            iam_role=iam_role,
+            profile=profile
+        )
 
         self.template_path = template_path
         self.s3_details = s3_details
@@ -87,7 +91,8 @@ class Stack(object):
             "sceptre.stack.Stack("
             "name='{name}', project_code='{project_code}', "
             "template_path='{template_path}', region='{region}', "
-            "iam_role='{iam_role}', parameters='{parameters}', "
+            "iam_role='{iam_role}', profile='{profile}', "
+            "parameters='{parameters}', "
             "sceptre_user_data='{sceptre_user_data}', "
             "hooks='{hooks}', s3_details='{s3_details}', "
             "dependencies='{dependencies}', role_arn='{role_arn}', "
@@ -99,6 +104,7 @@ class Stack(object):
                 template_path=self.template_path,
                 region=self.connection_manager.region,
                 iam_role=self.connection_manager.iam_role,
+                profile=self.connection_manager.profile,
                 parameters=self.parameters,
                 sceptre_user_data=self.sceptre_user_data,
                 hooks=self.hooks, s3_details=self.s3_details,

--- a/tests/fixtures/config/config.yaml
+++ b/tests/fixtures/config/config.yaml
@@ -1,4 +1,5 @@
 iam_role: account_iam_role
 project_code: account_project_code
 region: account_region
+profile: profile_name
 require_version: ">=0a"

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -201,6 +201,7 @@ class TestConfigReader(object):
                 ),
                 region="region_region",
                 iam_role="account_iam_role",
+                profile="profile_name",
                 parameters={"param1": "val1"},
                 sceptre_user_data={},
                 hooks={},

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -29,7 +29,8 @@ class TestStack(object):
         self.stack = Stack(
             name=sentinel.stack_name, project_code=sentinel.project_code,
             template_path=sentinel.template_path, region=sentinel.region,
-            iam_role=sentinel.iam_role, parameters={"key1": "val1"},
+            iam_role=sentinel.iam_role, profile=sentinel.profile,
+            parameters={"key1": "val1"},
             sceptre_user_data=sentinel.sceptre_user_data, hooks={},
             s3_details=None, dependencies=sentinel.dependencies,
             role_arn=sentinel.role_arn, protected=False,
@@ -49,7 +50,7 @@ class TestStack(object):
             external_name=sentinel.external_name
         )
         self.mock_ConnectionManager.assert_called_with(
-            sentinel.region, None
+            sentinel.region, iam_role=None, profile=None
         )
         assert stack.name == sentinel.stack_name
         assert stack.project_code == sentinel.project_code
@@ -70,6 +71,7 @@ class TestStack(object):
     def test_repr(self):
         self.stack.connection_manager.region = sentinel.region
         self.stack.connection_manager.iam_role = None
+        self.stack.connection_manager.profile = None
 
         assert self.stack.__repr__() == \
             "sceptre.stack.Stack(" \
@@ -77,7 +79,8 @@ class TestStack(object):
             "project_code='sentinel.project_code', " \
             "template_path='sentinel.template_path', " \
             "region='sentinel.region', " \
-            "iam_role='None', parameters='{'key1': 'val1'}', " \
+            "iam_role='None', profile='None', " \
+            "parameters='{'key1': 'val1'}', " \
             "sceptre_user_data='sentinel.sceptre_user_data', " \
             "hooks='{}', s3_details='None', " \
             "dependencies='sentinel.dependencies', "\


### PR DESCRIPTION
`profile` can now be passed to a stack's connection manager. `profile` can now be defined in config files and have `sceptre` use it for connections to AWS.

-----------------

* [x] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

-----------------

P.S. - I am a part of Intuit, Inc and I work with [Omer Azmon](https://github.com/oazmon)