### PR TITLE
[Resolves #456] Use full path for stack_group_path

### DIFF
--- a/sceptre/config_reader.py
+++ b/sceptre/config_reader.py
@@ -152,6 +152,7 @@ class ConfigReader(object):
         self.logger.debug("Reading in '%s' files...", rel_path)
         directory_path, filename = path.split(rel_path)
         abs_path = path.join(self.config_folder, rel_path)
+        self.stack_group_path = directory_path
 
         # Adding properties from class
         config = {
@@ -226,7 +227,7 @@ class ConfigReader(object):
             template = stack_group.get_template(basename)
             rendered_template = template.render(
                 environment_variable=environ,
-                stack_group_path=directory_path.split("/"),
+                stack_group_path=self.stack_group_path.split("/"),
                 **self.templating_vars
             )
 


### PR DESCRIPTION
[Resolves #456] Use full path for `stack_group_path` when rendering templates from all levels

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
