### PR TITLE
[Resolves #187] Fix launch env dependency path

### DIFF
--- a/tests/test_stack_group.py
+++ b/tests/test_stack_group.py
@@ -282,7 +282,8 @@ class TestStackGroup(object):
         mock_stack.name = "dev/mock_stack"
 
         mock_stack.dependencies = [
-            "dev/vpc",
+            "vpc",
+            "devsubnets",
             "dev/subnets",
             "prod/sg"
         ]
@@ -294,7 +295,20 @@ class TestStackGroup(object):
         # Note that "prod/sg" is filtered out, because it's not under the
         # top level stack_group path "dev".
         assert response == {
-            "dev/mock_stack": ["dev/vpc", "dev/subnets"]
+            "dev/mock_stack": ["dev/vpc", "dev/devsubnets", "dev/subnets"]
+        }
+
+    def test_get_empty_launch_dependencies(self):
+        mock_stack = MagicMock(spec=Stack)
+        mock_stack.name = "dev/mock_stack"
+        mock_stack.dependencies = []
+
+        self.stack_group.stacks = [mock_stack]
+
+        response = self.stack_group._get_launch_dependencies("dev")
+
+        assert response == {
+            "dev/mock_stack": []
         }
 
     @patch("sceptre.stack_group.StackGroup._get_launch_dependencies")


### PR DESCRIPTION
As highlighted in #187, a user must specify a full path for stack
dependencies, even within the same environment. The documentation
shows the initial intention was to allow a user to reference the
stack name without the full path.

Given the following project structure:

config/
- config.yaml
- dev/
  - vpc.yaml
  - subnet.yaml
- templates/
  - vpc.yaml
  - subnet.yaml

Previously, a user had to specify dependencies in one of two ways:

``
dependencies:
    - dev/vpc
    - {{ environment_path.0 }}/subnet
``

This commit means that users can now specify dependencies as:

``
dependencies:
    - vpc
    - subnet
```

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offences.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.