### PR TITLE
[Resolve #198][for v1] Create changesets for non-existent stacks

### DIFF
--- a/integration-tests/features/create-change-set.feature
+++ b/integration-tests/features/create-change-set.feature
@@ -18,5 +18,4 @@ Feature: Create change set
     Given stack "1/A" does not exist
     and the template for stack "1/A" is "valid_template.json"
     When the user creates change set "A" for stack "1/A"
-    Then a "ClientError" is raised
-    and the user is told "stack does not exist"
+    Then stack "1/A" has change set "A" in "CREATE_COMPLETE" state

--- a/integration-tests/sceptre-project/templates/valid_template.yaml
+++ b/integration-tests/sceptre-project/templates/valid_template.yaml
@@ -1,4 +1,4 @@
 Resources:
     WaitConditionHandle:
       Type: "AWS::CloudFormation::WaitConditionHandle"
-      Properties:
+      Properties: {}

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -534,6 +534,12 @@ class Stack(object):
         }
         create_change_set_kwargs.update(self._get_template_details())
         create_change_set_kwargs.update(self._get_role_arn())
+
+        try:
+            self.get_status()
+        except StackDoesNotExistError:
+            create_change_set_kwargs["ChangeSetType"] = "CREATE"
+
         self.logger.debug(
             "%s - Creating change set '%s'", self.name, change_set_name
         )

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -705,15 +705,17 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             kwargs={"Template": sentinel.template}
         )
 
+    @patch("sceptre.stack.Stack.get_status")
     @patch("sceptre.stack.Stack._format_parameters")
     @patch("sceptre.stack.Stack._get_template_details")
     def test_create_change_set_sends_correct_request(
-        self, mock_get_template_details, mock_format_params
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
         mock_format_params.return_value = sentinel.parameters
         mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.return_value = "CREATED"
         self.stack.environment_config = {
             "template_bucket_name": sentinel.template_bucket_name,
             "template_key_prefix": sentinel.template_key_prefix
@@ -742,15 +744,17 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             }
         )
 
+    @patch("sceptre.stack.Stack.get_status")
     @patch("sceptre.stack.Stack._format_parameters")
     @patch("sceptre.stack.Stack._get_template_details")
     def test_create_change_set_sends_correct_request_no_notifications(
-            self, mock_get_template_details, mock_format_params
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
         mock_format_params.return_value = sentinel.parameters
         mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.return_value = "CREATED"
         self.stack.environment_config = {
             "template_bucket_name": sentinel.template_bucket_name,
             "template_key_prefix": sentinel.template_key_prefix
@@ -779,15 +783,25 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         )
 
     @patch("sceptre.stack.Stack.get_status")
-    def test_create_change_set_sends_correct_request_for_nonexistent_stack(
-        self, mock_get_status
+    @patch("sceptre.stack.Stack._format_parameters")
+    @patch("sceptre.stack.Stack._get_template_details")
+    def test_create_change_set_sends_correct_request_for_non_existant_stack(
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
-        self.get_status = mock_get_status
-        mock_get_status.side_effect = StackDoesNotExistError()
-
-        self.stack._template.get_boto_call_parameter.return_value = {
+        mock_format_params.return_value = sentinel.parameters
+        mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.side_effect = StackDoesNotExistError()
+        self.stack.environment_config = {
+            "template_bucket_name": sentinel.template_bucket_name,
+            "template_key_prefix": sentinel.template_key_prefix
+        }
+        self.stack._config = {
+            "stack_tags": {"tag1": "val1"}
+        }
+        self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.config["notifications"] = [sentinel.notification]
 
         self.stack.create_change_set(sentinel.change_set_name)
         self.stack.connection_manager.call.assert_called_with(
@@ -796,10 +810,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             kwargs={
                 "StackName": sentinel.external_name,
                 "Template": sentinel.template,
-                "Parameters": [{
-                    "ParameterKey": "key1",
-                    "ParameterValue": "val1"
-                }],
+                "Parameters": sentinel.parameters,
                 "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                 "ChangeSetName": sentinel.change_set_name,
                 "RoleARN": sentinel.role_arn,


### PR DESCRIPTION
This is a cleaner implementation than #240 and will result in less failed AWS calls

But backported for V1

I've run local integration tests, but not submitted changes to fix local running of tests, to avoid pulling in more changes

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
