### PR TITLE
Added an 'init template' to quickly generate new template files.

### DIFF
--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -15,6 +15,13 @@ class ProjectAlreadyExistsError(SceptreException):
     pass
 
 
+class TemplateAlreadyExistsError(SceptreException):
+    """
+    Error raised when Sceptre project already exists.
+    """
+    pass
+
+
 class InvalidSceptreDirectoryError(SceptreException):
     """
     Error raised if a sceptre directory is invalid.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -713,6 +713,88 @@ class TestCli(object):
 
         self.patcher_getcwd.start()
 
+    def test_init_template(self):
+        self.patcher_getcwd.stop()
+        with self.runner.isolated_filesystem():
+            sceptre_dir = os.path.abspath('./example')
+            config_dir = os.path.join(sceptre_dir, "config")
+            template_dir = os.path.join(sceptre_dir, "templates")
+
+            os.mkdir(sceptre_dir)
+            os.mkdir(config_dir)
+            os.mkdir(template_dir)
+            os.chdir(sceptre_dir)
+
+            template_name = "mytemplate.yaml"
+            result = self.runner.invoke(cli, ["init", "template", template_name])
+            assert os.path.isfile(os.path.join(template_dir, template_name))
+
+        self.patcher_getcwd.start()
+
+    def test_init_template_already_exists(self):
+        self.patcher_getcwd.stop()
+        with self.runner.isolated_filesystem():
+            sceptre_dir = os.path.abspath('./example')
+            config_dir = os.path.join(sceptre_dir, "config")
+            template_dir = os.path.join(sceptre_dir, "templates")
+
+            os.mkdir(sceptre_dir)
+            os.mkdir(config_dir)
+            os.mkdir(template_dir)
+            os.chdir(sceptre_dir)
+
+            template_name = "mytemplate.yaml"
+            result = self.runner.invoke(cli, ["init", "template", template_name])
+            assert os.path.isfile(os.path.join(template_dir, template_name))
+
+            result = self.runner.invoke(cli, ["init", "template", template_name])
+            assert result.output == 'Template \"{0}\" already exists.\n'.format(template_name)
+
+        self.patcher_getcwd.start()
+
+    def test_init_template_with_env_config(self):
+        self.patcher_getcwd.stop()
+        with self.runner.isolated_filesystem():
+            sceptre_dir = os.path.abspath('./example')
+            config_dir = os.path.join(sceptre_dir, "config")
+            template_dir = os.path.join(sceptre_dir, "templates")
+
+            os.mkdir(sceptre_dir)
+            os.mkdir(config_dir)
+            os.mkdir(template_dir)
+            os.chdir(sceptre_dir)
+
+            env_name = 'testenv'
+            self.runner.invoke(cli, ["init", "env", env_name], input="y\n\n\n")
+
+            template_name = "mytemplate.yaml"
+            result = self.runner.invoke(cli, ["init", "template", template_name, "--env", env_name])
+            assert result.output == 'Created template: "{0}"\nCreated config file in environment "{1}" for "{0}"\n'.format(template_name, env_name)
+
+            env_dir = os.path.join(config_dir, env_name)
+            assert os.path.isfile(os.path.join(env_dir, template_name))
+
+        self.patcher_getcwd.start()
+
+    def test_init_template_with_missing_env(self):
+        self.patcher_getcwd.stop()
+        with self.runner.isolated_filesystem():
+            sceptre_dir = os.path.abspath('./example')
+            config_dir = os.path.join(sceptre_dir, "config")
+            template_dir = os.path.join(sceptre_dir, "templates")
+
+            os.mkdir(sceptre_dir)
+            os.mkdir(config_dir)
+            os.mkdir(template_dir)
+            os.chdir(sceptre_dir)
+
+            env_name = 'testenv'
+            template_name = "mytemplate.yaml"
+            result = self.runner.invoke(cli, ["init", "template", template_name, "--env", env_name])
+            assert result.output == 'Created template: "{0}"\nEnvironment "{1}" does not exist.\n'.format(template_name, env_name)
+
+        self.patcher_getcwd.start()
+
     def test_setup_logging_with_debug(self):
         logger = setup_logging(True, False)
         assert logger.getEffectiveLevel() == logging.DEBUG


### PR DESCRIPTION
I added this functionality to quickly generate empty templates and
add them to the appropriate environments if desired.

Usage:
```
sceptre init template <template_filename> --env <environment_name>
```

Example:
```
sceptre init template vpc.yaml --env dev --env prod
```

Note: my first contribution to the library - open to feedback, thanks!

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
