### PR TITLE
[resolves #326][for V1] Auto create change when needed

### DIFF
--- a/integration-tests/features/create-change-set.feature
+++ b/integration-tests/features/create-change-set.feature
@@ -18,5 +18,4 @@ Feature: Create change set
     Given stack "1/A" does not exist
     and the template for stack "1/A" is "valid_template.json"
     When the user creates change set "A" for stack "1/A"
-    Then a "ClientError" is raised
-    and the user is told "stack does not exist"
+    Then stack "1/A" has change set "A" in "CREATE_COMPLETE" state

--- a/integration-tests/features/create-stack.feature
+++ b/integration-tests/features/create-stack.feature
@@ -6,6 +6,12 @@ Feature: Create stack
     When the user creates stack "1/A"
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
+  Scenario: create new stack with a change set
+    Given stack "1/A" does not exist
+    and the template for stack "1/A" is "valid_template_with_transform.yaml"
+    When the user creates stack "1/A"
+    Then stack "1/A" exists in "CREATE_COMPLETE" state
+
   Scenario: create a stack that already exists
     Given stack "1/A" exists in "CREATE_COMPLETE" state
     and the template for stack "1/A" is "valid_template.json"

--- a/integration-tests/features/launch-stack.feature
+++ b/integration-tests/features/launch-stack.feature
@@ -1,19 +1,45 @@
 Feature: Launch stack
 
-  Scenario: launch a new stack
+  Scenario Outline: launch a new stack
     Given stack "1/A" does not exist
-    and the template for stack "1/A" is "valid_template.json"
+    and the template for stack "1/A" is "<filename>"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a stack that was newly created
+  Examples: Template
+    | filename                           |
+    | valid_template.json                |
+    | valid_template_with_transform.yaml |
+
+  Scenario Outline:: launch a stack that was newly created
     Given stack "1/A" exists in "CREATE_COMPLETE" state
-    and the template for stack "1/A" is "updated_template.json"
+    and the template for stack "1/A" is "<filename>"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
 
-  Scenario: launch a stack that has been previously updated
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |
+
+  Scenario Outline: launch a stack that has been previously updated
     Given stack "1/A" exists in "UPDATE_COMPLETE" state
-    and the template for stack "1/A" is "valid_template.json"
+    and the template for stack "1/A" is "<filename>"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
+
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |
+
+  Scenario Outline: launch an existing stack with no changes
+    Given the template for stack "1/A" is "<filename>"
+    and stack "1/A" exists using "<filename>"
+    When the user launches stack "1/A"
+    Then no exception is raised
+
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |

--- a/integration-tests/features/update-stack.feature
+++ b/integration-tests/features/update-stack.feature
@@ -6,6 +6,12 @@ Feature: Update stack
     When the user updates stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
 
+  Scenario: update a stack that has been created and now has a change set
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and the template for stack "1/A" is "updated_template_with_transform.yaml"
+    When the user updates stack "1/A"
+    Then stack "1/A" exists in "UPDATE_COMPLETE" state
+
   Scenario: update a stack that has been previously updated
     Given stack "1/A" exists in "UPDATE_COMPLETE" state
     and the template for stack "1/A" is "updated_template.json"

--- a/integration-tests/sceptre-project/config/1/A.yaml
+++ b/integration-tests/sceptre-project/config/1/A.yaml
@@ -1,1 +1,1 @@
-template_path: templates/malformed_template.json
+template_path: templates/updated_template_with_transform.yaml

--- a/integration-tests/sceptre-project/config/7/A.yaml
+++ b/integration-tests/sceptre-project/config/7/A.yaml
@@ -1,3 +1,3 @@
 sceptre_user_data:
   type: AWS::CloudFormation::WaitConditionHandle
-template_path: templates/jinja/valid_template.j2
+template_path: templates/jinja/invalid_template_missing_attr.j2

--- a/integration-tests/sceptre-project/templates/jinja/valid_template.j2
+++ b/integration-tests/sceptre-project/templates/jinja/valid_template.j2
@@ -1,4 +1,4 @@
 Resources:
     WaitConditionHandle:
       Type: "{{ sceptre_user_data.type }}"
-      Properties:
+      Properties: {}

--- a/integration-tests/sceptre-project/templates/updated_template_with_transform.yaml
+++ b/integration-tests/sceptre-project/templates/updated_template_with_transform.yaml
@@ -1,0 +1,9 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  WaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Properties: {}
+  AnotherWaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Properties: {}

--- a/integration-tests/sceptre-project/templates/valid_template.yaml
+++ b/integration-tests/sceptre-project/templates/valid_template.yaml
@@ -1,4 +1,4 @@
 Resources:
     WaitConditionHandle:
       Type: "AWS::CloudFormation::WaitConditionHandle"
-      Properties:
+      Properties: {}

--- a/integration-tests/sceptre-project/templates/valid_template_with_transform.yaml
+++ b/integration-tests/sceptre-project/templates/valid_template_with_transform.yaml
@@ -1,0 +1,6 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  WaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Properties: {}

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -534,6 +534,12 @@ class Stack(object):
         }
         create_change_set_kwargs.update(self._get_template_details())
         create_change_set_kwargs.update(self._get_role_arn())
