### PR TITLE
[Resolves #439] Add session token to connection manager config

### DIFF
--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -122,7 +122,10 @@ class ConnectionManager(object):
                   "profile_name": profile,
                   "region_name": region,
                   "aws_access_key_id": environ.get("AWS_ACCESS_KEY_ID"),
-                  "aws_secret_access_key": environ.get("AWS_SECRET_ACCESS_KEY")
+                  "aws_secret_access_key": environ.get(
+                    "AWS_SECRET_ACCESS_KEY"
+                  ),
+                  "aws_session_token": environ.get("AWS_SESSION_TOKEN")
                 }
 
                 session = boto3.session.Session(**config)

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -84,7 +84,8 @@ class TestConnectionManager(object):
             profile_name=None,
             region_name="eu-west-1",
             aws_access_key_id=ANY,
-            aws_secret_access_key=ANY
+            aws_secret_access_key=ANY,
+            aws_session_token=ANY
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
@@ -101,7 +102,8 @@ class TestConnectionManager(object):
             profile_name="profile",
             region_name="eu-west-1",
             aws_access_key_id=ANY,
-            aws_secret_access_key=ANY
+            aws_secret_access_key=ANY,
+            aws_session_token=ANY
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")


### PR DESCRIPTION
There was a small issue introduced with the cross region support, namely if providing temporary AWS creds then it wouldn't work as the AWS session token was never included in the config manager when supplied via environment variables.

-----------------

* [x] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
