### PR TITLE
Change cli init to new

### DIFF
--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -15,7 +15,7 @@ import colorama
 import yaml
 
 from sceptre import __version__
-from sceptre.cli.init import init_group
+from sceptre.cli.new import new_group
 from sceptre.cli.create import create_command
 from sceptre.cli.update import update_command
 from sceptre.cli.delete import delete_command
@@ -93,7 +93,7 @@ def cli(
             )
 
 
-cli.add_command(init_group)
+cli.add_command(new_group)
 cli.add_command(create_command)
 cli.add_command(update_command)
 cli.add_command(delete_command)

--- a/sceptre/cli/new.py
+++ b/sceptre/cli/new.py
@@ -9,8 +9,8 @@ from sceptre.cli.helpers import catch_exceptions
 from sceptre.exceptions import ProjectAlreadyExistsError
 
 
-@click.group(name="init")
-def init_group():
+@click.group(name="new")
+def new_group():
     """
     Commands for initialising Sceptre projects.
 
@@ -18,13 +18,13 @@ def init_group():
     pass
 
 
-@init_group.command("grp")
+@new_group.command("group")
 @click.argument('stack_group')
 @catch_exceptions
 @click.pass_context
-def init_stack_group(ctx, stack_group):
+def new_stack_group(ctx, stack_group):
     """
-    Initialises a stack_group in a project.
+    Creates a new Stack Group directory in a project.
 
     Creates STACK_GROUP folder in the project and a config.yaml with any
     required properties.
@@ -37,13 +37,13 @@ def init_stack_group(ctx, stack_group):
             _create_new_stack_group(config_dir, stack_group)
 
 
-@init_group.command("project")
+@new_group.command("project")
 @catch_exceptions
 @click.argument('project_name')
 @click.pass_context
-def init_project(ctx, project_name):
+def new_project(ctx, project_name):
     """
-    Initialises a new project.
+    Creates a new project.
     Creates PROJECT_NAME project folder and a config.yaml with any
     required properties.
     """
@@ -86,7 +86,7 @@ def _create_new_stack_group(config_dir, new_path):
     """
     # Create full path to stack_group
     folder_path = os.path.join(config_dir, new_path)
-    init_config_msg = 'Do you want initialise config.yaml?'
+    new_config_msg = 'Do you want initialise config.yaml?'
 
     # Make folders for the stack_group
     try:
@@ -94,12 +94,12 @@ def _create_new_stack_group(config_dir, new_path):
     except OSError as e:
         # Check if stack_group folder already exists
         if e.errno == errno.EEXIST:
-            init_config_msg =\
-              'StackGroup path exists. ' + init_config_msg
+            new_config_msg =\
+                'StackGroup path exists. ' + new_config_msg
         else:
             raise
 
-    if click.confirm(init_config_msg):
+    if click.confirm(new_config_msg):
         _create_config_file(config_dir, folder_path)
 
 

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -20,10 +20,9 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from sceptre import __version__
-from sceptre.exceptions import (
-    InvalidSceptreDirectoryError,
-    VersionIncompatibleError,
-    ConfigFileNotFoundError)
+from sceptre.exceptions import InvalidSceptreDirectoryError
+from sceptre.exceptions import VersionIncompatibleError
+from sceptre.exceptions import ConfigFileNotFoundError
 from sceptre.stack import Stack
 from . import strategies
 

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -4,7 +4,6 @@
 def get_external_stack_name(project_code, stack_name):
     """
     Returns the name given to a stack in CloudFormation.
-
     :param project_code: The project code, as defined in config.yaml.
     :type project_code: str
     :param stack_name: The name of the stack.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -424,7 +424,7 @@ class TestCli(object):
         assert result.exit_code == 0
         assert result.output == "mock-stack: status\n"
 
-    def test_init_project_non_existant(self):
+    def test_new_project_non_existant(self):
         with self.runner.isolated_filesystem():
             project_path = os.path.abspath('./example')
             config_dir = os.path.join(project_path, "config")
@@ -436,7 +436,7 @@ class TestCli(object):
                 "region": region
             }
 
