### PR TITLE
[Resolves #198, #240, #326] Auto create change-set & use

### DIFF
--- a/integration-tests/features/create-change-set.feature
+++ b/integration-tests/features/create-change-set.feature
@@ -18,5 +18,4 @@ Feature: Create change set
     Given stack "1/A" does not exist
     and the template for stack "1/A" is "valid_template.json"
     When the user creates change set "A" for stack "1/A"
-    Then a "ClientError" is raised
-    and the user is told "stack does not exist"
+    Then stack "1/A" has change set "A" in "CREATE_COMPLETE" state

--- a/integration-tests/features/create-stack.feature
+++ b/integration-tests/features/create-stack.feature
@@ -6,6 +6,12 @@ Feature: Create stack
     When the user creates stack "1/A"
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
+  Scenario: create new stack with a change set
+    Given stack "1/A" does not exist
+    and the template for stack "1/A" is "valid_template_with_transform.yaml"
+    When the user creates stack "1/A"
+    Then stack "1/A" exists in "CREATE_COMPLETE" state
+
   Scenario: create a stack that already exists
     Given stack "1/A" exists in "CREATE_COMPLETE" state
     and the template for stack "1/A" is "valid_template.json"

--- a/integration-tests/features/launch-stack.feature
+++ b/integration-tests/features/launch-stack.feature
@@ -1,19 +1,45 @@
 Feature: Launch stack
 
-  Scenario: launch a new stack
+  Scenario Outline: launch a new stack
     Given stack "1/A" does not exist
-    and the template for stack "1/A" is "valid_template.json"
+    and the template for stack "1/A" is "<filename>"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a stack that was newly created
+  Examples: Template
+    | filename                           |
+    | valid_template.json                |
+    | valid_template_with_transform.yaml |
+
+  Scenario Outline:: launch a stack that was newly created
     Given stack "1/A" exists in "CREATE_COMPLETE" state
-    and the template for stack "1/A" is "updated_template.json"
+    and the template for stack "1/A" is "<filename>"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
 
-  Scenario: launch a stack that has been previously updated
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |
+
+  Scenario Outline: launch a stack that has been previously updated
     Given stack "1/A" exists in "UPDATE_COMPLETE" state
-    and the template for stack "1/A" is "valid_template.json"
+    and the template for stack "1/A" is "<filename>"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
+
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |
+
+  Scenario Outline: launch an existing stack with no changes
+    Given the template for stack "1/A" is "<filename>"
+    and stack "1/A" exists using "<filename>"
+    When the user launches stack "1/A"
+    Then no exception is raised
+
+  Examples: Template
+    | filename                             |
+    | updated_template.json                |
+    | updated_template_with_transform.yaml |

--- a/integration-tests/features/update-stack.feature
+++ b/integration-tests/features/update-stack.feature
@@ -6,6 +6,12 @@ Feature: Update stack
     When the user updates stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
 
+  Scenario: update a stack that has been created and now has a change set
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and the template for stack "1/A" is "updated_template_with_transform.yaml"
+    When the user updates stack "1/A"
+    Then stack "1/A" exists in "UPDATE_COMPLETE" state
+
   Scenario: update a stack that has been previously updated
     Given stack "1/A" exists in "UPDATE_COMPLETE" state
     and the template for stack "1/A" is "updated_template.json"

--- a/integration-tests/sceptre-project/config/1/A.yaml
+++ b/integration-tests/sceptre-project/config/1/A.yaml
@@ -1,1 +1,1 @@
-template_path: templates/malformed_template.json
+template_path: templates/updated_template_with_transform.yaml

--- a/integration-tests/sceptre-project/config/7/A.yaml
+++ b/integration-tests/sceptre-project/config/7/A.yaml
@@ -1,3 +1,3 @@
 sceptre_user_data:
   type: AWS::CloudFormation::WaitConditionHandle
-template_path: templates/jinja/valid_template.j2
+template_path: templates/jinja/invalid_template_missing_attr.j2

--- a/integration-tests/sceptre-project/templates/jinja/valid_template.j2
+++ b/integration-tests/sceptre-project/templates/jinja/valid_template.j2
@@ -1,4 +1,4 @@
 Resources:
     WaitConditionHandle:
       Type: "{{ sceptre_user_data.type }}"
-      Properties:
+      Properties: {}

--- a/integration-tests/sceptre-project/templates/updated_template_with_transform.yaml
+++ b/integration-tests/sceptre-project/templates/updated_template_with_transform.yaml
@@ -1,0 +1,9 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  WaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Properties: {}
+  AnotherWaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Properties: {}

--- a/integration-tests/sceptre-project/templates/valid_template.yaml
+++ b/integration-tests/sceptre-project/templates/valid_template.yaml
@@ -1,4 +1,4 @@
 Resources:
     WaitConditionHandle:
       Type: "AWS::CloudFormation::WaitConditionHandle"
-      Properties:
+      Properties: {}

--- a/integration-tests/sceptre-project/templates/valid_template_with_transform.yaml
+++ b/integration-tests/sceptre-project/templates/valid_template_with_transform.yaml
@@ -1,0 +1,6 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  WaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Properties: {}

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -15,6 +15,7 @@ import time
 import threading
 
 from dateutil.tz import tzutc
+from uuid import uuid1
 import botocore
 
 from .config import Config
@@ -70,6 +71,7 @@ class Stack(object):
         self._hooks = None
         self._dependencies = None
         self._external_name = None
+        self._template_summary = None
 
     def __repr__(self):
         return (
@@ -190,32 +192,35 @@ class Stack(object):
         """
         self._protect_execution()
         self.logger.info("%s - Creating stack", self.name)
-        create_stack_kwargs = {
-            "StackName": self.external_name,
-            "Parameters": self._format_parameters(self.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
-            "NotificationARNs": self.config.get("notifications", []),
-            "Tags": [
-                {"Key": str(k), "Value": str(v)}
-                for k, v in self.config.get("stack_tags", {}).items()
-            ]
-        }
-        if "on_failure" in self.config:
-            create_stack_kwargs.update({
-                "OnFailure": self.config.get("on_failure")
-            })
-        create_stack_kwargs.update(self._get_template_details())
-        create_stack_kwargs.update(self._get_role_arn())
-        response = self.connection_manager.call(
-            service="cloudformation",
-            command="create_stack",
-            kwargs=create_stack_kwargs
-        )
-        self.logger.debug(
-            "%s - Create stack response: %s", self.name, response
-        )
+        if self.requires_change_set:
+            status = self.launch_using_change_set()
+        else:
+            create_stack_kwargs = {
+                "StackName": self.external_name,
+                "Parameters": self._format_parameters(self.parameters),
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "NotificationARNs": self.config.get("notifications", []),
+                "Tags": [
+                    {"Key": str(k), "Value": str(v)}
+                    for k, v in self.config.get("stack_tags", {}).items()
+                ]
+            }
+            if "on_failure" in self.config:
+                create_stack_kwargs.update({
+                    "OnFailure": self.config.get("on_failure")
+                })
+            create_stack_kwargs.update(self._get_template_details())
+            create_stack_kwargs.update(self._get_role_arn())
+            response = self.connection_manager.call(
+                service="cloudformation",
+                command="create_stack",
+                kwargs=create_stack_kwargs
+            )
+            self.logger.debug(
+                "%s - Create stack response: %s", self.name, response
+            )
 
-        status = self._wait_for_completion()
+            status = self._wait_for_completion()
 
         return status
 
@@ -229,28 +234,40 @@ class Stack(object):
         """
         self._protect_execution()
         self.logger.info("%s - Updating stack", self.name)
-        update_stack_kwargs = {
-            "StackName": self.external_name,
-            "Parameters": self._format_parameters(self.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
-            "NotificationARNs": self.config.get("notifications", []),
-            "Tags": [
-                {"Key": str(k), "Value": str(v)}
-                for k, v in self.config.get("stack_tags", {}).items()
-            ]
-        }
-        update_stack_kwargs.update(self._get_template_details())
-        update_stack_kwargs.update(self._get_role_arn())
-        response = self.connection_manager.call(
-            service="cloudformation",
-            command="update_stack",
-            kwargs=update_stack_kwargs
-        )
-        self.logger.debug(
-            "%s - Update stack response: %s", self.name, response
-        )
+        if self.requires_change_set:
+            try:
+                status = self.get_status()
+            except StackDoesNotExistError:
+                self.logger.warn(
+                    "%s - Can't update non-existant stack",
+                    self.name
+                )
+                status = "PENDING"
+            else:
+                status = self.launch_using_change_set()
+        else:
+            update_stack_kwargs = {
+                "StackName": self.external_name,
+                "Parameters": self._format_parameters(self.parameters),
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "NotificationARNs": self.config.get("notifications", []),
+                "Tags": [
+                    {"Key": str(k), "Value": str(v)}
+                    for k, v in self.config.get("stack_tags", {}).items()
+                ]
+            }
+            update_stack_kwargs.update(self._get_template_details())
+            update_stack_kwargs.update(self._get_role_arn())
+            response = self.connection_manager.call(
+                service="cloudformation",
+                command="update_stack",
+                kwargs=update_stack_kwargs
+            )
+            self.logger.debug(
+                "%s - Update stack response: %s", self.name, response
+            )
 
-        status = self._wait_for_completion()
+            status = self._wait_for_completion()
 
         return status
 
@@ -350,6 +367,29 @@ class Stack(object):
                 raise
         self.logger.info("%s - delete %s", self.name, status)
         return status
+
+    def launch_using_change_set(self, change_set_name=None):
+        """
+        Create/Update a stack using a change set
+
+        :param change_set_name: (optional) change-set-name to use
+        :returns: The change set's execution status.
+        :rtype: str
+        """
+        if change_set_name is None:
+            change_set_name = "-".join(["change-set", uuid1().hex])
+        self.create_change_set(change_set_name)
+        self.wait_for_cs_completion(change_set_name)
+        cs_status = self.describe_change_set(change_set_name)
+        if cs_status['Status'] == 'FAILED' and \
+                cs_status['StatusReason'] == 'No updates are to be performed.':
+            self.logger.info("%s - No updates to perform - deleting %s",
+                             self.name,
+                             change_set_name
+                             )
+            return self.delete_change_set(change_set_name)
+        else:
+            return self.execute_change_set(change_set_name)
 
     def lock(self):
         """
@@ -534,6 +574,12 @@ class Stack(object):
         }
         create_change_set_kwargs.update(self._get_template_details())
         create_change_set_kwargs.update(self._get_role_arn())
+
+        try:
+            self.get_status()
+        except StackDoesNotExistError:
+            create_change_set_kwargs["ChangeSetType"] = "CREATE"
+
         self.logger.debug(
             "%s - Creating change set '%s'", self.name, change_set_name
         )
@@ -695,6 +741,30 @@ class Stack(object):
             return {"TemplateURL": template_url}
         else:
             return {"TemplateBody": self.template.body}
+
+    @property
+    def get_template_summary(self):
+        """
+        The template summary
+        :returns: The template summary of the CloudFormation template.
+        :rtype: dict
+        """
+        if self._template_summary is None:
+            self._template_summary = self.connection_manager.call(
+                service="cloudformation",
+                command="get_template_summary",
+                kwargs=self._get_template_details()
+            )
+        return self._template_summary
+
+    @property
+    def requires_change_set(self):
+        """
+        Requires change set
+        :returns: whether the tempalte requires changes via change sets
+        :rtype: bool
+        """
+        return "DeclaredTransforms" in self.get_template_summary
 
     def _get_role_arn(self):
         """

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -5,6 +5,7 @@ from mock import patch, sentinel, Mock, MagicMock
 
 import datetime
 from dateutil.tz import tzutc
+from uuid import UUID
 
 from botocore.exceptions import ClientError
 
@@ -206,6 +207,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack._config = {"stack_tags": {
             "tag1": "val1"
         }}
+        self.stack._template_summary = {}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
         self.stack.config["notifications"] = [sentinel.notification]
@@ -246,6 +248,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack._config = {"stack_tags": {
             "tag1": "val1"
         }}
+        self.stack._template_summary = {}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
         self.stack.create()
@@ -285,6 +288,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack._config = {"stack_tags": {
             "tag1": "val1"
         }}
+        self.stack._template_summary = {}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
         self.stack.config["notifications"] = [sentinel.notification]
@@ -327,6 +331,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack._config = {"stack_tags": {
             "tag1": "val1"
         }}
+        self.stack._template_summary = {}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
         self.stack.config["notifications"] = [sentinel.notification]
@@ -367,6 +372,7 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         self.stack._config = {"stack_tags": {
             "tag1": "val1"
         }}
+        self.stack._template_summary = {}
         self.stack._hooks = {}
         self.stack.config["role_arn"] = sentinel.role_arn
 
@@ -388,11 +394,145 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         )
         mock_wait_for_completion.assert_called_once_with()
 
-    @patch("sceptre.stack.Stack.hooks")
+    @pytest.mark.parametrize("function",  ["create", "update"])
+    @patch("sceptre.stack.Stack.get_status")
+    @patch("sceptre.stack.Stack.launch_using_change_set")
+    def test_functions_calls_launch_using_change_set_when_required(
+            self, mock_launch_using_change_set, mock_get_status, function
+    ):
+        self.stack._config = {"protect": False}
+        self.stack._template_summary = {"DeclaredTransforms": []}
+        mock_get_status.return_value = "CREATE_COMPLETE"
+
+        self.stack.__getattribute__(function).__call__()
+
+        mock_launch_using_change_set.assert_called_once_with()
+
+    @patch("sceptre.stack.Stack.get_status")
+    @patch("sceptre.stack.Stack.launch_using_change_set")
+    def test_update_does_not_call_launch_using_change_set_when_non_existant(
+            self, mock_launch_using_change_set, mock_get_status
+    ):
+        self.stack._config = {"protect": False}
+        self.stack._template_summary = {"DeclaredTransforms": []}
+        mock_get_status.side_effect = StackDoesNotExistError()
+
+        self.stack.update()
+
+        mock_launch_using_change_set.assert_not_called()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_without_name(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._config = {"protect": False}
+        self.stack._template_summary = {"DeclaredTransforms": []}
+
+        mock_delete_change_set.return_value = {'Status': 'SUCCESS'}
+        mock_uuid.return_value = UUID(int=0)
+
+        self.stack.launch_using_change_set()
+
+        mock_uuid.assert_called_once()
+        mock_create_change_set.assert_called_once_with(
+            "change-set-00000000000000000000000000000000")
+        mock_wait_for_cs_completion.assert_called_once_with(
+            "change-set-00000000000000000000000000000000")
+        mock_execute_change_set.assert_called_once_with(
+            "change-set-00000000000000000000000000000000")
+        mock_delete_change_set.assert_not_called()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_with_name(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._config = {"protect": False}
+        self.stack._template_summary = {"DeclaredTransforms": []}
+        mock_describe_change_set.return_value = {'Status': 'SUCCESS'}
+
+        change_set_name = UUID(int=1)
+
+        self.stack.launch_using_change_set(change_set_name)
+
+        mock_uuid.asset_not_called()
+        mock_create_change_set.assert_called_once_with(change_set_name)
+        mock_wait_for_cs_completion.assert_called_once_with(change_set_name)
+        mock_execute_change_set.assert_called_once_with(change_set_name)
+        mock_delete_change_set.assert_not_called()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_with_name_and_failed_change_set(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._config = {"protect": False}
+        self.stack._template_summary = {"DeclaredTransforms": []}
+        mock_describe_change_set.return_value = {
+            'Status': 'FAILED', 'StatusReason': 'Invalid Template'
+        }
+
+        change_set_name = UUID(int=1)
+
+        self.stack.launch_using_change_set(change_set_name)
+
+        mock_uuid.asset_not_called()
+        mock_create_change_set.assert_called_once_with(change_set_name)
+        mock_wait_for_cs_completion.assert_called_once_with(change_set_name)
+        mock_execute_change_set.assert_called_once_with(change_set_name)
+        mock_delete_change_set.assert_not_called()
+
+    @patch('sceptre.stack.uuid1')
+    @patch("sceptre.stack.Stack.execute_change_set")
+    @patch("sceptre.stack.Stack.delete_change_set")
+    @patch("sceptre.stack.Stack.describe_change_set")
+    @patch("sceptre.stack.Stack.wait_for_cs_completion")
+    @patch("sceptre.stack.Stack.create_change_set")
+    def test_launch_using_change_set_with_name_and_no_changes(
+            self, mock_create_change_set, mock_wait_for_cs_completion,
+            mock_describe_change_set, mock_delete_change_set,
+            mock_execute_change_set, mock_uuid
+    ):
+        self.stack._config = {"protect": False}
+        self.stack._template_summary = {"DeclaredTransforms": []}
+        mock_describe_change_set.return_value = {
+            'Status': 'FAILED',
+            'StatusReason': 'No updates are to be performed.'
+        }
+
+        change_set_name = UUID(int=1)
+
+        self.stack.launch_using_change_set(change_set_name)
+
+        mock_uuid.asset_not_called()
+        mock_create_change_set.assert_called_once_with(change_set_name)
+        mock_wait_for_cs_completion.assert_called_once_with(change_set_name)
+        mock_execute_change_set.assert_not_called()
+        mock_delete_change_set.assert_called_once_with(change_set_name)
+
     @patch("sceptre.stack.Stack.create")
     @patch("sceptre.stack.Stack.get_status")
     def test_launch_with_stack_that_does_not_exist(
-            self, mock_get_status, mock_create, mock_hooks
+            self, mock_get_status, mock_create
     ):
         self.stack._config = {"protect": False}
         mock_get_status.side_effect = StackDoesNotExistError()
@@ -401,12 +541,11 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         mock_create.assert_called_once_with()
         assert response == sentinel.launch_response
 
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.create")
     @patch("sceptre.stack.Stack.delete")
     @patch("sceptre.stack.Stack.get_status")
     def test_launch_with_stack_that_failed_to_create(
-            self, mock_get_status, mock_delete, mock_create, mock_hooks
+            self, mock_get_status, mock_delete, mock_create
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_FAILED"
@@ -416,11 +555,10 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         mock_create.assert_called_once_with()
         assert response == sentinel.launch_response
 
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.update")
     @patch("sceptre.stack.Stack.get_status")
     def test_launch_with_complete_stack_with_updates_to_perform(
-            self, mock_get_status, mock_update, mock_hooks
+            self, mock_get_status, mock_update
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_COMPLETE"
@@ -429,11 +567,10 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         mock_update.assert_called_once_with()
         assert response == sentinel.launch_response
 
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.update")
     @patch("sceptre.stack.Stack.get_status")
     def test_launch_with_complete_stack_with_no_updates_to_perform(
-            self, mock_get_status, mock_update, mock_hooks
+            self, mock_get_status, mock_update
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_COMPLETE"
@@ -450,11 +587,10 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         mock_update.assert_called_once_with()
         assert response == StackStatus.COMPLETE
 
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.update")
     @patch("sceptre.stack.Stack.get_status")
     def test_launch_with_complete_stack_with_unknown_client_error(
-            self, mock_get_status, mock_update, mock_hooks
+            self, mock_get_status, mock_update
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_COMPLETE"
@@ -470,27 +606,24 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         with pytest.raises(ClientError):
             self.stack.launch()
 
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
-    def test_launch_with_in_progress_stack(self, mock_get_status, mock_hooks):
+    def test_launch_with_in_progress_stack(self, mock_get_status):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_IN_PROGRESS"
         response = self.stack.launch()
         assert response == StackStatus.IN_PROGRESS
 
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
-    def test_launch_with_failed_stack(self, mock_get_status, mock_hooks):
+    def test_launch_with_failed_stack(self, mock_get_status):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "UPDATE_FAILED"
         with pytest.raises(CannotUpdateFailedStackError):
             response = self.stack.launch()
             assert response == StackStatus.FAILED
 
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
     def test_launch_with_unknown_stack_status(
-            self, mock_get_status, mock_hooks
+            self, mock_get_status
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "UNKNOWN_STATUS"
@@ -498,10 +631,9 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             self.stack.launch()
 
     @patch("sceptre.stack.Stack._wait_for_completion")
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
     def test_delete_with_created_stack(
-            self, mock_get_status, mock_hooks, mock_wait_for_completion
+            self, mock_get_status, mock_wait_for_completion
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_COMPLETE"
@@ -517,10 +649,9 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         )
 
     @patch("sceptre.stack.Stack._wait_for_completion")
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
     def test_delete_when_wait_for_completion_raises_stack_does_not_exist_error(
-            self, mock_get_status, mock_hooks, mock_wait_for_completion
+            self, mock_get_status, mock_wait_for_completion
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_COMPLETE"
@@ -530,10 +661,9 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         assert status == StackStatus.COMPLETE
 
     @patch("sceptre.stack.Stack._wait_for_completion")
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
     def test_delete_when_wait_for_completion_raises_non_existent_client_error(
-            self, mock_get_status, mock_hooks, mock_wait_for_completion
+            self, mock_get_status, mock_wait_for_completion
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_COMPLETE"
@@ -551,10 +681,9 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
         assert status == StackStatus.COMPLETE
 
     @patch("sceptre.stack.Stack._wait_for_completion")
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
     def test_delete_when_wait_for_completion_raises_unexpected_client_error(
-            self, mock_get_status, mock_hooks, mock_wait_for_completion
+            self, mock_get_status, mock_wait_for_completion
     ):
         self.stack._config = {"protect": False}
         mock_get_status.return_value = "CREATE_COMPLETE"
@@ -572,10 +701,9 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             self.stack.delete()
 
     @patch("sceptre.stack.Stack._wait_for_completion")
-    @patch("sceptre.stack.Stack.hooks")
     @patch("sceptre.stack.Stack.get_status")
     def test_delete_with_non_existent_stack(
-            self, mock_get_status, mock_hooks, mock_wait_for_completion
+            self, mock_get_status, mock_wait_for_completion
     ):
         self.stack._config = {"protect": False}
         mock_get_status.side_effect = StackDoesNotExistError()
@@ -705,15 +833,17 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             kwargs={"Template": sentinel.template}
         )
 
+    @patch("sceptre.stack.Stack.get_status")
     @patch("sceptre.stack.Stack._format_parameters")
     @patch("sceptre.stack.Stack._get_template_details")
     def test_create_change_set_sends_correct_request(
-        self, mock_get_template_details, mock_format_params
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
         mock_format_params.return_value = sentinel.parameters
         mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.return_value = "CREATED"
         self.stack.environment_config = {
             "template_bucket_name": sentinel.template_bucket_name,
             "template_key_prefix": sentinel.template_key_prefix
@@ -742,15 +872,17 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
             }
         )
 
+    @patch("sceptre.stack.Stack.get_status")
     @patch("sceptre.stack.Stack._format_parameters")
     @patch("sceptre.stack.Stack._get_template_details")
     def test_create_change_set_sends_correct_request_no_notifications(
-            self, mock_get_template_details, mock_format_params
+        self, mock_get_template_details, mock_format_params, mock_get_status
     ):
         mock_format_params.return_value = sentinel.parameters
         mock_get_template_details.return_value = {
             "Template": sentinel.template
         }
+        mock_get_status.return_value = "CREATED"
         self.stack.environment_config = {
             "template_bucket_name": sentinel.template_bucket_name,
             "template_key_prefix": sentinel.template_key_prefix
@@ -775,6 +907,46 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
                 "Tags": [
                     {"Key": "tag1", "Value": "val1"}
                 ]
+            }
+        )
+
+    @patch("sceptre.stack.Stack.get_status")
+    @patch("sceptre.stack.Stack._format_parameters")
+    @patch("sceptre.stack.Stack._get_template_details")
+    def test_create_change_set_sends_correct_request_for_non_existant_stack(
+        self, mock_get_template_details, mock_format_params, mock_get_status
+    ):
+        mock_format_params.return_value = sentinel.parameters
+        mock_get_template_details.return_value = {
+            "Template": sentinel.template
+        }
+        mock_get_status.side_effect = StackDoesNotExistError()
+        self.stack.environment_config = {
+            "template_bucket_name": sentinel.template_bucket_name,
+            "template_key_prefix": sentinel.template_key_prefix
+        }
+        self.stack._config = {
+            "stack_tags": {"tag1": "val1"}
+        }
+        self.stack.config["role_arn"] = sentinel.role_arn
+        self.stack.config["notifications"] = [sentinel.notification]
+
+        self.stack.create_change_set(sentinel.change_set_name)
+        self.stack.connection_manager.call.assert_called_with(
+            service="cloudformation",
+            command="create_change_set",
+            kwargs={
+                "StackName": sentinel.external_name,
+                "Template": sentinel.template,
+                "Parameters": sentinel.parameters,
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "ChangeSetName": sentinel.change_set_name,
+                "RoleARN": sentinel.role_arn,
+                "NotificationARNs": [sentinel.notification],
+                "Tags": [
+                    {"Key": "tag1", "Value": "val1"}
+                ],
+                "ChangeSetType": "CREATE"
             }
         )
 
@@ -1015,16 +1187,31 @@ environment_config={'key': 'val'}, connection_manager=connection_manager)"
 
         assert template_details == {"TemplateURL": sentinel.template_url}
 
-    def test_get_template_details_without_upload(self):
-        self.stack._template = Mock(spec=Template)
-        self.stack._template.body = sentinel.body
+    @patch("sceptre.stack.Stack._get_template_details")
+    def test_get_template_summary(self, mock_get_template_details):
+        mock_get_template_details.return_value = sentinel._get_template_details
+        self.stack._template_summary = None
+
+        self.stack.get_template_summary()
+        self.stack.get_template_summary()
+
+        self.stack.connection_manager.call.assert_called_with(
+            service="cloudformation",
+            command="get_template_summary",
+            kwargs=sentinel._get_template_details
+        )
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ({"Parameters": []}, False),
+        ({"DeclaredTransforms": ["AWS::Serverless-2016-10-31"]}, True)
+    ])
+    def test_requires_change_set(self, test_input, expected):
+        self.stack._template_summary = test_input
         self.stack.environment_config = {
             "template_key_prefix": sentinel.template_key_prefix
         }
 
-        template_details = self.stack._get_template_details()
-
-        assert template_details == {"TemplateBody": sentinel.body}
+        assert self.stack.requires_change_set == expected
 
     def test_get_role_arn_without_role(self):
         self.stack._template = Mock(spec=Template)


### PR DESCRIPTION
This commit merges two PRs:

https://github.com/cloudreach/sceptre/pull/418
https://github.com/cloudreach/sceptre/pull/419

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offences.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
