### PR TITLE
[Resolves #257] improved Cross Region/Account Support

### DIFF
--- a/behave.ini
+++ b/behave.ini
@@ -1,0 +1,3 @@
+[behave]
+stderr_capture=False
+stdout_capture=False

--- a/integration-tests/environment.py
+++ b/integration-tests/environment.py
@@ -26,6 +26,8 @@ def before_all(context):
 
 
 def before_scenario(context, scenario):
+    os.environ.pop('AWS_REGION', None)
+    os.environ.pop('AWS_CONFIG_FILE', None)
     context.error = None
     context.response = None
     context.output = None

--- a/integration-tests/environment.py
+++ b/integration-tests/environment.py
@@ -26,8 +26,8 @@ def before_all(context):
 
 
 def before_scenario(context, scenario):
-    os.environ.pop('AWS_REGION', None)
-    os.environ.pop('AWS_CONFIG_FILE', None)
+    os.environ.pop("AWS_REGION", None)
+    os.environ.pop("AWS_CONFIG_FILE", None)
     context.error = None
     context.response = None
     context.output = None

--- a/integration-tests/features/stack-output-external-resolver.feature
+++ b/integration-tests/features/stack-output-external-resolver.feature
@@ -1,0 +1,9 @@
+Feature: Stack output external resolver
+
+  Scenario: launch a stack referencing the external output of an existing stack
+    Given environment "9" has AWS config "aws-config" set
+    and stack "9/A" exists using "dependencies/independent_template.json"
+    and stack "9/B" does not exist
+    and stack "9/B" has its project code resolved
+    When the user launches stack "9/B"
+    Then stack "9/B" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/stack-output-resolver.feature
+++ b/integration-tests/features/stack-output-resolver.feature
@@ -20,6 +20,15 @@ Feature: Stack output resolver
     and that stack "6/1/A" was created before "6/1/B"
     and that stack "6/1/B" was created before "6/1/C"
 
+  Scenario: launch a environment where stacks are in different regions
+    Given stack "6/2/A" does not exist in "eu-west-1"
+    and stack "6/2/B" does not exist in "eu-west-2"
+    and stack "6/2/C" does not exist in "eu-west-3"
+    When the user launches environment "6/2"
+    Then stack "6/2/A" in "eu-west-1" exists in "CREATE_COMPLETE" state
+    and stack "6/2/B" in "eu-west-2" exists in "CREATE_COMPLETE" state
+    and stack "6/2/C" in "eu-west-3" exists in "CREATE_COMPLETE" state
+
   Scenario: delete a stack referencing an output of existing stack
     Given stack "6/1/A" exists in "CREATE_COMPLETE" state
     and stack "6/1/B" exists in "CREATE_COMPLETE" state

--- a/integration-tests/sceptre-project/config/1/A.yaml
+++ b/integration-tests/sceptre-project/config/1/A.yaml
@@ -1,1 +1,1 @@
-template_path: templates/malformed_template.json
+template_path: templates/valid_template.json

--- a/integration-tests/sceptre-project/config/6/2/A.yaml
+++ b/integration-tests/sceptre-project/config/6/2/A.yaml
@@ -1,0 +1,2 @@
+template_path: templates/dependencies/independent_template.json
+region: eu-west-1

--- a/integration-tests/sceptre-project/config/6/2/B.yaml
+++ b/integration-tests/sceptre-project/config/6/2/B.yaml
@@ -1,4 +1,4 @@
-template_path: templates/dependencies/dependent_template.json
+template_path: templates/dependencies/dependent_template_local_export.json
 region: eu-west-2
 parameters:
   DependentStackName: !stack_output A::StackName

--- a/integration-tests/sceptre-project/config/6/2/C.yaml
+++ b/integration-tests/sceptre-project/config/6/2/C.yaml
@@ -1,4 +1,4 @@
 template_path: templates/dependencies/dependent_template.json
-region: eu-west-2
+region: eu-west-3
 parameters:
-  DependentStackName: !stack_output A::StackName
+  DependentStackName: !stack_output B::StackName

--- a/integration-tests/sceptre-project/config/6/2/C.yaml
+++ b/integration-tests/sceptre-project/config/6/2/C.yaml
@@ -1,4 +1,4 @@
-template_path: templates/dependencies/dependent_template.json
+template_path: templates/dependencies/dependent_template_local_export.json
 region: eu-west-3
 parameters:
   DependentStackName: !stack_output B::StackName

--- a/integration-tests/sceptre-project/config/9/A.yaml
+++ b/integration-tests/sceptre-project/config/9/A.yaml
@@ -1,0 +1,2 @@
+template_path: templates/dependencies/independent_template.json
+region: eu-west-1

--- a/integration-tests/sceptre-project/config/9/B.yaml
+++ b/integration-tests/sceptre-project/config/9/B.yaml
@@ -1,0 +1,4 @@
+template_path: templates/dependencies/dependent_template_local_export.json
+region: eu-west-1
+parameters:
+  DependentStackName: !stack_output_external {project_code}-9-A::StackName 9-A

--- a/integration-tests/sceptre-project/config/9/aws-config
+++ b/integration-tests/sceptre-project/config/9/aws-config
@@ -1,0 +1,2 @@
+[profile 9-A]
+region = eu-west-1

--- a/integration-tests/sceptre-project/templates/dependencies/dependent_template_local_export.json
+++ b/integration-tests/sceptre-project/templates/dependencies/dependent_template_local_export.json
@@ -1,0 +1,30 @@
+{
+  "Parameters": {
+    "DependentStackName": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "WaitConditionHandle": {
+      "Type": "AWS::CloudFormation::WaitConditionHandle",
+      "Properties": {}
+    }
+  },
+  "Outputs": {
+    "StackName": {
+      "Value": {
+        "Ref": "AWS::StackName"
+      }
+    },
+    "Output": {
+      "Value": {
+        "Ref": "DependentStackName"
+      },
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${AWS::StackName}-Output"
+        }
+      }
+    }
+  }
+}

