### PR TITLE
Adding stack_timeout (same code as PR #300 with integration tests fixed)

### DIFF
--- a/docs/docs/stack_config.md
+++ b/docs/docs/stack_config.md
@@ -22,6 +22,7 @@ A stack config file is a yaml object of key-value pairs configuring a particular
 - [role_arn](#role_arn) *(optional)*
 - [notifications](#notifications) *(optional)*
 - [template_path](#template_path) *(required)*
+- [stack_timeout](#stack_timeout) *(optional)*
 
 
 ### dependencies
@@ -122,6 +123,10 @@ The ARN of a [CloudFormation Service Role](http://docs.aws.amazon.com/AWSCloudFo
 ### notifications
 
 List of SNS topic ARNs to publish stack related events to. A maximum of 5 ARNs can be specified per stack. This configuration will be used by the `create-stack`, `update-stack`, and `create-change-set` commands. More information about stack notifications can found under the relevant section in the [AWS CloudFormation API documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html).
+
+### stack_timeout
+
+A timeout in minutes before considering the stack deployment as failed. After the specified timeout, the stack will be rolled back. Specifiyng zero, as well as ommiting the field, will result in no timeout. Supports only positive integer value.
 
 ### template_path
 

--- a/integration-tests/features/create-stack.feature
+++ b/integration-tests/features/create-stack.feature
@@ -29,3 +29,10 @@ Feature: Create stack
     and the template for stack "8/B" is "invalid_template.json"
     When the user creates stack "8/B"
     Then stack "8/B" exists in "CREATE_FAILED" state
+
+  Scenario: create new stack that is rolled back after timeout
+    Given stack "8/C" does not exist
+    and the template for stack "8/C" is "valid_template_wait_300.json"
+    and the stack_timeout for stack "8/C" is "1"
+    When the user creates stack "8/C"
+    Then stack "8/C" exists in "ROLLBACK_COMPLETE" state

--- a/integration-tests/features/update-stack.feature
+++ b/integration-tests/features/update-stack.feature
@@ -17,3 +17,10 @@ Feature: Update stack
     and the template for stack "1/A" is "updated_template.json"
     When the user updates stack "1/A"
     Then stack "1/A" does not exist
+
+  Scenario: update a stack that is rolled back after timeout
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and the template for stack "1/A" is "updated_template_wait_300.json"
+    and the stack_timeout for stack "1/A" is "1"
+    When the user updates stack "1/A"
+    Then stack "1/A" exists in "UPDATE_ROLLBACK_COMPLETE" state

--- a/integration-tests/sceptre-project/config/8/C.yaml
+++ b/integration-tests/sceptre-project/config/8/C.yaml
@@ -1,0 +1,2 @@
+stack_timeout: 1
+template_path: templates/valid_template_wait_300.json

--- a/integration-tests/sceptre-project/config/config.yaml
+++ b/integration-tests/sceptre-project/config/config.yaml
@@ -1,4 +1,4 @@
-profile: test_sceptre_profile
+profile:
 project_code: sceptre-integration-tests
 region: eu-west-1
 template_bucket_name: sceptre-integration-tests-templates

--- a/integration-tests/sceptre-project/templates/updated_template_wait_300.json
+++ b/integration-tests/sceptre-project/templates/updated_template_wait_300.json
@@ -1,0 +1,20 @@
+{
+  "Resources": {
+    "WaitConditionHandle": {
+      "Type": "AWS::CloudFormation::WaitConditionHandle",
+      "Properties": {}
+    },
+    "AnotherWaitConditionHandle": {
+      "Type": "AWS::CloudFormation::WaitConditionHandle",
+      "Properties": {}
+    },
+    "AnotherWaitCondition" : {
+     "Type" : "AWS::CloudFormation::WaitCondition",
+     "Properties" : {
+         "Count" : 1,
+         "Handle" : { "Ref" : "AnotherWaitConditionHandle" },
+         "Timeout" : "300"
+       }
+    }
+  }
+}

--- a/integration-tests/sceptre-project/templates/valid_template_wait_300.json
+++ b/integration-tests/sceptre-project/templates/valid_template_wait_300.json
@@ -1,0 +1,16 @@
+{
+  "Resources": {
+    "WaitConditionHandle": {
+      "Type": "AWS::CloudFormation::WaitConditionHandle",
+      "Properties": {}
+    },
+    "WaitCondition" : {
+     "Type" : "AWS::CloudFormation::WaitCondition",
+     "Properties" : {
+         "Count" : 1,
+         "Handle" : { "Ref" : "WaitConditionHandle" },
+         "Timeout" : "300"
+       }
+    }
+  }
+}

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -8,6 +8,7 @@ from helpers import retry_boto_call
 
 from sceptre.config_reader import ConfigReader
 
+
 def set_stack_timeout(context, stack_name, stack_timeout):
     config_path = os.path.join(
         context.sceptre_dir, "config", stack_name + ".yaml"
@@ -19,6 +20,7 @@ def set_stack_timeout(context, stack_name, stack_timeout):
 
     with open(config_path, 'w') as config_file:
         yaml.safe_dump(stack_config, config_file, default_flow_style=False)
+
 
 @given('stack "{stack_name}" does not exist')
 def step_impl(context, stack_name):
@@ -71,9 +73,11 @@ def step_impl(context, stack_name, template_name):
     status = get_stack_status(context, full_name)
     assert (status == "CREATE_COMPLETE")
 
+
 @given('the stack_timeout for stack "{stack_name}" is "{stack_timeout}"')
 def step_impl(context, stack_name, stack_timeout):
     set_stack_timeout(context, stack_name, stack_timeout)
+
 
 @when('the user creates stack "{stack_name}"')
 def step_impl(context, stack_name):

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -1,11 +1,24 @@
 from behave import *
 import time
+import os
+import yaml
 from botocore.exceptions import ClientError
 from helpers import read_template_file, get_cloudformation_stack_name
 from helpers import retry_boto_call
 
 from sceptre.config_reader import ConfigReader
 
+def set_stack_timeout(context, stack_name, stack_timeout):
+    config_path = os.path.join(
+        context.sceptre_dir, "config", stack_name + ".yaml"
+    )
+    with open(config_path) as config_file:
+        stack_config = yaml.safe_load(config_file)
+
+    stack_config["stack_timeout"] = int(stack_timeout)
+
+    with open(config_path, 'w') as config_file:
+        yaml.safe_dump(stack_config, config_file, default_flow_style=False)
 
 @given('stack "{stack_name}" does not exist')
 def step_impl(context, stack_name):
@@ -58,6 +71,9 @@ def step_impl(context, stack_name, template_name):
     status = get_stack_status(context, full_name)
     assert (status == "CREATE_COMPLETE")
 
+@given('the stack_timeout for stack "{stack_name}" is "{stack_timeout}"')
+def step_impl(context, stack_name, stack_timeout):
+    set_stack_timeout(context, stack_name, stack_timeout)
 
 @when('the user creates stack "{stack_name}"')
 def step_impl(context, stack_name):

--- a/sceptre/config_reader.py
+++ b/sceptre/config_reader.py
@@ -53,7 +53,8 @@ STACK_CONFIG_ATTRIBUTES = ConfigAttributes(
         "sceptre_user_data",
         "stack_name",
         "stack_tags",
-        "role_arn"
+        "role_arn",
+        "stack_timeout"
     }
 )
 
@@ -336,7 +337,8 @@ class ConfigReader(object):
                 tags=config.get("stack_tags", {}),
                 external_name=config.get("stack_name"),
                 notifications=config.get("notifications"),
-                on_failure=config.get("on_failure")
+                on_failure=config.get("on_failure"),
+                stack_timeout=config.get("stack_timeout", 0)
             )
 
             del self.templating_vars["environment_config"]

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -52,10 +52,11 @@ class Stack(object):
     hooks = HookProperty("hooks")
 
     def __init__(
-        self, name, project_code, template_path, region, iam_role=None,
-        profile=None, parameters=None, sceptre_user_data=None, hooks=None,
-        s3_details=None, dependencies=None, role_arn=None, protected=False,
-        tags=None, external_name=None, notifications=None, on_failure=None
+            self, name, project_code, template_path, region, iam_role=None,
+            profile=None, parameters=None, sceptre_user_data=None, hooks=None,
+            s3_details=None, dependencies=None, role_arn=None, protected=False,
+            tags=None, external_name=None, notifications=None, on_failure=None,
+            stack_timeout=0
     ):
         self.logger = logging.getLogger(__name__)
 
@@ -80,6 +81,7 @@ class Stack(object):
         self.on_failure = on_failure
         self.dependencies = dependencies or []
         self.tags = tags or {}
+        self.stack_timeout = stack_timeout
 
         self.hooks = hooks or {}
         self.parameters = parameters or {}
@@ -98,7 +100,8 @@ class Stack(object):
             "dependencies='{dependencies}', role_arn='{role_arn}', "
             "protected='{protected}', tags='{tags}', "
             "external_name='{external_name}', "
-            "notifications='{notifications}', on_failure='{on_failure}'"
+            "notifications='{notifications}', on_failure='{on_failure}', "
+            "stack_timeout='{stack_timeout}'"
             ")".format(
                 name=self.name, project_code=self.project_code,
                 template_path=self.template_path,
@@ -111,7 +114,8 @@ class Stack(object):
                 dependencies=self.dependencies, role_arn=self.role_arn,
                 protected=self.protected, tags=self.tags,
                 external_name=self.external_name,
-                notifications=self.notifications, on_failure=self.on_failure
+                notifications=self.notifications, on_failure=self.on_failure,
+                stack_timeout=self.stack_timeout
             )
         )
 
@@ -156,6 +160,7 @@ class Stack(object):
             create_stack_kwargs.update({"OnFailure": self.on_failure})
         create_stack_kwargs.update(self.template.get_boto_call_parameter())
         create_stack_kwargs.update(self._get_role_arn())
+        create_stack_kwargs.update(self._get_stack_timeout())
         response = self.connection_manager.call(
             service="cloudformation",
             command="create_stack",
@@ -200,9 +205,33 @@ class Stack(object):
             "%s - Update stack response: %s", self.name, response
         )
 
-        status = self._wait_for_completion()
+        status = self._wait_for_completion(self.stack_timeout)
+        # Cancel update after timeout
+        if status == StackStatus.IN_PROGRESS:
+            status = self.cancel_stack_update()
 
         return status
+
+    def cancel_stack_update(self):
+        """
+        Cancels a stack update.
+
+        :returns: The cancelled stack status.
+        :rtype: sceptre.stack_status.StackStatus
+        """
+        self.logger.warning(
+            "%s - Update stack time exceeded the specified timeout",
+            self.name
+        )
+        response = self.connection_manager.call(
+            service="cloudformation",
+            command="cancel_update_stack",
+            kwargs={"StackName": self.external_name}
+        )
+        self.logger.debug(
+            "%s - Cancel update stack response: %s", self.name, response
+        )
+        return self._wait_for_completion()
 
     def launch(self):
         """
@@ -620,6 +649,21 @@ class Stack(object):
         else:
             return {}
 
+    def _get_stack_timeout(self):
+        """
+        Return the timeout before considering the stack to be failing.
+
+        Returns an empty dict if no timeout is set.
+        :returns: the creation/update timeout
+        :rtype: dict
+        """
+        if self.stack_timeout:
+            return {
+                "TimeoutInMinutes": self.stack_timeout
+            }
+        else:
+            return {}
+
     def _protect_execution(self):
         """
         Raises a ProtectedStackError if protect == True.
@@ -633,23 +677,33 @@ class Stack(object):
                 "currently enabled".format(self.name)
             )
 
-    def _wait_for_completion(self):
+    def _wait_for_completion(self, timeout=0):
         """
         Waits for a stack operation to finish. Prints CloudFormation events
         while it waits.
 
+        :param timeout: Timeout before returning, in minutes.
+
         :returns: The final stack status.
         :rtype: sceptre.stack_status.StackStatus
         """
+        timeout = 60 * timeout
+
+        def timed_out(elapsed):
+            return elapsed >= timeout if timeout else False
+
         status = StackStatus.IN_PROGRESS
 
         self.most_recent_event_datetime = (
             datetime.now(tzutc()) - timedelta(seconds=3)
         )
-        while status == StackStatus.IN_PROGRESS:
+        elapsed = 0
+        while status == StackStatus.IN_PROGRESS and not timed_out(elapsed):
             status = self._get_simplified_status(self.get_status())
             self._log_new_events()
             time.sleep(4)
+            elapsed += 4
+
         return status
 
     @staticmethod

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -55,7 +55,8 @@ class Stack(object):
         self, name, project_code, template_path, region, iam_role=None,
         parameters=None, sceptre_user_data=None, hooks=None, s3_details=None,
         dependencies=None, role_arn=None, protected=False, tags=None,
-        external_name=None, notifications=None, on_failure=None, stack_timeout=0
+        external_name=None, notifications=None, on_failure=None,
+        stack_timeout=0
     ):
         self.logger = logging.getLogger(__name__)
 

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -212,7 +212,8 @@ class TestConfigReader(object):
                 tags={},
                 external_name=None,
                 notifications=None,
-                on_failure=None
+                on_failure=None,
+                stack_timeout=0
         )
         assert stack == sentinel.stack
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from mock import patch, sentinel, MagicMock, Mock
+from mock import patch, sentinel, MagicMock, Mock, call
 
 import datetime
 from dateutil.tz import tzutc
@@ -36,7 +36,8 @@ class TestStack(object):
             role_arn=sentinel.role_arn, protected=False,
             tags={"tag1": "val1"}, external_name=sentinel.external_name,
             notifications=[sentinel.notification],
-            on_failure=sentinel.on_failure
+            on_failure=sentinel.on_failure,
+            stack_timeout=sentinel.stack_timeout
         )
         self.stack._template = MagicMock(spec=Template)
 
