### PR TITLE
Implement SceptrePlan and Executor

### DIFF
--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -3,6 +3,7 @@ import click
 from sceptre.cli.helpers import catch_exceptions, confirmation
 from sceptre.cli.helpers import get_stack_or_stack_group
 from sceptre.stack_status import StackStatus
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.command(name="create")
@@ -25,9 +26,12 @@ def create_command(ctx, path, change_set_name, yes):
     stack, _ = get_stack_or_stack_group(ctx, path)
     if change_set_name:
         confirmation(action, yes, change_set=change_set_name, stack=path)
-        stack.create_change_set(change_set_name)
+        command = 'create_change_set'
+        plan = SceptrePlan(path, command, stack)
+        plan.execute(change_set_name)
     else:
         confirmation(action, yes, stack=path)
-        response = stack.create()
+        plan = SceptrePlan(path, action, stack)
+        response = plan.execute()
         if response != StackStatus.COMPLETE:
             exit(1)

--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -3,6 +3,7 @@ import click
 from sceptre.cli.helpers import catch_exceptions, get_stack_or_stack_group
 from sceptre.cli.helpers import confirmation
 from sceptre.stack_status import StackStatus
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.command(name="delete")
@@ -27,15 +28,19 @@ def delete_command(ctx, path, change_set_name, yes):
     if stack:
         if change_set_name:
             confirmation(action, yes, change_set=change_set_name, stack=path)
-            stack.delete_change_set(change_set_name)
+            command = 'delete_change_set'
+            plan = SceptrePlan(path, command, stack)
+            plan.execute(change_set_name)
         else:
             confirmation(action, yes, stack=path)
-            response = stack.delete()
+            plan = SceptrePlan(path, action, stack)
+            response = plan.execute()
             if response != StackStatus.COMPLETE:
                 exit(1)
     elif stack_group:
         confirmation(action, yes, stack_group=path)
-        response = stack_group.delete()
+        plan = SceptrePlan(path, action, stack_group)
+        response = plan.execute()
         if not all(
             status == StackStatus.COMPLETE for status in response.values()
         ):

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -3,9 +3,10 @@ import click
 from sceptre.cli.helpers import (
             catch_exceptions,
             get_stack_or_stack_group,
+            simplify_change_set_description,
             write
-          )
-from sceptre.cli.helpers import simplify_change_set_description
+            )
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.group(name="describe")
@@ -31,7 +32,9 @@ def describe_change_set(ctx, path, change_set_name, verbose):
 
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
-    description = stack.describe_change_set(change_set_name)
+    action = 'describe_change_set'
+    plan = SceptrePlan(path, action, stack)
+    description = plan.execute(change_set_name)
     if not verbose:
         description = simplify_change_set_description(description)
     write(description, ctx.obj["output_format"])
@@ -47,5 +50,7 @@ def describe_policy(ctx, path):
 
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
-    response = stack.get_policy()
+    action = 'get_policy'
+    plan = SceptrePlan(path, action, stack)
+    response = plan.execute()
     write(response.get('StackPolicyBody', {}))

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -2,6 +2,7 @@ import click
 
 from sceptre.cli.helpers import catch_exceptions, confirmation
 from sceptre.cli.helpers import get_stack_or_stack_group
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.command(name="execute")
@@ -19,4 +20,6 @@ def execute_command(ctx, path, change_set_name, yes):
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
     confirmation("execute", yes, change_set=change_set_name, stack=path)
-    stack.execute_change_set(change_set_name)
+    action = 'execute_change_set'
+    plan = SceptrePlan(path, action, stack)
+    plan.execute(change_set_name)

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -3,6 +3,7 @@ import click
 from sceptre.cli.helpers import catch_exceptions, get_stack_or_stack_group
 from sceptre.cli.helpers import confirmation
 from sceptre.stack_status import StackStatus
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.command(name="launch")
@@ -21,15 +22,16 @@ def launch_command(ctx, path, yes):
     action = "launch"
 
     stack, stack_group = get_stack_or_stack_group(ctx, path)
-
     if stack:
         confirmation(action, yes, stack=path)
-        response = stack.launch()
+        plan = SceptrePlan(path, action, stack)
+        response = plan.execute()
         if response != StackStatus.COMPLETE:
             exit(1)
     elif stack_group:
         confirmation(action, yes, stack_group=path)