+
+        try:
+            self.get_status()
+        except StackDoesNotExistError:
+            create_change_set_kwargs["ChangeSetType"] = "CREATE"
+
         self.logger.debug(
             "%s - Creating change set '%s'", self.name, change_set_name
         )

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -705,15 +705,17 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             kwargs={"Template": sentinel.template}
         )
 
+    @patch("sceptre.stack.Stack.get_status")
     @patch("sceptre.stack.Stack._format_parameters")
     @patch("sceptre.stack.Stack._get_template_details")
     def test_create_change_set_sends_correct_request(
-        self, mock_get_template_details, mock_format_params
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
         mock_format_params.return_value = sentinel.parameters
         mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.return_value = "CREATED"
         self.stack.environment_config = {
             "template_bucket_name": sentinel.template_bucket_name,
             "template_key_prefix": sentinel.template_key_prefix
@@ -742,15 +744,17 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             }
         )
 
+    @patch("sceptre.stack.Stack.get_status")
     @patch("sceptre.stack.Stack._format_parameters")
     @patch("sceptre.stack.Stack._get_template_details")
     def test_create_change_set_sends_correct_request_no_notifications(
-            self, mock_get_template_details, mock_format_params
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
         mock_format_params.return_value = sentinel.parameters
         mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.return_value = "CREATED"
         self.stack.environment_config = {
             "template_bucket_name": sentinel.template_bucket_name,
             "template_key_prefix": sentinel.template_key_prefix
@@ -779,15 +783,25 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         )
 
     @patch("sceptre.stack.Stack.get_status")
-    def test_create_change_set_sends_correct_request_for_nonexistent_stack(
-        self, mock_get_status
+    @patch("sceptre.stack.Stack._format_parameters")
+    @patch("sceptre.stack.Stack._get_template_details")
+    def test_create_change_set_sends_correct_request_for_non_existant_stack(
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
-        self.get_status = mock_get_status
-        mock_get_status.side_effect = StackDoesNotExistError()
-
-        self.stack._template.get_boto_call_parameter.return_value = {
+        mock_format_params.return_value = sentinel.parameters
+        mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.side_effect = StackDoesNotExistError()
+        self.stack.environment_config = {
+            "template_bucket_name": sentinel.template_bucket_name,
+            "template_key_prefix": sentinel.template_key_prefix
+        }
+        self.stack._config = {
+            "stack_tags": {"tag1": "val1"}
+        }
+        self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.config["notifications"] = [sentinel.notification]
 
         self.stack.create_change_set(sentinel.change_set_name)
         self.stack.connection_manager.call.assert_called_with(
@@ -796,10 +810,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             kwargs={
                 "StackName": sentinel.external_name,
                 "Template": sentinel.template,
-                "Parameters": [{
-                    "ParameterKey": "key1",
-                    "ParameterValue": "val1"
-                }],
+                "Parameters": sentinel.parameters,
                 "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                 "ChangeSetName": sentinel.change_set_name,
                 "RoleARN": sentinel.role_arn,


### PR DESCRIPTION
Use change sets if the template requires it

Add template_summary property to templates
Add requires_change_sets property to templates
Add launch_with_change_set function to stacks
Change behaviour of Create/Update stacks to launch_with_change_set when requires_change_set property of it's template is true
By implementing this transparently at the stack level, this supports launch as well as create/update env commands

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
