### PR TITLE
[Resolves #160] Improve output message for delete-change-set

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -570,8 +570,8 @@ class Stack(object):
         # If the call successfully completes, AWS CloudFormation
         # successfully deleted the change set.
         self.logger.info(
-            "%s - Successfully deleted change set '%s'",
-            self.name, change_set_name
+                "%s - Successfully deleted change set: '%s', if it existed.",
+                self.name, change_set_name
         )
 
     def describe_change_set(self, change_set_name):


### PR DESCRIPTION
There does not appear to be a suitable exception returned by AWS when
attempting to delete a change-set that does not exist. The AWS API
returns a 200 regardless of whether the change-set existed or not.

Therefore the best we can do is signal to the user that if the
change-set existed it has been deleted.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offences.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
