### PR TITLE
[Resolves #438] Add contrib to the sceptre package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     packages=[
         "sceptre",
         "sceptre/resolvers",
-        "sceptre/hooks"
+        "sceptre/hooks",
+        "contrib"
     ],
     package_dir={
         "sceptre": "sceptre"


### PR DESCRIPTION
 Contributions are in the same repo as core sceptre therefore it's
 versioned with core sceptre.  This would mean that it should also
 be released with sceptre.