### PR TITLE
[Resolve #351] Allows jinja2 >=2.8, for upgrades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ colorama==0.3.7
 coverage==4.4.2
 flake8==3.5.0
 freezegun==0.3.9
-Jinja2==2.8
+Jinja2>=2.8,<3
 mock>=2.0.0,<2.1.0
 moto==0.4.31
 packaging==16.8

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requirements = [
     "boto3>=1.3.0,<2",
     "click==6.6",
     "PyYaml==3.12",
-    "Jinja2==2.8",
+    "Jinja2>=2.8,<3",
     "packaging==16.8",
     "colorama==0.3.7",
     "six==1.11.0"


### PR DESCRIPTION
Resolves issue with Sceptre used as a library that was conflicting with using current stable releases of Jinja2 (latest is 2.10x).

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [ ] All unit tests (`make test`) are passing.
* [ ] Used the same coding conventions as the rest of the project.
* [ ] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
