### PR TITLE
[Resolves #302] Handled the case in _check_circular_dependencies when there are external dependencies

### DIFF
--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -282,12 +282,16 @@ class Environment(object):
         self.logger.debug("Checking for circular dependencies...")
 
         if self.stacks:
+            top_level_path = self.path + '/'  \
+                if self.path and self.path != '.' \
+                else ''
             encountered_stacks = {}
             available_nodes = {stack.name: stack for stack in self.stacks}
             for stack in self.stacks:
                 if encountered_stacks.get(stack, "UNENCOUNTERED") != "DONE":
                     encountered_stacks[stack] = "ENCOUNTERED"
                     encountered_stacks = _detect_cycles(
+                        top_level_path,
                         stack,
                         encountered_stacks,
                         available_nodes,

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -10,7 +10,7 @@ represent a logical grouping of stacks as an environment.
 
 import logging
 import threading
-
+import os
 import botocore
 
 from concurrent.futures import ThreadPoolExecutor, wait
@@ -282,7 +282,7 @@ class Environment(object):
         self.logger.debug("Checking for circular dependencies...")
 
         if self.stacks:
-            top_level_path = self.path + '/'  \
+            top_level_path = os.path.join(self.path, '')  \
                 if self.path and self.path != '.' \
                 else ''
             encountered_stacks = {}

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -182,7 +182,9 @@ def get_subclasses(class_type, directory=None):
     return classes
 
 
-def _detect_cycles(node, encountered_nodes, available_nodes, path):
+def _detect_cycles(
+        top_level_path, node, encountered_nodes,
+        available_nodes, path):
     """
     Use Depth-first search to detect cycles.
 
@@ -190,6 +192,10 @@ def _detect_cycles(node, encountered_nodes, available_nodes, path):
     during the depth first search.
     """
     for dependency_name in node.dependencies:
+        # if dependency not in available nodes, skip it
+        if not dependency_name.startswith(top_level_path):
+            continue  # skip
+
         dependency = available_nodes[dependency_name]
         status = encountered_nodes.get(dependency)
         if status == "ENCOUNTERED":
@@ -204,6 +210,7 @@ def _detect_cycles(node, encountered_nodes, available_nodes, path):
             encountered_nodes[dependency] = "ENCOUNTERED"
             path.append(dependency_name)
             _detect_cycles(
+                top_level_path,
                 dependency,
                 encountered_nodes,
                 available_nodes,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -317,39 +317,42 @@ class TestEnvironment(object):
     def test_check_for_circular_dependencies_with_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack1"]
-        stack2.name = "stack2"
+        stack1.dependencies = ["path/stack2"]
+        stack1.name = "path/stack1"
+        stack2.dependencies = ["path/stack1"]
+        stack2.name = "path/stack2"
         stacks = [stack1, stack2]
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack2', 'stack1'])
+        assert all(x in str(ex) for x in ['path/stack2', 'path/stack1'])
 
     def test_circular_dependencies_with_3_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack3"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack1"]
-        stack3.name = "stack3"
+        stack1.dependencies = ["path/stack2"]
+        stack1.name = "path/stack1"
+        stack2.dependencies = ["path/stack3"]
+        stack2.name = "path/stack2"
+        stack3.dependencies = ["path/stack1"]
+        stack3.name = "path/stack3"
         stacks = [stack1, stack2, stack3]
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack3', 'stack2', 'stack1'])
+        assert all(
+            x in str(ex)
+            for x in ['path/stack3', 'path/stack2', 'path/stack1']
+        )
 
     def test_no_circular_dependencies_throws_no_error(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2"]
-        stack1.name = "stack1"
+        stack1.dependencies = ["path/stack2"]
+        stack1.name = "path/stack1"
         stack2.dependencies = []
-        stack2.name = "stack2"
+        stack2.name = "path/stack2"
         stacks = [stack1, stack2]
 
         self.environment.stacks = stacks
@@ -359,10 +362,10 @@ class TestEnvironment(object):
     def test_no_circular_dependencies_with_nested_stacks(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["env1/stack2"]
-        stack1.name = "stack1"
+        stack1.dependencies = ["path/env1/stack2"]
+        stack1.name = "path/stack1"
         stack2.dependencies = []
-        stack2.name = "env1/stack2"
+        stack2.name = "path/env1/stack2"
         stacks = [stack1, stack2]
 
         self.environment.stacks = stacks
@@ -383,14 +386,14 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2", "stack3"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack4"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack4"]
-        stack3.name = "stack3"
+        stack1.dependencies = ["path/stack2", "path/stack3"]
+        stack1.name = "path/stack1"
+        stack2.dependencies = ["path/stack4"]
+        stack2.name = "path/stack2"
+        stack3.dependencies = ["path/stack4"]
+        stack3.name = "path/stack3"
         stack4.dependencies = []
-        stack4.name = "stack4"
+        stack4.name = "path/stack4"
         stacks = [stack1, stack2, stack3, stack4]
 
         self.environment.stacks = stacks
@@ -411,16 +414,16 @@ class TestEnvironment(object):
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
         stack5 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2", "stack3"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack4"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack4", "stack5"]
-        stack3.name = "stack3"
+        stack1.dependencies = ["path/stack2", "path/stack3"]
+        stack1.name = "path/stack1"
+        stack2.dependencies = ["path/stack4"]
+        stack2.name = "path/stack2"
+        stack3.dependencies = ["path/stack4", "path/stack5"]
+        stack3.name = "path/stack3"
         stack4.dependencies = []
-        stack4.name = "stack4"
+        stack4.name = "path/stack4"
         stack5.dependencies = []
-        stack5.name = "stack5"
+        stack5.name = "path/stack5"
         stacks = [stack1, stack2, stack3, stack4, stack5]
 
         self.environment.stacks = stacks
@@ -441,16 +444,16 @@ class TestEnvironment(object):
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
         stack5 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2", "stack3"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack4"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack4", "stack5"]
-        stack3.name = "stack3"
-        stack4.dependencies = ["stack5"]
-        stack4.name = "stack4"
+        stack1.dependencies = ["path/stack2", "path/stack3"]
+        stack1.name = "path/stack1"
+        stack2.dependencies = ["path/stack4"]
+        stack2.name = "path/stack2"
+        stack3.dependencies = ["path/stack4", "path/stack5"]
+        stack3.name = "path/stack3"
+        stack4.dependencies = ["path/stack5"]
+        stack4.name = "path/stack4"
         stack5.dependencies = []
-        stack5.name = "stack5"
+        stack5.name = "path/stack5"
         stacks = [stack1, stack2, stack3, stack4, stack5]
 
         self.environment.stacks = stacks
@@ -468,21 +471,21 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack4"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack1"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack2"]
-        stack3.name = "stack3"
-        stack4.dependencies = ["stack3"]
-        stack4.name = "stack4"
+        stack1.dependencies = ["path/stack4"]
+        stack1.name = "path/stack1"
+        stack2.dependencies = ["path/stack1"]
+        stack2.name = "path/stack2"
+        stack3.dependencies = ["path/stack2"]
+        stack3.name = "path/stack3"
+        stack4.dependencies = ["path/stack3"]
+        stack4.name = "path/stack4"
         stacks = [stack1, stack2, stack3, stack4]
 
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2',
-                                          'stack1'])
+        assert all(x in str(ex) for x in ['path/stack4', 'path/stack3',
+                                          'path/stack2', 'path/stack1'])
 
     def test_modified_3_cycle_throws_circ_dependencies_error(self):
         """
@@ -497,18 +500,63 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack3"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack4"]
-        stack3.name = "stack3"
-        stack4.dependencies = ["stack2"]
-        stack4.name = "stack4"
+        stack1.dependencies = ["path/stack2"]
+        stack1.name = "path/stack1"
+        stack2.dependencies = ["path/stack3"]
+        stack2.name = "path/stack2"
+        stack3.dependencies = ["path/stack4"]
+        stack3.name = "path/stack3"
+        stack4.dependencies = ["path/stack2"]
+        stack4.name = "path/stack4"
         stacks = [stack1, stack2, stack3, stack4]
 
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert (all(x in str(ex) for x in ['stack4', 'stack3', 'stack2']) and
-                'stack1' not in str(ex))
+        assert (
+            all(
+                x in str(ex)
+                for x in ['path/stack4', 'path/stack3', 'path/stack2']
+            )
+            and 'path/stack1' not in str(ex)
+        )
+
+    def test_circular_dependencies_with_dot_path(self):
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack1.dependencies = ["stack2"]
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1"]
+        stack2.name = "stack2"
+        stacks = [stack1, stack2]
+        self.environment.path = '.'
+        self.environment.stacks = stacks
+        with pytest.raises(CircularDependenciesError) as ex:
+            self.environment._check_for_circular_dependencies()
+        assert all(x in str(ex) for x in ['stack2', 'stack1'])
+
+    def test_circular_dependencies_with_none_path(self):
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack1.dependencies = ["stack2"]
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1"]
+        stack2.name = "stack2"
+        stacks = [stack1, stack2]
+        self.environment.path = None
+        self.environment.stacks = stacks
+        with pytest.raises(CircularDependenciesError) as ex:
+            self.environment._check_for_circular_dependencies()
+        assert all(x in str(ex) for x in ['stack2', 'stack1'])
+
+    # External dependency is a dependency on a Sceptre stack that is
+    # not in the environment currently executing
+    def test_circular_dependencies_with_external_dependecies(self):
+        stack1 = MagicMock(Spec=Stack)
+        stack1.dependencies = ["path2/stack1"]
+        stack1.name = "path/stack1"
+        stacks = [stack1]
+
+        self.environment.stacks = stacks
+        # Check this runs without throwing an exception
+        self.environment._check_for_circular_dependencies()


### PR DESCRIPTION
When there's an **external** dependency while launching an environment, `_check_circular_dependencies` method in `environment.py` throws up an error when it should not be including that dependency as a part of a circular dependency check _within_ an environment.

This has been handled by adding `top_level_path` of an environment and comparing it against the the dependency. If they are **not** similar, we do not consider it for the circular dependency check.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

-----------------

P.S. - I am a part of Intuit, Inc and I work with [Omer Azmon](https://github.com/oazmon)