### PR TITLE
[Resolves #326] Auto use change sets when needed

### DIFF
--- a/integration-tests/features/launch-stack.feature
+++ b/integration-tests/features/launch-stack.feature
@@ -17,3 +17,19 @@ Feature: Launch stack
     and the template for stack "1/A" is "valid_template.json"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
+
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |
+
+  Scenario Outline: launch an existing stack with no changes
+    Given the template for stack "1/A" is "<filename>"
+    and stack "1/A" exists using "<filename>"
+    When the user launches stack "1/A"
+    Then no exception is raised
+
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |

--- a/integration-tests/sceptre-project/config/1/A.yaml
+++ b/integration-tests/sceptre-project/config/1/A.yaml
@@ -1,1 +1,1 @@
-template_path: templates/malformed_template.json
+template_path: templates/updated_template_with_transform.yaml

--- a/integration-tests/sceptre-project/config/7/A.yaml
+++ b/integration-tests/sceptre-project/config/7/A.yaml
@@ -1,3 +1,3 @@
 sceptre_user_data:
   type: AWS::CloudFormation::WaitConditionHandle
-template_path: templates/jinja/valid_template.j2
+template_path: templates/jinja/invalid_template_missing_attr.j2

--- a/integration-tests/steps/helpers.py
+++ b/integration-tests/steps/helpers.py
@@ -26,6 +26,9 @@ def step_impl(context, message):
     else:
         raise Exception("Step has incorrect message")
 
+@then('no exception is raised')
+def step_impl(context):
+    assert (context.error is None)
 
 @then('no exception is raised')
 def step_impl(context):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -337,12 +337,13 @@ class Stack(object):
         self.create_change_set(change_set_name)
         self.wait_for_cs_completion(change_set_name)
         cs_status = self.describe_change_set(change_set_name)
-        if cs_status['Status'] == 'FAILED' and \
-                cs_status['StatusReason'] == 'No updates are to be performed.':
-            self.logger.info("%s - No updates to perform - deleting %s",
-                             self.name,
-                             change_set_name
-                             )
+        if cs_status["Status"] == "FAILED" and \
+                cs_status["StatusReason"] == "No updates are to be performed.":
+            self.logger.info(
+                "%s - No updates to perform - deleting %s",
+                self.name,
+                change_set_name
+            )
             return self.delete_change_set(change_set_name)
         else:
             return self.execute_change_set(change_set_name)

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -321,3 +321,30 @@ class Template(object):
         template = env.get_template(filename)
         body = template.render(**jinja_vars)
         return body
+
+
+    @property
+    def template_summary(self):
+        """
+        The template summary
+
+        :returns: The template summary of the CloudFormation template.
+        :rtype: dict
+        """
+        if self._template_summary is None:
+            self._template_summary = self.connection_manager.call(
+                service="cloudformation",
+                command="get_template_summary",
+                kwargs=self.get_boto_call_parameter()
+            )
+        return self._template_summary
+
+    @property
+    def requires_change_set(self):
+        """
+        Requires change set
+
+        :returns: whether the tempalte requires changes via change sets
+        :rtype: bool
+        """
+        return "DeclaredTransforms" in self.template_summary

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -318,6 +318,7 @@ class TestStack(object):
             sentinel.stack_timeout
         )
 
+
     @patch("sceptre.stack.Stack._wait_for_completion")
     def test_cancel_update_sends_correct_request(
             self, mock_wait_for_completion
@@ -329,6 +330,114 @@ class TestStack(object):
             kwargs={"StackName": sentinel.external_name}
         )
         mock_wait_for_completion.assert_called_once_with()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_without_name(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._template = Mock(spec=Template)
+        self.stack._template.requires_change_set = True
+
+        mock_delete_change_set.return_value = {'Status': 'SUCCESS'}
+        mock_uuid.return_value = UUID(int=0)
+
+        self.stack.launch_using_change_set()
+
+        mock_uuid.assert_called_once()
+        mock_create_change_set.assert_called_once_with(
+            "change-set-00000000000000000000000000000000")
+        mock_wait_for_cs_completion.assert_called_once_with(
+            "change-set-00000000000000000000000000000000")
+        mock_execute_change_set.assert_called_once_with(
+            "change-set-00000000000000000000000000000000")
+        mock_delete_change_set.assert_not_called()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_with_name(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._template = Mock(spec=Template)
+        self.stack._template.requires_change_set = True
+        mock_describe_change_set.return_value = {'Status': 'SUCCESS'}
+
+        change_set_name = UUID(int=1)
+
+        self.stack.launch_using_change_set(change_set_name)
+
+        mock_uuid.asset_not_called()
+        mock_create_change_set.assert_called_once_with(change_set_name)
+        mock_wait_for_cs_completion.assert_called_once_with(change_set_name)
+        mock_execute_change_set.assert_called_once_with(change_set_name)
+        mock_delete_change_set.assert_not_called()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_with_name_and_failed_change_set(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._template = Mock(spec=Template)
+        self.stack._template.requires_change_set = True
+        mock_describe_change_set.return_value = {
+            'Status': 'FAILED', 'StatusReason': 'Invalid Template'
+        }
+
+        change_set_name = UUID(int=1)
+
+        self.stack.launch_using_change_set(change_set_name)
+
+        mock_uuid.asset_not_called()
+        mock_create_change_set.assert_called_once_with(change_set_name)
+        mock_wait_for_cs_completion.assert_called_once_with(change_set_name)
+        mock_execute_change_set.assert_called_once_with(change_set_name)
+        mock_delete_change_set.assert_not_called()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_with_name_and_no_changes(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._template = Mock(spec=Template)
+        self.stack._template.requires_change_set = True
+        mock_describe_change_set.return_value = {
+            'Status': 'FAILED',
+            'StatusReason': 'No updates are to be performed.'
+        }
+
+        change_set_name = UUID(int=1)
+
+        self.stack.launch_using_change_set(change_set_name)
+
+        mock_uuid.asset_not_called()
+        mock_create_change_set.assert_called_once_with(change_set_name)
+        mock_wait_for_cs_completion.assert_called_once_with(change_set_name)
+        mock_execute_change_set.assert_not_called()
+        mock_delete_change_set.assert_called_once_with(change_set_name)
 
     @patch("sceptre.stack.Stack.create")
     @patch("sceptre.stack.Stack.get_status")

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -319,6 +319,7 @@ class TestStack(object):
         )
 
 
+
     @patch("sceptre.stack.Stack._wait_for_completion")
     def test_cancel_update_sends_correct_request(
             self, mock_wait_for_completion
@@ -330,6 +331,20 @@ class TestStack(object):
             kwargs={"StackName": sentinel.external_name}
         )
         mock_wait_for_completion.assert_called_once_with()
+
+    @patch("sceptre.stack.Stack.get_status")
+    @patch("sceptre.stack.Stack.launch_using_change_set")
+    def test_update_does_not_call_launch_using_change_set_when_non_existent(
+            self, mock_launch_using_change_set, mock_get_status
+    ):
+        self.stack._template = Mock(spec=Template)
+        self.stack._template.requires_change_set = True
+        mock_get_status.side_effect = StackDoesNotExistError()
+
+        return_value = self.stack.update()
+
+        mock_launch_using_change_set.assert_not_called()
+        assert(return_value == "PENDING")
 
     @patch('sceptre.stack.uuid1')
     @patch("sceptre.stack.Stack.execute_change_set")


### PR DESCRIPTION
See https://github.com/cloudreach/sceptre/pull/326
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2].
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit