### PR TITLE
Bump pyyaml version to prevent failures on Python 3.7 enviroments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("HISTORY.rst") as history_file:
 install_requirements = [
     "boto3>=1.3.0,<2",
     "click==6.6",
-    "PyYaml==3.12",
+    "PyYaml==3.13",
     "Jinja2>=2.8,<3",
     "packaging==16.8",
     "colorama==0.3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py36,py37
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Also, build on 3.7