### PR TITLE
[Resolves #344] New `print-env-config` and `print-stack-config` commands

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -42,6 +42,8 @@ $ sceptre describe-stack-resources
 $ sceptre diff
 $ sceptre execute-change-set
 $ sceptre generate-template
+$ sceptre generate-env-config
+$ sceptre generate-stack-config
 $ sceptre get-stack-policy
 $ sceptre init
 $ sceptre launch-env

--- a/docs/docs/environment_config.md
+++ b/docs/docs/environment_config.md
@@ -192,6 +192,17 @@ Any templated value can be supplied with a default value with the syntax:
 ```
 
 
+### Display resolved environment config
+
+You can use the `generate-env-config` COMMAND to have Sceptre resolve all cascaded configurations and templated variables and print the final Environment configuration as YAML to stdout.
+
+This can be useful for debugging or inspection if you need to test how templating and/or cascading changes the final Environment configuration.
+
+```shell
+sceptre --var-file=prod.yaml --var region=us-east-1 generate-env-config path/to/environment
+```
+
+
 ## Examples
 
 ```yaml

--- a/docs/docs/stack_config.md
+++ b/docs/docs/stack_config.md
@@ -150,6 +150,19 @@ parameters:
 ```
 
 
+### Display resolved stack config
+
+You can use the `generate-stack-config` COMMAND to have Sceptre resolve all standard/custom resolvers and templated variables and print the final Stack configuration as YAML to stdout.
+
+This can be useful for debugging or inspection if you need to test how templating and/or resolvers changes the final Stack configuration.
+
+Note that this command will not display `parameters`, `sceptre_user_data` or `hooks` configurations since they use resolvers.
+
+```shell
+sceptre generate-stack-config path/to/environment some-stack
+```
+
+
 Environment Variables
 ---------------------
 
@@ -157,7 +170,7 @@ It is possible to replace values in stack config files with environment variable
 
 ## Sceptre User Data
 
-Python or Jinja templates can contain data which should be parameterised, but can't be parameterised using CloudFormation parameters. An example of this is if a Python template which creates an IAM Role reads in the policy from a JSON file. The file path must be hardcoded in the Python template.
+Python or Jinja templates can contain data which should be parameterized, but can't be parameterized using CloudFormation parameters. An example of this is if a Python template which creates an IAM Role reads in the policy from a JSON file. The file path must be hardcoded in the Python template.
 
 Sceptre user data allows users to store arbitrary key-value pairs in their `<stack-name>.yaml` file. This data is then passed as a Python `dict` to the `sceptre_handler(sceptre_user_data)` function in Python templates.
 

--- a/sceptre/cli.py
+++ b/sceptre/cli.py
@@ -617,6 +617,50 @@ def get_stack_policy(ctx, environment, stack):
     write(response.get('StackPolicyBody', {}))
 
 
+@cli.command(name="generate-env-config")
+@environment_options
+@click.pass_context
+@catch_exceptions
+def generate_env_config(ctx, environment):
+    """
+    Displays the ENVIRONMENT Configuration used.
+
+    Prints the ENVIRONMENT configuration as yaml after resolving all cascading
+    and templated configurations.
+    """
+    env = get_env(ctx.obj["sceptre_dir"], environment, ctx.obj["options"])
+    write(dict(env._get_config()), 'yaml')
+
+
+@cli.command(name="generate-stack-config")
+@stack_options
+@click.pass_context
+@catch_exceptions
+def generate_stack_config(ctx, environment, stack):
+    """
+    Displays the Stack Configuration used.
+
+    Prints the Stack configuration as yaml after resolving all
+    templated variables.
+
+    NOTE: The yaml output does NOT include any `parameters`, `hooks` or
+    `sceptre_user_data` configurations
+    """
+    env = get_env(ctx.obj["sceptre_dir"], environment, ctx.obj["options"])
+    stack = env.stacks[stack]
+    stack_config = dict(stack.config)
+    if 'parameters' in stack_config:
+        del stack_config['parameters']
+        stack_config['parameters'] = stack.parameters
+    if 'sceptre_user_data' in stack_config:
+        del stack_config['sceptre_user_data']
+        stack_config['sceptre_user_data'] = stack.sceptre_user_data
+    if 'hooks' in stack_config:
+        del stack_config['hooks']
+
+    write(stack_config, 'yaml')
+
+
 @cli.group(name="init")
 def init():
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,24 @@ class TestCli(object):
 
     @patch("sceptre.cli.os.getcwd")
     @patch("sceptre.cli.get_env")
+    def test_generate_stack_config(self, mock_get_env, mock_getcwd):
+        mock_getcwd.return_value = sentinel.cwd
+        result = self.runner.invoke(
+            cli, ["generate-stack-config", "dev", "vpc"]
+         )
+        mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
+        assert result.output == "{}\n\n"
+
+    @patch("sceptre.cli.os.getcwd")
+    @patch("sceptre.cli.get_env")
+    def test_generate_env_config(self, mock_get_env, mock_getcwd):
+        mock_getcwd.return_value = sentinel.cwd
+        result = self.runner.invoke(cli, ["generate-env-config", "dev"])
+        mock_get_env.assert_called_with(sentinel.cwd, "dev", {})
+        assert result.output == "{}\n\n"
+
+    @patch("sceptre.cli.os.getcwd")
+    @patch("sceptre.cli.get_env")
     def test_lock_stack(self, mock_get_env, mock_getcwd):
         mock_getcwd.return_value = sentinel.cwd
         self.runner.invoke(cli, ["lock-stack", "dev", "vpc"])


### PR DESCRIPTION
This PR introduces the following new commands:

* `print-env-config`

This command prints the final Environment configuration as YAML after resolving all cascaded configurations and templates.

* `print-stack-config`

This command prints the final Stack configuration as YAML after resolving all templated variables and/or custom/standard resolvers. Note that the YAML output does not include any `hooks` configurations.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
