### PR TITLE
[Resolves #414] Fix CLI return for update-stack-cs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -527,6 +527,58 @@ class TestCli(object):
         assert result.exit_code == 1
 
     @patch("sceptre.cli.os.getcwd")
+    @patch("sceptre.cli.uuid1")
+    @patch("sceptre.cli.get_env")
+    def test_update_with_change_set_with_stack_status_complete(
+        self, mock_get_env, mock_uuid1, mock_getcwd
+    ):
+        mock_getcwd.return_value = sentinel.cwd
+        mock_get_env.return_value.stacks["vpc"].wait_for_cs_completion\
+            .return_value = StackChangeSetStatus.READY
+        mock_get_env.return_value.stacks["vpc"].get_status\
+            .return_value = StackStatus.COMPLETE
+        mock_get_env.return_value.stacks["vpc"].describe_change_set\
+            .return_value = "description"
+        mock_uuid1().hex = "1"
+        result = self.runner.invoke(
+            cli, ["update-stack-cs", "dev", "vpc", "--verbose"], input="y"
+        )
+        mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
+        mock_get_env.return_value.stacks["vpc"].create_change_set\
+            .assert_called_with("change-set-1")
+        mock_get_env.return_value.stacks["vpc"].wait_for_cs_completion\
+            .assert_called_with("change-set-1")
+        mock_get_env.return_value.stacks["vpc"].execute_change_set\
+            .assert_called_with("change-set-1")
+        assert result.exit_code == 0
+
+    @patch("sceptre.cli.os.getcwd")
+    @patch("sceptre.cli.uuid1")
+    @patch("sceptre.cli.get_env")
+    def test_update_with_change_set_with_stack_status_failed(
+        self, mock_get_env, mock_uuid1, mock_getcwd
+    ):
+        mock_getcwd.return_value = sentinel.cwd
+        mock_get_env.return_value.stacks["vpc"].wait_for_cs_completion\
+            .return_value = StackChangeSetStatus.READY
+        mock_get_env.return_value.stacks["vpc"].get_status\
+            .return_value = StackStatus.FAILED
+        mock_get_env.return_value.stacks["vpc"].describe_change_set\
+            .return_value = "description"
+        mock_uuid1().hex = "1"
+        result = self.runner.invoke(
+            cli, ["update-stack-cs", "dev", "vpc", "--verbose"], input="y"
+        )
+        mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
+        mock_get_env.return_value.stacks["vpc"].create_change_set\
+            .assert_called_with("change-set-1")
+        mock_get_env.return_value.stacks["vpc"].wait_for_cs_completion\
+            .assert_called_with("change-set-1")
+        mock_get_env.return_value.stacks["vpc"].execute_change_set\
+            .assert_called_with("change-set-1")
+        assert result.exit_code == 1
+
+    @patch("sceptre.cli.os.getcwd")
     @patch("sceptre.cli.get_env")
     def test_describe_stack_outputs(self, mock_get_env, mock_getcwd):
         mock_getcwd.return_value = sentinel.cwd


### PR DESCRIPTION
The update-stack-cs command always exited with a `0` (success)
irrespective of whether the change-set executed successfully or not.

This commit updates the behavior to be consistent with `update-stack`
by checking the status of the stack after the change-set execution
is complete.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
