### PR TITLE
[Resolves #249] Add error message for non-leaf env

### DIFF
--- a/contrib/kms-resolver/README.md
+++ b/contrib/kms-resolver/README.md
@@ -1,0 +1,36 @@
+---
+layout: docs
+title: Resolvers
+---
+
+# Overview
+
+The purpose of this resolver is to retrieve values from the AWS KMS. 
+
+## Available Resolvers
+
+### kms
+
+Fetches the value stored in AWS KMS.
+
+Syntax:
+
+```yaml
+parameter|sceptre_user_data:
+    <name>: !kms CIPHERTEXT
+```
+
+Example:
+
+Encrypt data with KMS to get a Ciphertext:
+```
+aws kms --key-id <KMS Key Id> --plaintext <data> --output text --query CiphertextBlob
+
+AQICAHhZyEsV0yflwE0mpKvPz7/O/zc1epgIurV43wXF/qF6MwFQYwZq7TrvtQ2....
+```
+
+Use sceptre to retrieve and decrypt the value from KMS:
+```
+parameters:
+    database_password: !kms AQICAHhZyEsV0yflwE0mpKvPz7/O/zc1epgIurV43wXF/qF6MwFQYwZq7TrvtQ2...
+```

--- a/contrib/kms-resolver/kms.py
+++ b/contrib/kms-resolver/kms.py
@@ -1,0 +1,32 @@
+from sceptre.resolvers import Resolver
+import base64
+
+
+class KMS(Resolver):
+    """
+    Resolver for KMS. Resolves data stored in KMS from a Ciphertext.
+
+    :param argument: The Ciphertext from KMS.
+    :type argument: str
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(KMS, self).__init__(*args, **kwargs)
+
+    def resolve(self):
+        """
+        Retrieves data from KMS.
+
+        :returns: Value from KMS.
+        :rtype: str
+        """
+        decoded_value = None
+        if self.argument:
+            ciphertext = self.argument
+            ciphertext_blob = base64.b64decode(ciphertext)
+            kms_client = self.connection_manager.boto_session.client('kms')
+            meta = kms_client.decrypt(CiphertextBlob=ciphertext_blob)
+            binary_value = meta[u'Plaintext']
+            decoded_value = binary_value.decode()
+        return decoded_value

--- a/contrib/ssm-resolver/README.md
+++ b/contrib/ssm-resolver/README.md
@@ -1,0 +1,35 @@
+---
+layout: docs
+title: Resolvers
+---
+
+# Overview
+
+The purpose of this resolver is to retrieve values from the AWS SSM. 
+
+## Available Resolvers
+
+### ssm
+
+Fetches the value stored in AWS SSM Parameter Store.
+
+Syntax:
+
+```yaml
+parameter|sceptre_user_data:
+    <name>: !ssm /prefix/param
+```
+
+Example:
+
+Add encrypted data to the parameter store:
+```
+aws ssm put-parameter --name <parameter prefix>/<parameter name> \
+--value <parameter value> --key-id <kms key id> --type "SecureString"
+```
+
+Use sceptre to retrieve and decrypt the value from SSM:
+```
+parameters:
+    database_password: !ssm /dev/DbPassword
+```

--- a/contrib/ssm-resolver/ssm.py
+++ b/contrib/ssm-resolver/ssm.py
@@ -1,0 +1,29 @@
+from sceptre.resolvers import Resolver
+
+
+class SSM(Resolver):
+    """
+    Resolver for SSM. Resolves the value stored in the parameter store.
+
+    :param argument: The SSM parameter
+    :type argument: str
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(SSM, self).__init__(*args, **kwargs)
+
+    def resolve(self):
+        """
+        Retrieves the parameter value from SSM Parameter Store.
+
+        :returns: parameter value
+        :rtype: str
+        """
+        decoded_value = None
+        if self.argument:
+            param = self.argument
+            ssm_client = self.connection_manager.boto_session.client('ssm')
+            meta = ssm_client.get_parameter(Name=param, WithDecryption=True)
+            decoded_value = meta['Parameter']['Value']
+        return decoded_value

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -21,6 +21,13 @@ class EnvironmentPathNotFoundError(SceptreException):
     pass
 
 
+class NonLeafEnvironmentError(SceptreException):
+    """
+    Error raised if a directory does not exist
+    """
+    pass
+
+
 class InvalidEnvironmentPathError(SceptreException):
     """
     Error raised if the environment path string is invalid


### PR DESCRIPTION
Previously, error messages were vauge when trying to take action on
non-leaf environments. This commit adds better error handling with a
more useful message for the end user.

-----------------

* [ ] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [ ] All unit tests (`make test`) are passing.
* [ ] Used the same coding conventions as the rest of the project.
* [ ] The new code doesn't generate flake8 (`make lint`) offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