-        response = stack_group.launch()
+        plan = SceptrePlan(path, action, stack_group)
+        response = plan.execute()
         if not all(
             status == StackStatus.COMPLETE for status in response.values()
         ):

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -5,6 +5,7 @@ from sceptre.cli.helpers import (
           get_stack_or_stack_group,
           write
         )
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.group(name="list")
@@ -27,11 +28,14 @@ def list_resources(ctx, path):
     """
     stack, stack_group = get_stack_or_stack_group(ctx, path)
     output_format = ctx.obj["output_format"]
+    action = 'describe_resources'
 
     if stack:
-        write(stack.describe_resources(), output_format)
+        plan = SceptrePlan(path, action, stack)
+        write(plan.execute(), output_format)
     elif stack_group:
-        write(stack_group.describe_resources(), output_format)
+        plan = SceptrePlan(path, action, stack_group)
+        write(plan.execute(), output_format)
 
 
 @list_group.command(name="outputs")
@@ -48,7 +52,9 @@ def list_outputs(ctx, path, export):
 
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
-    response = stack.describe_outputs()
+    action = 'describe_outputs'
+    plan = SceptrePlan(path, action, stack)
+    response = plan.execute()
 
     if export == "envvar":
         write("\n".join(
@@ -73,7 +79,10 @@ def list_change_sets(ctx, path):
 
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
-    response = stack.list_change_sets()
+    action = 'list_change_sets'
+    plan = SceptrePlan(path, action, stack)
+    response = plan.execute()
+
     if response['ResponseMetadata']['HTTPStatusCode'] == 200:
         del response['ResponseMetadata']
     write(response, ctx.obj["output_format"])

--- a/sceptre/cli/policy.py
+++ b/sceptre/cli/policy.py
@@ -1,6 +1,7 @@
 import click
 
 from sceptre.cli.helpers import catch_exceptions, get_stack_or_stack_group
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.command(name="set-policy")
@@ -21,8 +22,14 @@ def set_policy_command(ctx, path, policy_file, built_in):
     stack, _ = get_stack_or_stack_group(ctx, path)
 
     if built_in == 'deny-all':
-        stack.lock()
+        action = 'lock'
+        plan = SceptrePlan(path, action, stack)
+        plan.execute()
     elif built_in == 'allow-all':
-        stack.unlock()
+        action = 'unlock'
+        plan = SceptrePlan(path, action, stack)
+        plan.execute()
     else:
-        stack.set_policy(policy_file)
+        action = 'set_policy'
+        plan = SceptrePlan(path, action, stack)
+        plan.execute(policy_file)

--- a/sceptre/cli/status.py
+++ b/sceptre/cli/status.py
@@ -5,6 +5,7 @@ from sceptre.cli.helpers import (
      get_stack_or_stack_group,
      write
     )
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.command(name="status")
@@ -24,7 +25,11 @@ def status_command(ctx, path):
     stack, stack_group = get_stack_or_stack_group(ctx, path)
 
     if stack:
-        write(stack.get_status(), no_colour=no_colour)
+        command = 'get_status'
+        plan = SceptrePlan(path, command, stack)
+        write(plan.execute(), no_colour=no_colour)
     elif stack_group:
-        write(stack_group.describe(), output_format=output_format,
+        command = 'describe'
+        plan = SceptrePlan(path, command, stack_group)
+        write(plan.execute(), output_format=output_format,
               no_colour=no_colour)

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -6,6 +6,7 @@ from sceptre.cli.helpers import (
           get_stack_or_stack_group,
           write
         )
+from sceptre.plan.plan import SceptrePlan
 
 
 @click.command(name="validate")
@@ -19,7 +20,9 @@ def validate_command(ctx, path):
     Validates the template used for stack in PATH.
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
-    response = stack.template.validate()
+    action = 'validate'
+    plan = SceptrePlan(path, action, stack.template)
+    response = plan.execute()
     if response['ResponseMetadata']['HTTPStatusCode'] == 200:
         del response['ResponseMetadata']
         click.echo("Template is valid. Template details:\n")
@@ -37,7 +40,9 @@ def generate_command(ctx, path):
     Prints the template used for stack in PATH.
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
-    write(stack.template.body)
+    action = 'generate'
+    plan = SceptrePlan(path, action, stack.template)
+    write(plan.execute())
 
 
 @click.command(name="estimate-cost")
@@ -52,7 +57,9 @@ def estimate_cost_command(ctx, path):
     browser with the returned URI.
     """
     stack, _ = get_stack_or_stack_group(ctx, path)
-    response = stack.template.estimate_cost()
+    action = 'estimate_cost'
+    plan = SceptrePlan(path, action, stack.template)
+    response = plan.execute()
 
     if response['ResponseMetadata']['HTTPStatusCode'] == 200:
         del response['ResponseMetadata']

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -33,7 +33,7 @@ def update_command(ctx, path, change_set, verbose, yes):
 
     stack, _ = get_stack_or_stack_group(ctx, path)
     if change_set:
-        action = 'create_chage_set'
+        action = 'create_change_set'
         change_set_name = "-".join(["change-set", uuid1().hex])
         plan = SceptrePlan(path, action, stack)
         plan.execute(change_set_name)

--- a/sceptre/plan/__init__.py
+++ b/sceptre/plan/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+
+__author__ = 'Cloudreach'
+__email__ = 'sceptre@cloudreach.com'
+
+
+# Set up logging to ``/dev/null`` like a library is supposed to.
+# http://docs.python.org/3.3/howto/logging.html#configuring-logging-for-a-library
+class NullHandler(logging.Handler):  # pragma: no cover
+    def emit(self, record):
+        pass
+
+
+logging.getLogger('sceptre').addHandler(NullHandler())

