### PR TITLE
[Resolves #336] Lint integration tests and docs (#320)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ help:
 	@echo ""
 	@ $(MAKE) -C docs help
 
+
 clean: clean-build clean-pyc clean-test docs-clean
 
 clean-build:
@@ -52,7 +53,7 @@ clean-test:
 	rm -f test-results.xml
 
 lint:
-	flake8 sceptre tests
+	flake8 .
 	python setup.py check -r -s -m
 
 test:

--- a/docs/_api/conf.py
+++ b/docs/_api/conf.py
@@ -12,9 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -218,17 +215,17 @@ htmlhelp_basename = 'sceptredoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/integration-tests/steps/helpers.py
+++ b/integration-tests/steps/helpers.py
@@ -27,6 +27,11 @@ def step_impl(context, message):
         raise Exception("Step has incorrect message")
 
 
+@then('no exception is raised')
+def step_impl(context):
+    assert (context.error is None)
+
+
 @then('a "{exception_type}" is raised')
 def step_impl(context, exception_type):
     if exception_type == "TemplateSceptreHandlerError":

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click==6.6
 colorama==0.3.7
 coverage==4.4.2
 flake8==3.5.0
+flake8-per-file-ignores==0.4
 freezegun==0.3.9
 Jinja2>=2.8,<3
 mock>=2.0.0,<2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,15 @@ universal = 1
 [aliases]
 test = pytest
 
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    .tox,
+    venv
+max-complexity = 12
+per-file-ignores =
+    docs/_api/conf.py: E265
+    integration-tests/steps/*: F811,E501,F403,F405


### PR DESCRIPTION
Add flake8-per-file-ignores to requirements to ignore:
Long lines and duplicated defines needed for behave
docs/_api/config.py to comment the config consistently
set max-complexity to 12 to protect code quality

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
