### PR TITLE
[Resolve #445] add Dockerfile and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.6-alpine
+
+#
+# a simple image for running Sceptre without installing Python
+#
+# to build it:
+#   $ docker build . -t sceptre-local
+#
+# to then deploy it to Dockerhub after version X.Y.Z is released:
+#   $ docker login
+#   $ docker tag sceptre-local rgitzel/sceptre:X.Y.Z
+#   $ docker push rgitzel/sceptre:X.Y.Z
+#
+# if it's the newest version:
+#   $ docker tag sceptre-local rgitzel/sceptre:latest
+#   $ docker push rgitzel/sceptre:latest
+
+
+# we'll copy the repo files to here
+ARG SRC_FOLDER="/src"
+
+# expect the folder of Sceptre files to be mounted here
+ARG SCEPTRE_FOLDER="/sceptre"
+
+# copy the relevant files
+RUN mkdir $SRC_FOLDER
+COPY contrib $SRC_FOLDER/contrib
+COPY HISTORY.rst $SRC_FOLDER
+COPY Makefile $SRC_FOLDER
+COPY README.rst $SRC_FOLDER
+COPY requirements.txt $SRC_FOLDER
+COPY sceptre $SRC_FOLDER/sceptre
+COPY setup.* $SRC_FOLDER/
+
+# install from those files
+RUN pip install -e $SRC_FOLDER
+
+# Sceptre files should be here
+VOLUME ["$SCEPTRE_FOLDER"]
+WORKDIR $SCEPTRE_FOLDER
+
+ENTRYPOINT [ "sceptre" ]

--- a/README.rst
+++ b/README.rst
@@ -83,11 +83,16 @@ Sceptre provides environment-level commands. This one deletes the whole ``dev`` 
 Usage
 -----
 
-Sceptre can be used from the CLI, or imported as a Python package.
+Sceptre can be used directly from the command-line, via Docker, or imported as a Python package.
 
-CLI::
+Command-line
+^^^^^^^^^^^^
+.. code-block:: text
 
+  $ sceptre
   Usage: sceptre [OPTIONS] COMMAND [ARGS]...
+
+    Implements sceptre's CLI.
 
   Options:
   --version             Show the version and exit.
@@ -126,8 +131,21 @@ CLI::
   validate-template         Validate the template.
 
 
-Python:
+Docker
+^^^^^^
 
+Running Sceptre via Docker is useful in situations where you can't expect (or don't want) to install Python and the required libraries.
+::
+.. code-block:: text
+
+  $ docker run cloudreach/sceptre
+  Usage: sceptre [OPTIONS] COMMAND [ARGS]...
+
+For more information, see the `Docker image documentation <https://hub.docker.com/r/cloudreach/sceptre/>`_
+
+
+Python
+^^^^^^
 .. code-block:: python
 
   from sceptre.environment import Environment
@@ -136,7 +154,7 @@ Python:
   stack = env.stacks["stack_name"]
   stack.create()
 
-A full API description of the sceptre package can be found in the `Documentation <https://sceptre.cloudreach.com/latest/docs/index.html>`__.
+A full API description of the sceptre package can be found in the `Documentation <https://sceptre.cloudreach.com/latest/docs/index.html>`_.
 
 
 Install


### PR DESCRIPTION
This Dockerfile lets you run Sceptre without installing it. 

Note that the image needs to be published before the examples in the README will work.  

However, if you replace `cloudreach` with `rgitzel` in the Docker image names, the examples should work.

-----------------

* [ x ] Wrote [good commit messages][1].
* [ x] [Squashed related commits together][2] after the changes have been approved.
* [ x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [n/a] Added unit tests.
* [ n/a] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x ] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
