### PR TITLE
[Resolves #271] Decrease circleci parallel runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           paths:
             - .tox
   integration-tests:
-    parallelism: 4
+    parallelism: 2
     docker:
       - image: cloudreach/sceptre-circleci:0.2
         environment:


### PR DESCRIPTION
We have been seeing a number of 'Resetting dropped connection' in our
integration tests due to throttling on AWS's side. This commit lowers
the number of parallel runs of the integrations tests, in an attempt to
resolve this issue.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.