### PR TITLE
[Resolves #461] Fix empty config merge KeyError

### DIFF
--- a/sceptre/config.py
+++ b/sceptre/config.py
@@ -204,9 +204,10 @@ class Config(dict):
                     value = strategy(
                         cascaded_config.get(config_key), config.get(config_key)
                     )
-                    if value:
+                    if value and config_key in config:
                         cascaded_config[config_key] = value
                         config.pop(config_key)
+
                 cascaded_config.update(config)
                 return cascaded_config
 

--- a/tests/fixtures/config/account/environment/config.yaml
+++ b/tests/fixtures/config/account/environment/config.yaml
@@ -1,1 +1,3 @@
 template_bucket_name: environment_template_bucket_name
+dependencies:
+  - top/level

--- a/tests/fixtures/config/account/environment/region/config.yaml
+++ b/tests/fixtures/config/account/environment/region/config.yaml
@@ -1,1 +1,3 @@
 region: region_region
+dependencies:
+  - child/level

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,7 +112,7 @@ class TestConfig(object):
             "project_code": "account_project_code",
             "iam_role": "account_iam_role",
             "require_version": ">=0a",
-            'dependencies': []
+            'dependencies': ['top/level', 'child/level']
         }
 
     def test_read_with_templated_config_file(self):


### PR DESCRIPTION
A small bug was introducted when ba00c01 was added.

There was a case where a KeyError was raised when trying to act on
a config file that is empty. This commit resolves this KeyError
issue and updates the tests.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offences.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
