### PR TITLE
[Resolves #187] Fix launch env dependency path

### DIFF
--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -303,14 +303,20 @@ class Environment(object):
         }
 
         # Filter out dependencies which aren't under the top level environmnent
-        launch_dependencies = {
-            stack_name: [
-                dependency
-                for dependency in dependencies
-                if dependency.startswith(top_level_environment_path)
-            ]
-            for stack_name, dependencies in all_dependencies.items()
-        }
+        launch_dependencies = {}
+
+        for stack_name, dependencies in all_dependencies.items():
+            stack_dependencies = []
+            for dependency in dependencies:
+                if dependency.startswith(top_level_environment_path):
+                    stack_dependencies.append(dependency)
+                # If there is no slash in path, head will be empty.
+                elif os.path.split(dependency)[0] == '':
+                    full_path_dependency = os.path.join(
+                            top_level_environment_path,
+                            dependency)
+                    stack_dependencies.append(full_path_dependency)
+            launch_dependencies.update({stack_name: stack_dependencies})
         return launch_dependencies
 
     def _get_delete_dependencies(self):

--- a/sceptre/environment.py
+++ b/sceptre/environment.py
@@ -308,7 +308,7 @@ class Environment(object):
         for stack_name, dependencies in all_dependencies.items():
             stack_dependencies = []
             for dependency in dependencies:
-                if dependency.startswith(top_level_environment_path):
+                if dependency.startswith(top_level_environment_path + '/'):
                     stack_dependencies.append(dependency)
                 # If there is no slash in path, head will be empty.
                 elif os.path.split(dependency)[0] == '':

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -365,11 +365,24 @@ class TestEnvironment(object):
             "name": StackStatus.PENDING
         }
 
+    def test_get_empty_launch_dependencies(self):
+        mock_stack = Mock()
+        mock_stack.name = "dev/mock_stack"
+        mock_stack.dependencies = []
+
+        self.environment.stacks = {"mock_stack": mock_stack}
+
+        response = self.environment._get_launch_dependencies("dev")
+
+        assert response == {
+            "dev/mock_stack": []
+        }
+
     def test_get_launch_dependencies(self):
         mock_stack = Mock()
         mock_stack.name = "dev/mock_stack"
         mock_stack.dependencies = [
-            "dev/vpc",
+            "vpc",
             "dev/subnets",
             "prod/sg"
         ]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -383,6 +383,7 @@ class TestEnvironment(object):
         mock_stack.name = "dev/mock_stack"
         mock_stack.dependencies = [
             "vpc",
+            "devsubnets",
             "dev/subnets",
             "prod/sg"
         ]
@@ -394,7 +395,7 @@ class TestEnvironment(object):
         # Note that "prod/sg" is filtered out, because it's not under the
         # top level environment path "dev".
         assert response == {
-            "dev/mock_stack": ["dev/vpc", "dev/subnets"]
+            "dev/mock_stack": ["dev/vpc", "dev/devsubnets", "dev/subnets"]
         }
 
     @patch("sceptre.environment.Environment._get_launch_dependencies")


### PR DESCRIPTION
As highlighted in #187, a user must specify a full path for stack
dependencies, even within the same environment. The documentation
shows the initial intention was to allow a user to reference the
stack name without the full path.

Given the following project structure:

config/
- config.yaml
- dev/
  - vpc.yaml
  - subnet.yaml
- templates/
  - vpc.yaml
  - subnet.yaml

Previously, a user had to specify dependencies in one of two ways:

```
dependencies:
    - dev/vpc
    - {{ environment_path.0 }}/subnet
```

This commit means that users can now specify dependencies as:

```
dependencies:
    - vpc
    - dev/subnet
    - {{ environment_path.0 }}/xyz
```

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