@@ -88,7 +89,8 @@ class TestStack(object):
             "protected='False', tags='{'tag1': 'val1'}', " \
             "external_name='sentinel.external_name', " \
             "notifications='[sentinel.notification]', " \
-            "on_failure='sentinel.on_failure'" \
+            "on_failure='sentinel.on_failure', " \
+            "stack_timeout='sentinel.stack_timeout'" \
             ")"
 
     @patch("sceptre.stack.Template")
@@ -120,13 +122,18 @@ class TestStack(object):
         assert stack.external_name == "external_name"
 
     @patch("sceptre.stack.Stack._wait_for_completion")
-    def test_create_sends_correct_request(self, mock_wait_for_completion):
+    @patch("sceptre.stack.Stack._get_stack_timeout")
+    def test_create_sends_correct_request(
+            self, mock_get_stack_timeout, mock_wait_for_completion
+    ):
         self.stack._template.get_boto_call_parameter.return_value = {
             "Template": sentinel.template
         }
+        mock_get_stack_timeout.return_value = {
+            "TimeoutInMinutes": sentinel.timeout
+        }
 
         self.stack.create()
-
         self.stack.connection_manager.call.assert_called_with(
             service="cloudformation",
             command="create_stack",
@@ -143,7 +150,8 @@ class TestStack(object):
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}
                 ],