--- a/integration-tests/steps/helpers.py
+++ b/integration-tests/steps/helpers.py
@@ -1,7 +1,6 @@
 from behave import *
 import os
 import time
-import re
 
 import jinja2.exceptions
 

--- a/integration-tests/steps/helpers.py
+++ b/integration-tests/steps/helpers.py
@@ -1,6 +1,7 @@
 from behave import *
 import os
 import time
+import re
 
 import jinja2.exceptions
 
@@ -48,6 +49,30 @@ def step_impl(context, exception_type):
         assert isinstance(context.error, jinja2.exceptions.UndefinedError)
     else:
         raise Exception("Step has incorrect message")
+
+
+@given('environment "{environment}" has AWS config "{config}" set')
+def step_impl(context, environment, config):
+    config_path = os.path.join(
+        context.sceptre_dir, "config", environment, config
+    )
+
+    os.environ['AWS_CONFIG_FILE'] = config_path
+
+
+@given('stack "{stack_name}" has its project code resolved')
+def step_impl(context, stack_name):
+    config_path = os.path.join(
+        context.sceptre_dir, "config", stack_name + ".yaml"
+    )
+
+    with open(config_path, "r") as file:
+        file_data = file.read()
+
+    file_data = file_data.replace("{project_code}", context.project_code)
+
+    with open(config_path, "w") as file:
+        file.write(file_data)
 
 
 def read_template_file(context, template_name):