-            result = self.runner.invoke(cli, ["init", "project", "example"])
+            result = self.runner.invoke(cli, ["new", "project", "example"])
             assert not result.exception
             assert os.path.isdir(config_dir)
             assert os.path.isdir(template_dir)
@@ -446,7 +446,7 @@ class TestCli(object):
 
             assert config == defaults
 
-    def test_init_project_already_exist(self):
+    def test_new_project_already_exist(self):
         with self.runner.isolated_filesystem():
             project_path = os.path.abspath('./example')
             config_dir = os.path.join(project_path, "config")
@@ -461,7 +461,7 @@ class TestCli(object):
             with open(config_filepath, 'w') as config_file:
                 yaml.dump(existing_config, config_file)
 
-            result = self.runner.invoke(cli, ["init", "project", "example"])
+            result = self.runner.invoke(cli, ["new", "project", "example"])
             assert result.exit_code == 1
             assert result.output == 'Folder \"example\" already exists.\n'
             assert os.path.isdir(config_dir)
@@ -471,12 +471,12 @@ class TestCli(object):
                 config = yaml.load(config_file)
             assert existing_config == config
 
-    def test_init_project_another_exception(self):
+    def test_new_project_another_exception(self):
         with self.runner.isolated_filesystem():
-            patcher_mkdir = patch("sceptre.cli.init.os.mkdir")
+            patcher_mkdir = patch("sceptre.cli.new.os.mkdir")
             mock_mkdir = patcher_mkdir.start()
             mock_mkdir.side_effect = OSError(errno.EINVAL)
-            result = self.runner.invoke(cli, ["init", "project", "example"])
+            result = self.runner.invoke(cli, ["new", "project", "example"])
             mock_mkdir = patcher_mkdir.stop()
             assert str(result.exception) == str(OSError(errno.EINVAL))
 
@@ -515,7 +515,7 @@ class TestCli(object):
             )
         ]
     )
-    def test_init_stack_group(
+    def test_create_new_stack_group_folder(
         self, stack_group, config_structure, stdin, result
     ):
         with self.runner.isolated_filesystem():
@@ -543,7 +543,7 @@ class TestCli(object):
             os.chdir(project_path)
 
             cmd_result = self.runner.invoke(
-                cli, ["init", "grp", stack_group],
+                cli, ["new", "group", stack_group],
                 input=stdin
             )
 
@@ -557,7 +557,7 @@ class TestCli(object):
                     "No config.yaml file needed - covered by parent config.\n"
                 )
 
-    def test_init_stack_group_with_existing_folder(self):
+    def test_new_stack_group_folder_with_existing_folder(self):
         with self.runner.isolated_filesystem():
             project_path = os.path.abspath('./example')
             config_dir = os.path.join(project_path, "config")
@@ -567,7 +567,7 @@ class TestCli(object):
             os.chdir(project_path)
 
             cmd_result = self.runner.invoke(
-                cli, ["init", "grp", "A"], input="y\n\n\n"
+                cli, ["new", "group", "A"], input="y\n\n\n"
             )
 
             assert cmd_result.output.startswith(
@@ -579,7 +579,7 @@ class TestCli(object):
                 config = yaml.load(config_file)
             assert config == {"project_code": "", "region": ""}
 
-    def test_init_stack_group_with_another_exception(self):
+    def test_new_stack_group_folder_with_another_exception(self):
         with self.runner.isolated_filesystem():
             project_path = os.path.abspath('./example')
             config_dir = os.path.join(project_path, "config")
@@ -587,10 +587,10 @@ class TestCli(object):
 
             os.makedirs(stack_group_dir)
             os.chdir(project_path)
-            patcher_mkdir = patch("sceptre.cli.init.os.mkdir")
+            patcher_mkdir = patch("sceptre.cli.new.os.mkdir")
             mock_mkdir = patcher_mkdir.start()
             mock_mkdir.side_effect = OSError(errno.EINVAL)
-            result = self.runner.invoke(cli, ["init", "grp", "A"])
+            result = self.runner.invoke(cli, ["new", "group", "A"])
             mock_mkdir = patcher_mkdir.stop()
             assert str(result.exception) == str(OSError(errno.EINVAL))
 


### PR DESCRIPTION
A small rename of `init` cli command group to `new`
-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