-                "OnFailure": sentinel.on_failure
+                "OnFailure": sentinel.on_failure,
+                "TimeoutInMinutes": sentinel.timeout
             }
         )
         mock_wait_for_completion.assert_called_once_with()
@@ -175,19 +183,21 @@ class TestStack(object):
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}
                 ],
-                "OnFailure": sentinel.on_failure
+                "OnFailure": sentinel.on_failure,
+                "TimeoutInMinutes": sentinel.stack_timeout
             }
         )
         mock_wait_for_completion.assert_called_once_with()
 
     @patch("sceptre.stack.Stack._wait_for_completion")
-    def test_create_sends_correct_request_with_no_failure(
+    def test_create_sends_correct_request_with_no_failure_no_timeout(
         self, mock_wait_for_completion
     ):
         self.stack._template.get_boto_call_parameter.return_value = {
             "Template": sentinel.template
         }
         self.stack.on_failure = None
+        self.stack.stack_timeout = 0
 
         self.stack.create()
 
@@ -237,7 +247,46 @@ class TestStack(object):
                 ]
             }
         )
-        mock_wait_for_completion.assert_called_once_with()
+        mock_wait_for_completion.assert_called_once_with(
+            sentinel.stack_timeout
+        )
+
+    @patch("sceptre.stack.Stack._wait_for_completion")
+    def test_update_cancels_after_timeout(self, mock_wait_for_completion):
+        self.stack._template = Mock(spec=Template)
+        self.stack._template.get_boto_call_parameter.return_value = {
+            "Template": sentinel.template
+        }
+        mock_wait_for_completion.return_value = StackStatus.IN_PROGRESS
+
+        self.stack.update()
+        calls = [
+            call(
+                service="cloudformation",
+                command="update_stack",
+                kwargs={
+                    "StackName": sentinel.external_name,
+                    "Template": sentinel.template,
+                    "Parameters": [{
+                        "ParameterKey": "key1",
+                        "ParameterValue": "val1"
+                    }],
+                    "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                    "RoleARN": sentinel.role_arn,
+                    "NotificationARNs": [sentinel.notification],
+                    "Tags": [
+                        {"Key": "tag1", "Value": "val1"}
+                    ]
+                }),
+            call(
+                service="cloudformation",
+                command="cancel_update_stack",
+                kwargs={"StackName": sentinel.external_name})
+        ]
+        self.stack.connection_manager.call.assert_has_calls(calls)
+        mock_wait_for_completion.assert_has_calls(
+            [call(sentinel.stack_timeout), call()]
+        )
 
     @patch("sceptre.stack.Stack._wait_for_completion")
     def test_update_sends_correct_request_no_notification(
@@ -267,6 +316,20 @@ class TestStack(object):
                     {"Key": "tag1", "Value": "val1"}
                 ]
             }
+        )
+        mock_wait_for_completion.assert_called_once_with(
+            sentinel.stack_timeout
+        )
+
+    @patch("sceptre.stack.Stack._wait_for_completion")
+    def test_cancel_update_sends_correct_request(
+            self, mock_wait_for_completion
+    ):
+        self.stack.cancel_stack_update()
+        self.stack.connection_manager.call.assert_called_once_with(
+            service="cloudformation",
+            command="cancel_update_stack",
+            kwargs={"StackName": sentinel.external_name}
         )
         mock_wait_for_completion.assert_called_once_with()
 


### PR DESCRIPTION
Added a stack_timeout key in stack yaml config files. Allow timeout and auto-rollback of stucked cloudformation deployments.

For stack creations: timeout is simply passed in the underlying create_stack boto3 call using the TimeoutInMinutes parameter. Cloudformation solely handles the timeout behavior.
For stack updates: wait_for_completion takes the timeout in as an optional parameter. If elapsed time overreach the timeout, a cancel_update_stack call is performed.

Hope this can be found useful by others. Still a lot of love for Sceptre here at Ubisoft, cheers!

* I removed the default profile value because it crashes most of the tests right now.

-----------------

* [x] Wrote [good commit messages].
* [x] [Squashed related commits together]
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