--- a/sceptre/config_reader.py
+++ b/sceptre/config_reader.py
@@ -34,7 +34,6 @@ ENVIRONMENT_CONFIG_ATTRIBUTES = ConfigAttributes(
         "region"
     },
     {
-        "iam_role",
         "template_bucket_name",
         "template_key_prefix",
         "require_version"
@@ -46,6 +45,7 @@ STACK_CONFIG_ATTRIBUTES = ConfigAttributes(
         "template_path"
     },
     {
+        "profile",
         "dependencies",
         "hooks",
         "parameters",
@@ -325,7 +325,7 @@ class ConfigReader(object):
                 project_code=config["project_code"],
                 template_path=abs_template_path,
                 region=config["region"],
-                iam_role=config.get("iam_role"),
+                profile=config.get("profile"),
                 parameters=config.get("parameters", {}),
                 sceptre_user_data=config.get("sceptre_user_data", {}),
                 hooks=config.get("hooks", {}),

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -76,6 +76,7 @@ class ConnectionManager(object):
     _client_lock = threading.Lock()
     _boto_sessions = {}
     _clients = {}
+    _stack_keys = {}
 
     def __init__(self, region, profile=None, stack_name=None):
         self.logger = logging.getLogger(__name__)
@@ -83,6 +84,9 @@ class ConnectionManager(object):
         self.region = region
         self.profile = profile
         self.stack_name = stack_name
+
+        if stack_name:
+            self._stack_keys[stack_name] = (region, profile)
 
     def __repr__(self):
         return (
@@ -185,8 +189,11 @@ class ConnectionManager(object):
         :rtype: dict
         """
         if region is None and profile is None:
-            region = region or self.region
-            profile = profile or self.profile
+            if stack_name and stack_name in self._stack_keys:
+                region, profile = self._stack_keys[stack_name]
+            else:
+                region = self.region
+                profile = self.profile
 
         if kwargs is None:  # pragma: no cover
             kwargs = {}

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -175,11 +175,12 @@ class ConnectionManager(object):
         :returns: The response from the Boto3 call.
         :rtype: dict
         """
-        if stack_name:
+        if stack_name and stack_name in self._stack_keys:
             region, profile = self._stack_keys[stack_name]
         else:
             profile = profile or self.profile
             region = region or self.region
+            self._stack_keys[stack_name] = (region, profile)
 
         if kwargs is None:  # pragma: no cover
             kwargs = {}

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -11,8 +11,9 @@ import functools
 import logging
 import threading
 import time
-
 import boto3
+
+from os import environ
 from botocore.exceptions import ClientError
 
 from .helpers import mask_key
@@ -112,10 +113,15 @@ class ConnectionManager(object):
                 self.logger.debug("No Boto3 session found, creating one...")
                 self.logger.debug("Using cli credentials...")
 
-                # Region takes precedence
-                session = boto3.session.Session(
-                    profile_name=profile, region_name=region
-                )
+                # Credentials from env take priority over profile
+                config = {
+                  "profile_name": profile,
+                  "region_name": region,
+                  "aws_access_key_id": environ.get("AWS_ACCESS_KEY_ID"),
+                  "aws_secret_access_key": environ.get("AWS_SECRET_ACCESS_KEY")
+                }
+
+                session = boto3.session.Session(**config)
                 self._boto_sessions[key] = session
 
                 self.logger.debug(

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -65,8 +65,8 @@ class ConnectionManager(object):
 
     :param profile: The aws credential profile that should be used.
     :type profile: str
-    :param iam_role: The iam_role that should be assumed in the account.
-    :type iam_role: str
+    :param stack_name: The cloudformation stack name for this connection.
+    :type stack_name: str
     :param region: The region to use.
     :type region: str
     """
@@ -82,6 +82,7 @@ class ConnectionManager(object):
 
         self.region = region
         self.profile = profile
+        self.stack_name = stack_name
 
         if stack_name:
             self._stack_keys[stack_name] = (region, profile)
@@ -89,8 +90,8 @@ class ConnectionManager(object):
     def __repr__(self):
         return (
             "sceptre.connection_manager.ConnectionManager(region='{0}', "
-            "iam_role='{1}', profile='{2}')".format(
-                self.region, self.profile
+            "profile='{1}', stack_name='{2}')".format(
+                self.region, self.profile, self.stack_name
             )
         )
 
@@ -98,11 +99,10 @@ class ConnectionManager(object):
         """
         Returns a boto session in the target account.
 
-        If an ``iam_role`` is specified in ConnectionManager's initialiser,
-        then STS is used to assume the specified IAM role in the account and
-        uses temporary credentials to create the boto session. If ``iam_role``
-        is not specified, the default AWS credentials are used to create the
-        boto session.
+        If a ``profile`` is specified in ConnectionManager's initialiser,
+        then the profile is used to generate temporary credentials to create
+        the boto session. If ``profile`` is not specified then the default
+        profile is assumed to create the boto session.
 
         :returns: The Boto3 session.
         :rtype: boto3.session.Session

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -148,7 +148,7 @@ class ConnectionManager(object):
         :rtype: boto3.client.Client
         """
         with self._client_lock:
-            key = (service, region)
+            key = (service, region, profile)
             if self._clients.get(key) is None:
                 self.logger.debug(
                     "No %s client found, creating one...", service

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -91,7 +91,7 @@ class ConnectionManager(object):
             )
         )
 
-    def _get_session(self, profile, region):
+    def _get_session(self, profile, region=None):
         """
         Returns a boto session in the target account.
 
@@ -112,8 +112,10 @@ class ConnectionManager(object):
                 self.logger.debug("No Boto3 session found, creating one...")
                 self.logger.debug("Using cli credentials...")
 
-                # Region takes precedence when both profile and region are specified
-                session = boto3.session.Session(profile_name=profile, region_name=region)
+                # Region takes precedence
+                session = boto3.session.Session(
+                    profile_name=profile, region_name=region
+                )
                 self._boto_sessions[key] = session
 
                 self.logger.debug(
@@ -152,12 +154,15 @@ class ConnectionManager(object):
                 self.logger.debug(
                     "No %s client found, creating one...", service
                 )
-                self._clients[key] = self._get_session(profile, region).client(service)
+                self._clients[key] = self._get_session(
+                    profile, region
+                ).client(service)
             return self._clients[key]
 
     @_retry_boto_call
     def call(
-        self, service, command, kwargs=None, profile=None, region=None, stack_name=None
+        self, service, command, kwargs=None, profile=None, region=None,
+        stack_name=None
     ):
         """
         Makes a threadsafe Boto3 client call.

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -71,6 +71,7 @@ class Environment(object):
         self._build(
             "launch", threading_events, stack_statuses, launch_dependencies
         )
+
         return stack_statuses
 
     def delete(self):

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -5,8 +5,8 @@ import glob
 import imp
 import inspect
 import os
-import re
 import sys
+import re
 
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -64,7 +64,8 @@ class StackOutputBase(Resolver):
             response = connection_manager.call(
                 service="cloudformation",
                 command="describe_stacks",
-                kwargs={"StackName": stack_name}
+                kwargs={"StackName": stack_name},
+                stack_name=stack_name
             )
         except ClientError as e:
             if "does not exist" in e.response["Error"]["Message"]:

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -4,6 +4,7 @@ import abc
 import six
 import logging
 import os
+import shlex
 
 from botocore.exceptions import ClientError
 
@@ -22,7 +23,7 @@ class StackOutputBase(Resolver):
         self.logger = logging.getLogger(__name__)
         super(StackOutputBase, self).__init__(*args, **kwargs)
 
-    def _get_output_value(self, stack_name, output_key):
+    def _get_output_value(self, stack_name, output_key, profile=None):
         """
         Tries to get the stack output named by ``output_key``
 
@@ -34,7 +35,7 @@ class StackOutputBase(Resolver):
         :rtype: str
         :raises: sceptre.exceptions.DependencyStackMissingOutputError
         """
-        outputs = self._get_stack_outputs(stack_name)
+        outputs = self._get_stack_outputs(stack_name, profile)
 
         try:
             return outputs[output_key]
@@ -45,7 +46,7 @@ class StackOutputBase(Resolver):
                 )
             )
 
-    def _get_stack_outputs(self, stack_name):
+    def _get_stack_outputs(self, stack_name, profile=None):
         """
         Communicates with AWS Cloudformation to fetch outputs from a specific
         stack.
@@ -60,11 +61,13 @@ class StackOutputBase(Resolver):
             stack_name
         ))
         connection_manager = self.stack.connection_manager
+
         try:
             response = connection_manager.call(
                 service="cloudformation",
                 command="describe_stacks",
                 kwargs={"StackName": stack_name},
+                profile=profile,
                 stack_name=stack_name
             )
         except ClientError as e:
@@ -150,5 +153,13 @@ class StackOutputExternal(StackOutputBase):
         self.logger.debug(
             "Resolving external stack output: {0}".format(self.argument)
         )
-        dependency_stack_name, output_key = self.argument.split("::")
-        return self._get_output_value(dependency_stack_name, output_key)
+
+        profile = None
+        arguments = shlex.split(self.argument)
+
+        stack_argument = arguments[0]
+        if len(arguments) > 1:
+            profile = arguments[1]
+
+        dependency_stack_name, output_key = stack_argument.split("::")
+        return self._get_output_value(dependency_stack_name, output_key, profile)

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -162,4 +162,6 @@ class StackOutputExternal(StackOutputBase):
             profile = arguments[1]
 
         dependency_stack_name, output_key = stack_argument.split("::")
-        return self._get_output_value(dependency_stack_name, output_key, profile)
+        return self._get_output_value(
+            dependency_stack_name, output_key, profile
+        )

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -67,7 +67,7 @@ class Stack(object):
             get_external_stack_name(self.project_code, self.name)
 
         self.connection_manager = ConnectionManager(
-            region, profile, external_name
+            region, profile, self.external_name
         )
 
         self.profile = profile

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -52,8 +52,8 @@ class Stack(object):
     hooks = HookProperty("hooks")
 
     def __init__(
-        self, name, project_code, template_path, region, iam_role=None,
-        parameters=None, sceptre_user_data=None, hooks=None, s3_details=None,
+        self, name, project_code, template_path, region, parameters=None,
+        sceptre_user_data=None, hooks=None, s3_details=None,
         dependencies=None, role_arn=None, protected=False, tags=None,
         external_name=None, notifications=None, on_failure=None, profile=None,
         stack_timeout=0
@@ -70,6 +70,12 @@ class Stack(object):
             region, profile, external_name
         )
 
+        self.profile = profile
+        self.hooks = hooks or {}
+        self.parameters = parameters or {}
+        self.sceptre_user_data = sceptre_user_data or {}
+        self.notifications = notifications or []
+
         self.template_path = template_path
         self.s3_details = s3_details
         self._template = None
@@ -81,17 +87,12 @@ class Stack(object):
         self.tags = tags or {}
         self.stack_timeout = stack_timeout
 
-        self.hooks = hooks or {}
-        self.parameters = parameters or {}
-        self.sceptre_user_data = sceptre_user_data or {}
-        self.notifications = notifications or []
-
     def __repr__(self):
         return (
             "sceptre.stack.Stack("
             "name='{name}', project_code='{project_code}', "
             "template_path='{template_path}', region='{region}', "
-            "iam_role='{iam_role}', parameters='{parameters}', "
+            "profile='{profile}', parameters='{parameters}', "
             "sceptre_user_data='{sceptre_user_data}', "
             "hooks='{hooks}', s3_details='{s3_details}', "
             "dependencies='{dependencies}', role_arn='{role_arn}', "
@@ -103,8 +104,7 @@ class Stack(object):
                 name=self.name, project_code=self.project_code,
                 template_path=self.template_path,
                 region=self.connection_manager.region,
-                iam_role=self.connection_manager.iam_role,
-                parameters=self.parameters,
+                profile=self.profile, parameters=self.parameters,
                 sceptre_user_data=self.sceptre_user_data,
                 hooks=self.hooks, s3_details=self.s3_details,
                 dependencies=self.dependencies, role_arn=self.role_arn,

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -152,6 +152,7 @@ class Stack(object):
                 for k, v in self.tags.items()
             ]
         }
+
         if self.on_failure:
             create_stack_kwargs.update({"OnFailure": self.on_failure})
         create_stack_kwargs.update(self.template.get_boto_call_parameter())

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -55,7 +55,7 @@ class Stack(object):
         self, name, project_code, template_path, region, iam_role=None,
         parameters=None, sceptre_user_data=None, hooks=None, s3_details=None,
         dependencies=None, role_arn=None, protected=False, tags=None,
-        external_name=None, notifications=None, on_failure=None,
+        external_name=None, notifications=None, on_failure=None, profile=None,
         stack_timeout=0
     ):
         self.logger = logging.getLogger(__name__)
@@ -66,7 +66,9 @@ class Stack(object):
         self.external_name = external_name or \
             get_external_stack_name(self.project_code, self.name)
 
-        self.connection_manager = ConnectionManager(region, iam_role)
+        self.connection_manager = ConnectionManager(
+            region, profile, external_name
+        )
 
         self.template_path = template_path
         self.s3_details = s3_details

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -70,12 +70,6 @@ class Stack(object):
             region, profile, self.external_name
         )
 
