### PR TITLE
[Resolves #458] Remove depreciation warning

### DIFF
--- a/docs/docs/stack_config.md
+++ b/docs/docs/stack_config.md
@@ -135,10 +135,6 @@ The path to the CloudFormation, Jinja2 or Python template to build the stack fro
 
 ## Cascading Config
 
-<div class="alert alert-warning">
-Cascading stack config is being deprecated, and should not be used.
-</div>
-
 Stack config can be cascaded in the same way Environment config can be, as described in the section in Environment Config on [Cascading Config]({{ site.baseurl }}/docs/environment_config.html#cascading-config).
 
 


### PR DESCRIPTION
Previous authors had wanted to remove cascading config and added a
warning about this to the docs. This is no longer the case so removing
the warning.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offences.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.