### PR TITLE
[Resolves #298] Fix stack config dependencies merging

### DIFF
--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -28,7 +28,7 @@ from . import strategies
 ConfigAttributes = collections.namedtuple("Attributes", "required optional")
 
 CONFIG_MERGE_STRATEGIES = {
-    'dependencies': strategies.child_wins,
+    'dependencies': strategies.list_join,
     'hooks': strategies.child_wins,
     'parameters': strategies.child_wins,
     'protect': strategies.child_wins,

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -159,9 +159,11 @@ class Config(dict):
 
         Traverses the environment path, from top to bottom, reading in all
         relevant config files. If config items appear in files lower down the
-        environment tree, they overwrite items from further up. Jinja2 is used
-        to template in variables from user_variables, environment variables,
-        and the segments of the environment path.
+        environment tree, they overwrite items from further up, depending on
+        the config merge strategy used.
+
+        Jinja2 is used to template in variables from user_variables,
+        environment variables, and the segments of the environment path.
 
         :param user_variables: A dict of key value pairs to be supplied to \
         the config file via Jinja2 templating.
@@ -209,6 +211,11 @@ class Config(dict):
                 return cascaded_config
 
         config = get_config(path)
+
+        config['dependencies'] = strategies.list_join(
+            self.get("dependencies"),
+            config.get("dependencies")
+        )
 
         self.update(config)
 

--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -23,8 +23,21 @@ from .exceptions import VersionIncompatibleError
 from .hooks import Hook
 from .resolvers import Resolver
 from .helpers import get_subclasses
+from . import strategies
 
 ConfigAttributes = collections.namedtuple("Attributes", "required optional")
+
+CONFIG_MERGE_STRATEGIES = {
+    'dependencies': strategies.child_wins,
+    'hooks': strategies.child_wins,
+    'parameters': strategies.child_wins,
+    'protect': strategies.child_wins,
+    'sceptre_user_data': strategies.child_wins,
+    'stack_name': strategies.child_wins,
+    'stack_tags': strategies.child_wins,
+    'role_arn': strategies.child_wins,
+    'template_path': strategies.child_wins
+}
 
 ENVIRONMENT_CONFIG_ATTRIBUTES = ConfigAttributes(
     {
@@ -185,6 +198,13 @@ class Config(dict):
                     if yaml_data is not None:
                         config = yaml_data
                 cascaded_config = get_config(os.path.dirname(path))
+                for config_key, strategy in CONFIG_MERGE_STRATEGIES.items():
+                    value = strategy(
+                        cascaded_config.get(config_key), config.get(config_key)
+                    )
+                    if value:
+                        cascaded_config[config_key] = value
+                        config.pop(config_key)
                 cascaded_config.update(config)
                 return cascaded_config
 

--- a/sceptre/strategies.py
+++ b/sceptre/strategies.py
@@ -1,8 +1,8 @@
 def list_join(a, b):
     if a and not isinstance(a, list):
-        raise TypeError(f'{a} is not a list')
+        raise TypeError('{} is not a list'.format(a))
     if b and not isinstance(b, list):
-        raise TypeError(f'{b} is not a list')
+        raise TypeError('{} is not a list'.format(b))
 
     if a is None:
         return b
@@ -15,9 +15,9 @@ def list_join(a, b):
 
 def dict_merge(a, b):
     if a and not isinstance(a, dict):
-        raise TypeError(f'{a} is not a dict')
+        raise TypeError('{} is not a list'.format(a))
     if b and not isinstance(b, dict):
-        raise TypeError(f'{b} is not a dict')
+        raise TypeError('{} is not a list'.format(b))
 
     if a is None:
         return b

--- a/sceptre/strategies.py
+++ b/sceptre/strategies.py
@@ -1,0 +1,32 @@
+def list_join(a, b):
+    if a and not isinstance(a, list):
+        raise TypeError(f'{a} is not a list')
+    if b and not isinstance(b, list):
+        raise TypeError(f'{b} is not a list')
+
+    if a is None:
+        return b
+
+    if b is not None:
+        return a + b
+
+    return a
+
+
+def dict_merge(a, b):
+    if a and not isinstance(a, dict):
+        raise TypeError(f'{a} is not a dict')
+    if b and not isinstance(b, dict):
+        raise TypeError(f'{b} is not a dict')
+
+    if a is None:
+        return b
+
+    if b is not None:
+        return a.update(b)
+
+    return a
+
+
+def child_wins(a, b):
+    return b


### PR DESCRIPTION
Previously, the `dependencies` data structure in stacks were not being merged properly. This resulted in issues, such as #298, being reported. For example, in the sceptre project displayed below, if `bundle/b/y.yaml` had a `!stack_ouput` from `bundle/a/x.yaml` an implicit dependency is created. If we then specified that `bundle/b/y.yaml` had a dependency on `bundle/a/x.yaml` the dependencies would not resolve properly. 

```
.
├── config
│   ├── bundle
│      ├── a
│      │   └── x.yaml
│      ├── b
│      │   └── y.yaml
│      ├── c
│      │   └── z.yaml
│      └── config.yaml
│   
├── templates
    └── template.json
```

The fix submitted with this commit gives us flexibility in dealing with different merge strategies for config items, if required in the future. 

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offences.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