-        self.profile = profile
-        self.hooks = hooks or {}
-        self.parameters = parameters or {}
-        self.sceptre_user_data = sceptre_user_data or {}
-        self.notifications = notifications or []
-
         self.template_path = template_path
         self.s3_details = s3_details
         self._template = None
@@ -86,6 +80,12 @@ class Stack(object):
         self.dependencies = dependencies or []
         self.tags = tags or {}
         self.stack_timeout = stack_timeout
+
+        self.profile = profile
+        self.hooks = hooks or {}
+        self.parameters = parameters or {}
+        self.sceptre_user_data = sceptre_user_data or {}
+        self.notifications = notifications or []
 
     def __repr__(self):
         return (

--- a/tests/fixtures/config/config.yaml
+++ b/tests/fixtures/config/config.yaml
@@ -1,4 +1,4 @@
-iam_role: account_iam_role
+profile: account_profile
 project_code: account_project_code
 region: account_region
 require_version: ">=0a"

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -200,7 +200,7 @@ class TestConfigReader(object):
                     self.test_sceptre_directory, "path/to/template"
                 ),
                 region="region_region",
-                iam_role="account_iam_role",
+                profile="account_profile",
                 parameters={"param1": "val1"},
                 sceptre_user_data={},
                 hooks={},

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
-from dateutil import tz
-
 import pytest
 from mock import Mock, patch, sentinel
 from moto import mock_s3
