### PR TITLE
[Resolves #302] For v1 - Handled the case in _check_circular_dependencies when there are external dependencies

### DIFF
--- a/integration-tests/steps/change_sets.py
+++ b/integration-tests/steps/change_sets.py
@@ -49,9 +49,9 @@ def step_impl(context, stack_name):
 
 @when('the user creates change set "{change_set_name}" for stack "{stack_name}"')
 def step_impl(context, change_set_name, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
-    stack = env.stacks[basename]
+    stack = env.stacks[stack_name]
     allowed_errors = {'ValidationError', 'ChangeSetNotFound'}
     try:
         stack.create_change_set(change_set_name)
@@ -66,9 +66,9 @@ def step_impl(context, change_set_name, stack_name):
 
 @when('the user deletes change set "{change_set_name}" for stack "{stack_name}"')
 def step_impl(context, change_set_name, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
-    stack = env.stacks[basename]
+    stack = env.stacks[stack_name]
     allowed_errors = {'ValidationError', 'ChangeSetNotFound'}
     try:
         stack.delete_change_set(change_set_name)
@@ -82,9 +82,9 @@ def step_impl(context, change_set_name, stack_name):
 
 @when('the user lists change sets for stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
-    stack = env.stacks[basename]
+    stack = env.stacks[stack_name]
     allowed_errors = {'ValidationError', 'ChangeSetNotFound'}
     try:
         response = stack.list_change_sets()
@@ -99,9 +99,9 @@ def step_impl(context, stack_name):
 
 @when('the user executes change set "{change_set_name}" for stack "{stack_name}"')
 def step_impl(context, change_set_name, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
-    stack = env.stacks[basename]
+    stack = env.stacks[stack_name]
     allowed_errors = {'ValidationError', 'ChangeSetNotFound'}
     try:
         stack.execute_change_set(change_set_name)
@@ -115,9 +115,9 @@ def step_impl(context, change_set_name, stack_name):
 
 @when('the user describes change set "{change_set_name}" for stack "{stack_name}"')
 def step_impl(context, change_set_name, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
-    stack = env.stacks[basename]
+    stack = env.stacks[stack_name]
     allowed_errors = {'ValidationError', 'ChangeSetNotFound'}
     try:
         response = stack.describe_change_set(change_set_name)

--- a/integration-tests/steps/stack_policies.py
+++ b/integration-tests/steps/stack_policies.py
@@ -19,20 +19,20 @@ def step_impl(context, stack_name, state):
 
 @when('the user unlocks stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        env.stacks[basename].unlock()
+        env.stacks[stack_name].unlock()
     except ClientError as e:
         context.error = e
 
 
 @when('the user locks stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        env.stacks[basename].lock()
+        env.stacks[stack_name].lock()
     except ClientError as e:
         context.error = e
 

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -61,10 +61,10 @@ def step_impl(context, stack_name, template_name):
 
 @when('the user creates stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        env.stacks[basename].create()
+        env.stacks[stack_name].create()
     except ClientError as e:
         if e.response['Error']['Code'] == 'AlreadyExistsException' \
           and e.response['Error']['Message'].endswith("already exists"):
@@ -75,10 +75,10 @@ def step_impl(context, stack_name):
 
 @when('the user updates stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        env.stacks[basename].update()
+        env.stacks[stack_name].update()
     except ClientError as e:
         message = e.response['Error']['Message']
         if e.response['Error']['Code'] == 'ValidationError' \
@@ -91,10 +91,10 @@ def step_impl(context, stack_name):
 
 @when('the user deletes stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        env.stacks[basename].delete()
+        env.stacks[stack_name].delete()
     except ClientError as e:
         if e.response['Error']['Code'] == 'ValidationError' \
           and e.response['Error']['Message'].endswith("does not exist"):
@@ -105,20 +105,20 @@ def step_impl(context, stack_name):
 
 @when('the user launches stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        env.stacks[basename].launch()
+        env.stacks[stack_name].launch()
     except Exception as e:
         context.error = e
 
 
 @when('the user describes the resources of stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
 
-    context.output = env.stacks[basename].describe_resources()
+    context.output = env.stacks[stack_name].describe_resources()
 
 
 @then('stack "{stack_name}" exists in "{desired_status}" state')

--- a/integration-tests/steps/templates.py
+++ b/integration-tests/steps/templates.py
@@ -27,20 +27,20 @@ def step_impl(context, stack_name, template_name):
 
 @when('the user validates the template for stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        context.response = env.stacks[basename].validate_template()
+        context.response = env.stacks[stack_name].validate_template()
     except ClientError as e:
         context.error = e
 
 
 @when('the user generates the template for stack "{stack_name}"')
 def step_impl(context, stack_name):
-    environment_name, basename = os.path.split(stack_name)
+    environment_name, _ = os.path.split(stack_name)
     env = Environment(context.sceptre_dir, environment_name)
     try:
-        context.output = env.stacks[basename].template.body
+        context.output = env.stacks[stack_name].template.body
     except Exception as e:
         context.error = e
 

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -22,7 +22,7 @@ from .exceptions import StackDoesNotExistError
 from .config import Config
 from .connection_manager import ConnectionManager
 from .exceptions import InvalidEnvironmentPathError
-from .helpers import recurse_into_sub_environments, get_name_tuple
+from .helpers import recurse_into_sub_environments
 from .helpers import _detect_cycles
 from .stack import Stack
 from .stack_status import StackStatus
@@ -338,13 +338,14 @@ class Environment(object):
         :raises: sceptre.workplan.CircularDependenciesException
         """
         self.logger.debug("Checking for circular dependencies...")
-
+        top_level_path = self.path if self.path and self.path != '.' else ''
         if self.is_leaf:
             encountered_stacks = {}
             for stack in self.stacks.values():
                 if encountered_stacks.get(stack, "UNENCOUNTERED") != "DONE":
                     encountered_stacks[stack] = "ENCOUNTERED"
                     encountered_stacks = _detect_cycles(
+                        top_level_path,
                         stack,
                         encountered_stacks,
                         self.stacks,
@@ -416,7 +417,7 @@ class Environment(object):
                 environment_config=config,
                 connection_manager=connection_manager
             )
-            stacks[get_name_tuple(stack_name)[-1]] = stack
+            stacks[stack_name] = stack
         return stacks
 
     def _get_available_environments(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -338,7 +338,8 @@ class Environment(object):
         :raises: sceptre.workplan.CircularDependenciesException
         """
         self.logger.debug("Checking for circular dependencies...")
-        top_level_path = self.path if self.path and self.path != '.' else ''
+        top_level_path = os.path.join(self.path, '') \
+            if self.path and self.path != '.' else ''
         if self.is_leaf:
             encountered_stacks = {}
             for stack in self.stacks.values():

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -402,38 +402,42 @@ class TestEnvironment(object):
     def test_check_for_circular_dependencies_with_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack1"]
-        stack2.name = "stack2"
+        stack1.dependencies = ["environment_path/stack2"]
+        stack1.name = "environment_path/stack1"
+        stack2.dependencies = ["environment_path/stack1"]
+        stack2.name = "environment_path/stack2"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2
         }
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack2', 'stack1'])
+        assert all(x in str(ex) for x in ['environment_path/stack2',
+                                          'environment_path/stack1'])
 
     def test_circular_dependencies_with_3_circular_dependencies(self):
         stack1 = MagicMock(Spec=Stack)
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack3"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack1"]
-        stack3.name = "stack3"
+        stack1.dependencies = ["environment_path/stack2"]
+        stack1.name = "environment_path/stack1"
+        stack2.dependencies = ["environment_path/stack3"]
+        stack2.name = "environment_path/stack2"
+        stack3.dependencies = ["environment_path/stack1"]
+        stack3.name = "environment_path/stack3"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2,
-            "stack3": stack3
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2,
+            "environment_path/stack3": stack3
         }
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack3', 'stack2', 'stack1'])
+        assert all(x in str(ex) for x in ['environment_path/stack3',
+                                          'environment_path/stack2',
+                                          'environment_path/stack1'
+                                          ])
 
     def test_no_circular_dependencies_throws_no_error(self):
         stack1 = MagicMock(Spec=Stack)
@@ -443,8 +447,8 @@ class TestEnvironment(object):
         stack2.dependencies = []
         stack2.name = "stack2"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2
         }
         self.environment.stacks = stacks
         # Check this runs without throwing an exception
@@ -464,19 +468,21 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2", "stack3"]
+        stack1.dependencies = ["environment_path/stack2",
+                               "environment_path/stack3"
+                               ]
         stack1.name = "stack1"
-        stack2.dependencies = ["stack4"]
+        stack2.dependencies = ["environment_path/stack4"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack4"]
+        stack3.dependencies = ["environment_path/stack4"]
         stack3.name = "stack3"
         stack4.dependencies = []
         stack4.name = "stack4"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2,
-            "stack3": stack3,
-            "stack4": stack4
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2,
+            "environment_path/stack3": stack3,
+            "environment_path/stack4": stack4
         }
         self.environment.stacks = stacks
         self.environment._check_for_circular_dependencies()
@@ -496,22 +502,26 @@ class TestEnvironment(object):
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
         stack5 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2", "stack3"]
+        stack1.dependencies = ["environment_path/stack2",
+                               "environment_path/stack3"
+                               ]
         stack1.name = "stack1"
-        stack2.dependencies = ["stack4"]
+        stack2.dependencies = ["environment_path/stack4"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack4", "stack5"]
+        stack3.dependencies = ["environment_path/stack4",
+                               "environment_path/stack5"
+                               ]
         stack3.name = "stack3"
         stack4.dependencies = []
         stack4.name = "stack4"
         stack5.dependencies = []
         stack5.name = "stack5"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2,
-            "stack3": stack3,
-            "stack4": stack4,
-            "stack5": stack5
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2,
+            "environment_path/stack3": stack3,
+            "environment_path/stack4": stack4,
+            "environment_path/stack5": stack5
         }
         self.environment.stacks = stacks
         self.environment._check_for_circular_dependencies()
@@ -531,22 +541,28 @@ class TestEnvironment(object):
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
         stack5 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2", "stack3"]
+        stack1.dependencies = [
+            "environment_path/stack2",
+            "environment_path/stack3"
+        ]
         stack1.name = "stack1"
-        stack2.dependencies = ["stack4"]
+        stack2.dependencies = ["environment_path/stack4"]
         stack2.name = "stack2"
-        stack3.dependencies = ["stack4", "stack5"]
+        stack3.dependencies = [
+            "environment_path/stack4",
+            "environment_path/stack5"
+        ]
         stack3.name = "stack3"
-        stack4.dependencies = ["stack5"]
+        stack4.dependencies = ["environment_path/stack5"]
         stack4.name = "stack4"
         stack5.dependencies = []
         stack5.name = "stack5"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2,
-            "stack3": stack3,
-            "stack4": stack4,
-            "stack5": stack5
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2,
+            "environment_path/stack3": stack3,
+            "environment_path/stack4": stack4,
+            "environment_path/stack5": stack5
         }
         self.environment.stacks = stacks
         self.environment._check_for_circular_dependencies()
@@ -563,25 +579,29 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack4"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack1"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack2"]
-        stack3.name = "stack3"
-        stack4.dependencies = ["stack3"]
-        stack4.name = "stack4"
+        stack1.dependencies = ["environment_path/stack4"]
+        stack1.name = "environment_path/stack1"
+        stack2.dependencies = ["environment_path/stack1"]
+        stack2.name = "environment_path/stack2"
+        stack3.dependencies = ["environment_path/stack2"]
+        stack3.name = "environment_path/stack3"
+        stack4.dependencies = ["environment_path/stack3"]
+        stack4.name = "environment_path/stack4"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2,
-            "stack3": stack3,
-            "stack4": stack4
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2,
+            "environment_path/stack3": stack3,
+            "environment_path/stack4": stack4
         }
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert all(x in str(ex) for x in ['stack4', 'stack3', 'stack2',
-                                          'stack1'])
+        assert all(x in str(ex) for x in [
+            'environment_path/stack4',
+            'environment_path/stack3',
+            'environment_path/stack2',
+            'environment_path/stack1'
+        ])
 
     def test_modified_3_cycle_throws_circ_dependencies_error(self):
         """
@@ -596,25 +616,28 @@ class TestEnvironment(object):
         stack2 = MagicMock(Spec=Stack)
         stack3 = MagicMock(Spec=Stack)
         stack4 = MagicMock(Spec=Stack)
-        stack1.dependencies = ["stack2"]
-        stack1.name = "stack1"
-        stack2.dependencies = ["stack3"]
-        stack2.name = "stack2"
-        stack3.dependencies = ["stack4"]
-        stack3.name = "stack3"
-        stack4.dependencies = ["stack2"]
-        stack4.name = "stack4"
+        stack1.dependencies = ["environment_path/stack2"]
+        stack1.name = "environment_path/stack1"
+        stack2.dependencies = ["environment_path/stack3"]
+        stack2.name = "environment_path/stack2"
+        stack3.dependencies = ["environment_path/stack4"]
+        stack3.name = "environment_path/stack3"
+        stack4.dependencies = ["environment_path/stack2"]
+        stack4.name = "environment_path/stack4"
         stacks = {
-            "stack1": stack1,
-            "stack2": stack2,
-            "stack3": stack3,
-            "stack4": stack4
+            "environment_path/stack1": stack1,
+            "environment_path/stack2": stack2,
+            "environment_path/stack3": stack3,
+            "environment_path/stack4": stack4
         }
         self.environment.stacks = stacks
         with pytest.raises(CircularDependenciesError) as ex:
             self.environment._check_for_circular_dependencies()
-        assert (all(x in str(ex) for x in ['stack4', 'stack3', 'stack2']) and
-                'stack1' not in str(ex))
+        assert (all(x in str(ex) for x in [
+            'environment_path/stack4',
+            'environment_path/stack3',
+            'environment_path/stack2'
+        ]) and 'environment_path/stack1' not in str(ex))
 
     @patch("sceptre.environment.Config")
     def test_get_config(self, mock_Config):
@@ -705,3 +728,55 @@ class TestEnvironment(object):
 
         response = self.environment._load_environments()
         assert response == {"env": sentinel.environment}
+
+    # External dependency is a dependency on a Sceptre stack that is
+    # not in the environment currently executing
+    def test_circular_dependencies_with_external_dependecies(self):
+        stack1 = MagicMock(Spec=Stack)
+        stack1.dependencies = ["path2/stack1"]
+        stack1.name = "environment_path/stack1"
+        stacks = {"stack1": stack1}
+
+        self.environment.stacks = stacks
+        # Check this runs without throwing an exception
+        self.environment._check_for_circular_dependencies()
+
+    def test__circular_dependencies_with_none_path(self):
+        stack1 = MagicMock(Spec=Stack)
+        stack2 = MagicMock(Spec=Stack)
+        stack1.dependencies = ["stack2"]
+        stack1.name = "stack1"
+        stack2.dependencies = ["stack1"]
+        stack2.name = "stack2"
+        stacks = {
+            "stack1": stack1,
+            "stack2": stack2
+        }
+        self.environment.path = None
+        self.environment.stacks = stacks
+        with pytest.raises(CircularDependenciesError) as ex:
+            self.environment._check_for_circular_dependencies()
+        assert all(x in str(ex) for x in [
+            "stack1",
+            "stack2"
+        ])
+
+    def test__circular_dependencies_with_dot_path(self):
+            stack1 = MagicMock(Spec=Stack)
+            stack2 = MagicMock(Spec=Stack)
+            stack1.dependencies = ["stack2"]
+            stack1.name = "stack1"
+            stack2.dependencies = ["stack1"]
+            stack2.name = "stack2"
+            stacks = {
+                "stack1": stack1,
+                "stack2": stack2
+            }
+            self.environment.path = '.'
+            self.environment.stacks = stacks
+            with pytest.raises(CircularDependenciesError) as ex:
+                self.environment._check_for_circular_dependencies()
+            assert all(x in str(ex) for x in [
+                "stack1",
+                "stack2"
+            ])


### PR DESCRIPTION
This is similar to an [earlier PR](https://github.com/cloudreach/sceptre/pull/352) raised for the `master` branch for the same issue. When an external dependency is encountered _within_ an environment, it need not be considered for the circular dependency check. 

This has been handled by adding `top_level_path` of an environment in the `_check_circular_dependency()` method and comparing it against the current dependency. If they are not in the same environment being currently executed, we do not consider it for the circular dependency check.

-----------------

* [x] Wrote good commit messages.
* [x] Squashed related commits together after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] ~~Added~~ Modified integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

-----------------

P.S. - I am a part of Intuit, Inc and I work with [Omer Azmon](https://github.com/oazmon)
