### PR TITLE
[Resolves #382] Setup integration tests for contributors

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -88,7 +88,7 @@ Get Started
 
     $ git checkout -b <branch-name>
 
-5. When you're done making changes, check that your changes pass linting, unit tests and have sufficient coverage:
+5. When you're done making changes, check that your changes pass linting, unit tests and have sufficient coverage and integration tests pass:
 
    Check linting:
 
@@ -114,6 +114,36 @@ Get Started
 
    If you use pyenv to manage Python versions, try `pip install tox-pyenv` to make tox and pyenv play nicely.
 
+   Run integration tests:
+
+   If you haven't setup your local environment or personal CircleCI account to run integration tests then follow these steps:
+
+   To run on CircleCi (please do this before submitting your PR so we can see that your tests are passing):
+
+   - Login to CircleCi using your Github Account.
+   - Click `Add Projects`, you will be presented with a list of projects from your GitHub Account.
+   - On your sceptre fork press the `Set Up Project`.
+   - You can ignore the setup steps, we already have a CircleCi config file in Sceptre. Click the "Start Building".
+   - Modify the project settings under `Builds -> Sceptre` and the settings cog on the right hand side.
+   - Once in the `Project Settings` section under `Permissions` select `AWS Permissions`.
+   - Add a `Access Key ID` and `Secret Access Key` from an AWS user from your AWS account. The user will require "Full" permissions for `CloudFormation` and `S3` and Write permissions for `STS` (AssumeRole).
+
+   Once you have set up CircleCi any time you commit to a branch in your fork all tests will be run, including integration tests.
+
+   You can also (optionally) run the integration tests locally, which is quicker during development.
+
+   To run integration tests locally `pip install behave` in your sceptre virtualenv and run:
+
+   .. code-block:: shell
+      $ behave integration-tests
+
+   or to run a specific tests:
+
+   .. code-block:: shell
+      $ behave-integration-tests -n "scenario-name"
+
+   Note: you will need to make sure you have installed and configured `awscli` to work with an AWS account that you have access to. You can use the same user that you use for CircleCi.
+
 6. Make sure the changes comply with the pull request guidelines in the section on `Contributing Code`_.
 
 7. Commit and push your changes.
@@ -125,6 +155,7 @@ Get Started
    e.g. ``[Resolves #123] Fix description of resolver syntax in documentation``
 
 8. Submit a pull request through the GitHub website.
+
 
 
 Credits

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -122,11 +122,11 @@ Get Started
 
    - Login to CircleCi using your Github Account.
    - Click `Add Projects`, you will be presented with a list of projects from your GitHub Account.
-   - On your sceptre fork press the `Set Up Project`.
-   - You can ignore the setup steps, we already have a CircleCi config file in Sceptre. Click the "Start Building".
-   - Modify the project settings under `Builds -> Sceptre` and the settings cog on the right hand side.
+   - On your sceptre fork press the `Set Up Project` button.
+   - You can ignore the setup steps, we already have a CircleCi config file in Sceptre. Click "Start Building".
+   - Modify the `Project Settings`, which can be found by navigating: `Builds -> Sceptre` and selecting the `Settings` icon, on the right hand side of the page.
    - Once in the `Project Settings` section under `Permissions` select `AWS Permissions`.
-   - Add a `Access Key ID` and `Secret Access Key` from an AWS user from your AWS account. The user will require "Full" permissions for `CloudFormation` and `S3` and Write permissions for `STS` (AssumeRole).
+   - Add your `Access Key ID` and `Secret Access Key` that is associated with an IAM User from your AWS account. The IAM User will require "Full" permissions for `CloudFormation` and `S3` and Write permissions for `STS` (AssumeRole).
 
    Once you have set up CircleCi any time you commit to a branch in your fork all tests will be run, including integration tests.
 


### PR DESCRIPTION
Instructions have been added about how to setup a sceptre fork with
CircleCi. Currently, there is no visability of integration tests for a
forked PR. We only find out whether the PR has passing integration
tests after they are merged into master.

Setting up integration tests in CircleCi is very quick and running them
is free. The cost of asking contributors to set this up outweighs the
cost of dealing with the repercussions of merging bad branches.

-----------------

* [x] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