-from freezegun import freeze_time
 
 from boto3.session import Session
 from botocore.exceptions import ClientError, UnknownServiceError
@@ -18,146 +14,94 @@ from sceptre.exceptions import RetryLimitExceededError
 class TestConnectionManager(object):
 
     def setup_method(self, test_method):
-        self.iam_role = None
+        self.stack_name = None
         self.profile = None
         self.region = "eu-west-1"
 
         self.connection_manager = ConnectionManager(
             region=self.region,
-            iam_role=self.iam_role,
+            stack_name=self.stack_name,
             profile=self.profile
         )
-
-    def test_connection_manager_initialised_with_all_parameters(self):
-        connection_manager = ConnectionManager(
-            region=self.region,
-            iam_role="role",
-            profile="profile"
-        )
-        assert connection_manager.iam_role == "role"
-        assert connection_manager.profile == "profile"
-        assert connection_manager.region == self.region
-        assert connection_manager._boto_session is None
-        assert connection_manager.clients == {}
 
     def test_connection_manager_initialised_with_no_optional_parameters(self):
         connection_manager = ConnectionManager(region=sentinel.region)
 
-        assert connection_manager.iam_role is None
+        assert connection_manager.stack_name is None
         assert connection_manager.profile is None
         assert connection_manager.region == sentinel.region
-        assert connection_manager._boto_session is None
-        assert connection_manager.clients == {}
+        assert connection_manager._boto_sessions == {}
+        assert connection_manager._stack_keys == {}
+        assert connection_manager._clients == {}
+
+    def test_connection_manager_initialised_with_all_parameters(self):
+        connection_manager = ConnectionManager(
+            region=self.region,
+            stack_name="stack",
+            profile="profile"
+        )
+        assert connection_manager.stack_name == "stack"
+        assert connection_manager.profile == "profile"
+        assert connection_manager.region == self.region
+        assert connection_manager._boto_sessions == {}
+        assert connection_manager._stack_keys == {
+            "stack": (self.region, "profile")
+        }
+        assert connection_manager._clients == {}
 
     def test_repr(self):
-        self.connection_manager.iam_role = "role"
+        self.connection_manager.stack_name = "stack"
         self.connection_manager.profile = "profile"
         self.connection_manager.region = "region"
         response = self.connection_manager.__repr__()
         assert response == "sceptre.connection_manager.ConnectionManager(" \
-            "region='region', iam_role='role', profile='profile')"
+            "region='region', profile='profile', stack_name='stack')"
 
     def test_boto_session_with_cache(self):