--- a/sceptre/plan/executor.py
+++ b/sceptre/plan/executor.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+sceptre.plan.executor
+This module implements a SceptrePlanExecutor, which is responsible for
+executing the command specified in a SceptrePlan.
+"""
+
+
+class SceptrePlanExecutor(object):
+
+    def __init__(self):
+        pass
+
+    def execute(self, plan, *args):
+            return getattr(plan.subject, plan.command)(*args)

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+"""
+sceptre.plan.executor
+This module implements a SceptrePlanExecutor, which is responsible for
+executing the command specified in a SceptrePlan.
+"""
+
+from sceptre.config.graph import StackDependencyGraph
+from sceptre.plan.executor import SceptrePlanExecutor
+from sceptre.plan.type import PlanType
+from sceptre import stack, stack_group
+
+
+class SceptrePlan(SceptrePlanExecutor):
+    path = ""
+    dependencies = StackDependencyGraph()
+    launch_order = []
+    command = ""
+    plan_type = ""
+
+    def __init__(self, path, command, subject):
+        self.path = path
+        self.command = command
+        self.subject = subject
+        if isinstance(self.subject, stack.Stack):
+            self.plan_type = PlanType.STACK
+        elif isinstance(self.subject,
+                        stack_group.StackGroup):
+            self.plan_type = PlanType.STACK_GROUP
+
+    def execute(self, *args):
+        return super(SceptrePlan, self).execute(self, *args)

--- a/sceptre/plan/type.py
+++ b/sceptre/plan/type.py
@@ -1,0 +1,10 @@
+from enum import Enum
+from sceptre.stack import Stack
+from sceptre.stack_group import StackGroup
+from sceptre.template import Template
+
+
+class PlanType(Enum):
+    STACK_GROUP = StackGroup
+    STACK = Stack
+    TEMPLATE = Template

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -175,6 +175,9 @@ class Template(object):
 
         return url
 
+    def generate(self):
+        return self.body
+
     def _bucket_exists(self):
         """
         Checks if the bucket ``bucket_name`` exists.

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,66 @@
+import pytest
+from mock import Mock, patch, sentinel
+
+from sceptre.stack import Stack
+from sceptre.stack_group import StackGroup
+from sceptre.plan.plan import SceptrePlan
+from sceptre.plan.type import PlanType
+
+
+class TestSceptrePlan(object):
+
+    def setup_method(self, test_method):
+        self.patcher_SceptrePlanner = patch("sceptre.plan.plan.SceptrePlanner")
+        self.stack = Stack(
+            name=sentinel.stack_name, project_code=sentinel.project_code,
+            template_path=sentinel.template_path, region=sentinel.region,
+            profile=sentinel.profile, parameters={"key1": "val1"},
+            sceptre_user_data=sentinel.sceptre_user_data, hooks={},
+            s3_details=None, dependencies=sentinel.dependencies,
+            role_arn=sentinel.role_arn, protected=False,
+            tags={"tag1": "val1"}, external_name=sentinel.external_name,
+            notifications=[sentinel.notification],
+            on_failure=sentinel.on_failure,
+            stack_timeout=sentinel.stack_timeout
+        )
+
+        self.stack_group = StackGroup(
+            path="path",
+            options=sentinel.options
+        )
+
+    def test_planner_executes_without_params(self):
+        plan = SceptrePlan('test/path', 'test-command', self.stack_group)
+        plan.execute = Mock(name="execute")
+        plan.execute.return_value = sentinel.success
+
+        result = plan.execute()
+        plan.execute.assert_called_once_with()
+        assert result == sentinel.success
+
+    def test_planner_executes_with_params(self):
+        plan = SceptrePlan('test/path', 'test-command', self.stack_group)
+        plan.execute = Mock(name='execute')
+        plan.execute.return_value = sentinel.success
+
+        result = plan.execute('test-attribute')
+        plan.execute.assert_called_once_with('test-attribute')
+        assert result == sentinel.success
+
+    def test_stack_group_type_is_set(self):
+        plan = SceptrePlan('test/path', 'test-command', self.stack_group)
+        assert plan.plan_type == PlanType.STACK_GROUP
+
+    def test_stack_type_is_set(self):
+        plan = SceptrePlan('test/path', 'test-command', self.stack)
+        assert plan.plan_type == PlanType.STACK
+
+    def test_command_not_found_error_raised(self):
+        with pytest.raises(AttributeError):
+            plan = SceptrePlan('test/path', 'test-command', self.stack)
+            plan.execute()
+
+    def test_command_not_callable_error_raised(self):
+        with pytest.raises(TypeError):
+            plan = SceptrePlan('test/path', 'name', self.stack)
+            plan.execute()


### PR DESCRIPTION
Add SceptrePlan and Executor

    This PR is part of a wider piece of work that changes the way
    Sceptre will load and execute commands on stacks and stack groups.
    Between this commit and bf39d57f1591911799aad985f8e748fb7e2b8b4b sceptre
    will be able to preload all the objects and configuration necessary to
    execute an action, rather than taking actions on-the-fly, which is the
    behaviour in version 1.

-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.