-        self.connection_manager._boto_session = sentinel.boto_session
-        assert self.connection_manager.boto_session == sentinel.boto_session
+        self.connection_manager._boto_sessions["test"] = sentinel.boto_session
+
+        boto_session = self.connection_manager._boto_sessions["test"]
+        assert boto_session == sentinel.boto_session
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_no_iam_role_and_no_profile(
+    def test_boto_session_with_no_profile(
             self, mock_Session
     ):
-        self.connection_manager._boto_session = None
-        self.connection_manager.iam_role = None
+        self.connection_manager._boto_sessions = {}
         self.connection_manager.profile = None
 
-        boto_session = self.connection_manager.boto_session
+        boto_session = self.connection_manager._get_session(
+            self.connection_manager.profile
+        )
+
         assert boto_session.isinstance(mock_Session)
         mock_Session.assert_called_once_with(
-            region_name="eu-west-1",
             profile_name=None
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_no_iam_role_and_profile(self, mock_Session):
-        self.connection_manager._boto_session = None
-        self.connection_manager.iam_role = None
+    def test_boto_session_with_profile(self, mock_Session):
+        self.connection_manager._boto_sessions = {}
         self.connection_manager.profile = "profile"
 
-        boto_session = self.connection_manager.boto_session
+        boto_session = self.connection_manager._get_session(
+            self.connection_manager.profile
+        )
+
         assert boto_session.isinstance(mock_Session)
         mock_Session.assert_called_once_with(
-            region_name="eu-west-1",
             profile_name="profile"
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_iam_role_and_no_profile(self, mock_Session):
-        self.connection_manager._boto_session = None
-        self.connection_manager.iam_role = "non-default"
-        self.connection_manager.profile = None
-
-        mock_credentials = {
-            "Credentials": {
-                "AccessKeyId": "id",
-                "SecretAccessKey": "key",
-                "SessionToken": "token",
-                "Expiration": datetime(2020, 1, 1)
-            }
-        }
-
-        mock_Session.return_value.client.return_value.\
-            assume_role.return_value = mock_credentials
-
-        boto_session = self.connection_manager.boto_session
-        assert boto_session.isinstance(mock_Session)
-
-        mock_Session.assert_any_call(
-            profile_name=None,
-            region_name=self.region
-        )
-        mock_Session.assert_any_call(
-            aws_access_key_id="id",
-            aws_secret_access_key="key",
-            aws_session_token="token",
-            region_name=self.region
-        )
-
-    @patch("sceptre.connection_manager.boto3.session.Session")
-    def test_boto_session_with_iam_role_and_profile(self, mock_Session):
-        self.connection_manager._boto_session = None
-        self.connection_manager.iam_role = "non-default"
-        self.connection_manager.profile = "profile"
-
-        mock_credentials = {
-            "Credentials": {
-                "AccessKeyId": "id",
-                "SecretAccessKey": "key",
-                "SessionToken": "token",
-                "Expiration": datetime(2020, 1, 1)
-            }
-        }
-
-        mock_Session.return_value.client.return_value. \
-            assume_role.return_value = mock_credentials
-
-        boto_session = self.connection_manager.boto_session
-        assert boto_session.isinstance(mock_Session)
-
-        mock_Session.assert_any_call(
-            profile_name="profile",
-            region_name=self.region
-        )
-        mock_Session.assert_any_call(
-            aws_access_key_id="id",
-            aws_secret_access_key="key",
-            aws_session_token="token",
-            region_name=self.region
-        )
-
-    @patch("sceptre.connection_manager.boto3.session.Session")
     def test_two_boto_sessions(self, mock_Session):
-        self.connection_manager._boto_session = None
-        boto_session_1 = self.connection_manager.boto_session
-        boto_session_2 = self.connection_manager.boto_session
+        self.connection_manager._boto_sessions = {
+            "one": mock_Session,
+            "two": mock_Session
+        }
+
+        boto_session_1 = self.connection_manager._boto_sessions["one"]
+        boto_session_2 = self.connection_manager._boto_sessions["two"]
         assert boto_session_1 == boto_session_2
 
     @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
@@ -165,66 +109,52 @@ class TestConnectionManager(object):
         self, mock_get_credentials
     ):
         service = "s3"
+        region = "eu-west-1"
+        profile = None
 
-        client = self.connection_manager._get_client(service)
+        client = self.connection_manager._get_client(service, region, profile)
         expected_client = Session().client(service)
         assert str(type(client)) == str(type(expected_client))
 
     @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
     def test_get_client_with_invalid_client_type(self, mock_get_credentials):
         service = "invalid_type"
+        region = "eu-west-1"
+        profile = None
+
         with pytest.raises(UnknownServiceError):
-            self.connection_manager._get_client(service)
+            self.connection_manager._get_client(service, region, profile)
 
     @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
     def test_get_client_with_exisiting_client(self, mock_get_credentials):
         service = "cloudformation"
-        client_1 = self.connection_manager._get_client(service)
-        client_2 = self.connection_manager._get_client(service)
+        region = "eu-west-1"
+        profile = None
+
+        client_1 = self.connection_manager._get_client(
+            service, region, profile
+        )
+        client_2 = self.connection_manager._get_client(
+            service, region, profile
+        )
         assert client_1 == client_2
 
     @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
-    def test_get_client_with_exisiting_client_and_iam_role_none(
+    def test_get_client_with_exisiting_client_and_profile_none(
             self, mock_get_credentials
     ):
         service = "cloudformation"
-        self.connection_manager._iam_role = None
-        client_1 = self.connection_manager._get_client(service)
-        client_2 = self.connection_manager._get_client(service)
+        region = "eu-west-1"
+        profile = None
+
+        self.connection_manager.profile = None
+        client_1 = self.connection_manager._get_client(
+            service, region, profile
+        )
+        client_2 = self.connection_manager._get_client(
+            service, region, profile
+        )
         assert client_1 == client_2
-
-    def test_clear_session_cache_if_expired_with_no_iam_role(self):
-        self.connection_manager.iam_role = None
-        self.connection_manager._boto_session_expiration = sentinel.expiration
-        self.connection_manager.clients = sentinel.clients
-        self.connection_manager._boto_session = sentinel.boto_session
-        self.connection_manager._clear_session_cache_if_expired()
-        assert self.connection_manager.clients == sentinel.clients
-        assert self.connection_manager._boto_session == sentinel.boto_session
-
-    @freeze_time("2000-01-30")
-    def test_clear_session_cache_if_expired_with_future_date(self):
-        self.connection_manager.iam_role = "iam_role"
-        future_date = datetime(2015, 1, 30, tzinfo=tz.tzutc())
-        self.connection_manager._boto_session_expiration = future_date
-        self.connection_manager.clients = sentinel.clients
-        self.connection_manager._boto_session = sentinel.boto_session
-        self.connection_manager._clear_session_cache_if_expired()
-        assert self.connection_manager.clients == sentinel.clients
-        assert self.connection_manager._boto_session == sentinel.boto_session
-
-    @freeze_time("2015-01-30")
-    def test_clear_session_cache_if_expired_with_expired_date(self):
-        self.connection_manager.iam_role = "iam_role"
-        past_date = datetime(2000, 1, 30, tzinfo=tz.tzutc())
-        self.connection_manager._boto_session_expiration = past_date
-
-        self.connection_manager.clients = sentinel.clients
-        self.connection_manager._boto_session = sentinel.boto_session
-
-        self.connection_manager._clear_session_cache_if_expired()
-        assert self.connection_manager.clients == {}
-        assert self.connection_manager._boto_session is None
 
     @mock_s3
     def test_call_with_valid_service_and_call(self):

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -113,7 +113,9 @@ class TestConnectionManager(object):
         profile = None
         stack = self.stack_name
 
-        client = self.connection_manager._get_client(service, region, profile, stack)
+        client = self.connection_manager._get_client(
+            service, region, profile, stack
+        )
         expected_client = Session().client(service)
         assert str(type(client)) == str(type(expected_client))
 
@@ -125,7 +127,9 @@ class TestConnectionManager(object):
         stack = self.stack_name
 
         with pytest.raises(UnknownServiceError):
-            self.connection_manager._get_client(service, region, profile, stack)
+            self.connection_manager._get_client(
+                service, region, profile, stack
+            )
 
     @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
     def test_get_client_with_exisiting_client(self, mock_get_credentials):

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -169,6 +169,21 @@ class TestConnectionManager(object):
         return_value = self.connection_manager.call(service, command, {})
         assert return_value['ResponseMetadata']['HTTPStatusCode'] == 200
 
+    @mock_s3
+    def test_call_with_valid_service_and_stack_name_call(self):
+        service = 's3'
+        command = 'list_buckets'
+
+        connection_manager = ConnectionManager(
+            region=self.region,
+            stack_name='stack'
+        )
+
+        return_value = connection_manager.call(
+            service, command, {}, stack_name='stack'
+        )
+        assert return_value['ResponseMetadata']['HTTPStatusCode'] == 200
+
 
 class TestRetry():
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -71,12 +71,12 @@ class TestConnectionManager(object):
         self.connection_manager.profile = None
 
         boto_session = self.connection_manager._get_session(
-            self.connection_manager.profile
+            self.connection_manager.profile, self.region
         )
 
         assert boto_session.isinstance(mock_Session)
         mock_Session.assert_called_once_with(
-            profile_name=None
+            profile_name=None, region_name="eu-west-1"
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
@@ -85,12 +85,12 @@ class TestConnectionManager(object):
         self.connection_manager.profile = "profile"
 
         boto_session = self.connection_manager._get_session(
-            self.connection_manager.profile
+            self.connection_manager.profile, self.region
         )
 
         assert boto_session.isinstance(mock_Session)
         mock_Session.assert_called_once_with(
-            profile_name="profile"
+            profile_name="profile", region_name="eu-west-1"
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
@@ -111,8 +111,9 @@ class TestConnectionManager(object):
         service = "s3"
         region = "eu-west-1"
         profile = None
+        stack = self.stack_name
 
-        client = self.connection_manager._get_client(service, region, profile)
+        client = self.connection_manager._get_client(service, region, profile, stack)
         expected_client = Session().client(service)
         assert str(type(client)) == str(type(expected_client))
 
@@ -121,21 +122,23 @@ class TestConnectionManager(object):
         service = "invalid_type"
         region = "eu-west-1"
         profile = None
+        stack = self.stack_name
 
         with pytest.raises(UnknownServiceError):
-            self.connection_manager._get_client(service, region, profile)
+            self.connection_manager._get_client(service, region, profile, stack)
 
     @patch("sceptre.connection_manager.boto3.session.Session.get_credentials")
     def test_get_client_with_exisiting_client(self, mock_get_credentials):
         service = "cloudformation"
         region = "eu-west-1"
         profile = None
+        stack = self.stack_name
 
         client_1 = self.connection_manager._get_client(
-            service, region, profile
+            service, region, profile, stack
         )
         client_2 = self.connection_manager._get_client(
-            service, region, profile
+            service, region, profile, stack
         )
         assert client_1 == client_2
 
@@ -146,13 +149,14 @@ class TestConnectionManager(object):
         service = "cloudformation"
         region = "eu-west-1"
         profile = None
+        stack = self.stack_name
 
         self.connection_manager.profile = None
         client_1 = self.connection_manager._get_client(
-            service, region, profile
+            service, region, profile, stack
         )
         client_2 = self.connection_manager._get_client(
-            service, region, profile
+            service, region, profile, stack
         )
         assert client_1 == client_2
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -19,7 +19,6 @@ class TestConnectionManager(object):
         self.region = "eu-west-1"
 
         ConnectionManager._boto_sessions = {}
-        ConnectionManager._stack_keys = {}
         ConnectionManager._clients = {}
 
         self.connection_manager = ConnectionManager(
@@ -35,7 +34,6 @@ class TestConnectionManager(object):
         assert connection_manager.profile is None
         assert connection_manager.region == sentinel.region
         assert connection_manager._boto_sessions == {}
-        assert connection_manager._stack_keys == {}
         assert connection_manager._clients == {}
 
     def test_connection_manager_initialised_with_all_parameters(self):
@@ -49,9 +47,6 @@ class TestConnectionManager(object):
         assert connection_manager.profile == "profile"
         assert connection_manager.region == self.region
         assert connection_manager._boto_sessions == {}
-        assert connection_manager._stack_keys == {
-            "stack": (self.region, "profile")
-        }
         assert connection_manager._clients == {}
 
     def test_repr(self):
@@ -167,21 +162,6 @@ class TestConnectionManager(object):
         command = 'list_buckets'
 
         return_value = self.connection_manager.call(service, command, {})
-        assert return_value['ResponseMetadata']['HTTPStatusCode'] == 200
-
-    @mock_s3
-    def test_call_with_valid_service_and_stack_name_call(self):
-        service = 's3'
-        command = 'list_buckets'
-
-        connection_manager = ConnectionManager(
-            region=self.region,
-            stack_name='stack'
-        )
-
-        return_value = connection_manager.call(
-            service, command, {}, stack_name='stack'
-        )
         assert return_value['ResponseMetadata']['HTTPStatusCode'] == 200
 
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -18,6 +18,10 @@ class TestConnectionManager(object):
         self.profile = None
         self.region = "eu-west-1"
 
+        ConnectionManager._boto_sessions = {}
+        ConnectionManager._stack_keys = {}
+        ConnectionManager._clients = {}
+
         self.connection_manager = ConnectionManager(
             region=self.region,
             stack_name=self.stack_name,
@@ -40,6 +44,7 @@ class TestConnectionManager(object):
             stack_name="stack",
             profile="profile"
         )
+
         assert connection_manager.stack_name == "stack"
         assert connection_manager.profile == "profile"
         assert connection_manager.region == self.region

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -96,7 +96,7 @@ class TestStackOutputExternalResolver(object):
         mock_get_output_value.return_value = "output_value"
         stack_output_external_resolver.resolve()
         mock_get_output_value.assert_called_once_with(
-            "another/account-vpc", "VpcId"
+            "another/account-vpc", "VpcId", None
         )
         assert stack.dependencies == []
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -50,7 +50,7 @@ class TestStack(object):
             external_name=sentinel.external_name
         )
         self.mock_ConnectionManager.assert_called_with(
-            sentinel.region, None
+            sentinel.region, None, sentinel.external_name
         )
         assert stack.name == sentinel.stack_name
         assert stack.project_code == sentinel.project_code

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -29,7 +29,7 @@ class TestStack(object):
         self.stack = Stack(
             name=sentinel.stack_name, project_code=sentinel.project_code,
             template_path=sentinel.template_path, region=sentinel.region,
-            iam_role=sentinel.iam_role, parameters={"key1": "val1"},
+            profile=sentinel.profile, parameters={"key1": "val1"},
             sceptre_user_data=sentinel.sceptre_user_data, hooks={},
             s3_details=None, dependencies=sentinel.dependencies,
             role_arn=sentinel.role_arn, protected=False,
@@ -70,7 +70,7 @@ class TestStack(object):
 
     def test_repr(self):
         self.stack.connection_manager.region = sentinel.region
-        self.stack.connection_manager.iam_role = None
+        self.stack.connection_manager.profile = sentinel.profile
 
         assert self.stack.__repr__() == \
             "sceptre.stack.Stack(" \
@@ -78,7 +78,7 @@ class TestStack(object):
             "project_code='sentinel.project_code', " \
             "template_path='sentinel.template_path', " \
             "region='sentinel.region', " \
-            "iam_role='None', parameters='{'key1': 'val1'}', " \
+            "profile='sentinel.profile', parameters='{'key1': 'val1'}', " \
             "sceptre_user_data='sentinel.sceptre_user_data', " \
             "hooks='{}', s3_details='None', " \
             "dependencies='sentinel.dependencies', "\


### PR DESCRIPTION
This will deprecate the original functionality of using `iam_role` and instead allow the user to use an AWS Profile (supported by `boto` and `awscli`). The profile itself is usually defined in the `~/.aws/config` file (prefixed with `profile <name>`) but could be placed anywhere with the use of `AWS_CONFIG_FILE` which specifies the path to the configuration file.

This will break any sort of compatibility with the use of `iam_role` and instead a profile has to be created. The profile can be added to the sceptre configuration file in the same manner as the `iam_role` used to. 

The current level of precedence is as follows (and is all according to the default AWS Config/CLI behaviour linked below):
  1. Environment variable credentials take priority over profiles
  2. Region specified in the Sceptre `Stack` configuration will take priority over the one specified in the profile
  3. Profile takes priority last 

You are able to specify a profile which can target a different account and region while providing credentials through environment variables, instance role or else as required. More information on AWS profiles, configuration and credentials can be found [here](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html).

Example stack configuration:

```yaml
profile: development-profile
project_code: cost-code
```

As far as the the YAML / sceptre resolver tag are concerned:
-  `!stack_output` should work as intended with full cross account/region functionality. 
- `!stack_output_external` has been redesigned slightly, it can now take in an optional 2nd arg, which is the profile. Example: `SomeParam: !stack_output_external SomeStack::Output SomeProfile` where `SomeProfile` is the profile defined in your AWS Config file to use for fetching that specific stack output. If the last argument isn't supplied then it is assumed to use whatever default is available.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
