### PR TITLE
Delete launch order

### DIFF
--- a/integration-tests/environment.py
+++ b/integration-tests/environment.py
@@ -24,6 +24,18 @@ def before_all(context):
     context.cloudformation = boto3.resource('cloudformation')
     context.client = boto3.client("cloudformation")
 
+    config_path = os.path.join(
+        context.sceptre_dir, "config", "9/B" + ".yaml"
+    )
+
+    with open(config_path, "r") as file:
+        file_data = file.read()
+
+    file_data = file_data.replace("{project_code}", context.project_code)
+
+    with open(config_path, "w") as file:
+        file.write(file_data)
+
 
 def before_scenario(context, scenario):
     os.environ.pop("AWS_REGION", None)

--- a/integration-tests/features/stack-output-external-resolver.feature
+++ b/integration-tests/features/stack-output-external-resolver.feature
@@ -4,6 +4,5 @@ Feature: Stack output external resolver
     Given stack_group "9" has AWS config "aws-config" set
     and stack "9/A" exists using "dependencies/independent_template.json"
     and stack "9/B" does not exist
-    and stack "9/B" has its project code resolved
     When the user launches stack "9/B"
     Then stack "9/B" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/stack-output-resolver.feature
+++ b/integration-tests/features/stack-output-resolver.feature
@@ -38,7 +38,6 @@ Feature: Stack output resolver
     and stack "6/1/C" does not exist
     When the user deletes stack "6/1/B"
     Then stack "6/1/B" does not exist
-    and stack "6/1/A" does not exist
 
   Scenario: delete a stack referencing an output of existing stack
     Given stack "6/1/A" exists in "CREATE_COMPLETE" state

--- a/integration-tests/steps/change_sets.py
+++ b/integration-tests/steps/change_sets.py
@@ -139,14 +139,14 @@ def step_impl(context, change_set_name, stack_name):
     allowed_errors = {'ValidationError', 'ChangeSetNotFound'}
 
     try:
-        sceptre_plan.describe_change_set(change_set_name)
+        responses = sceptre_plan.describe_change_set(change_set_name)
     except ClientError as e:
         if e.response['Error']['Code'] in allowed_errors:
             context.error = e
             return
         else:
             raise e
-    context.output = sceptre_plan.responses
+    context.output = responses
 
 
 @then('stack "{stack_name}" has change set "{change_set_name}" in "{state}" state')
@@ -196,10 +196,10 @@ def step_impl(context, change_set_name, stack_name):
     )
 
     del response["ResponseMetadata"]
-    for output in context.output:
+    for stack, output in context.output.items():
         del output["ResponseMetadata"]
 
-    for output in context.output:
+    for stack, output in context.output.items():
         assert response == output
 
 

--- a/integration-tests/steps/helpers.py
+++ b/integration-tests/steps/helpers.py
@@ -60,21 +60,6 @@ def step_impl(context, stack_group, config):
     os.environ['AWS_CONFIG_FILE'] = config_path
 
 
-@given('stack "{stack_name}" has its project code resolved')
-def step_impl(context, stack_name):
-    config_path = os.path.join(
-        context.sceptre_dir, "config", stack_name + ".yaml"
-    )
-
-    with open(config_path, "r") as file:
-        file_data = file.read()
-
-    file_data = file_data.replace("{project_code}", context.project_code)
-
-    with open(config_path, "w") as file:
-        file.write(file_data)
-
-
 def read_template_file(context, template_name):
     path = os.path.join(context.sceptre_dir, "templates", template_name)
     with open(path) as template:

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -139,6 +139,8 @@ def step_impl(context, stack_name):
     )
 
     sceptre_plan = SceptrePlan(sceptre_context)
+    sceptre_plan.resolve(command='delete', reverse=True)
+
     try:
         sceptre_plan.delete()
     except ClientError as e:

--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -39,10 +39,11 @@ def delete_command(ctx, path, change_set_name, yes):
     )
 
     plan = SceptrePlan(context)
+    plan.resolve(command='delete', reverse=True)
 
     dependencies = ''
-    for stacks in reversed(plan.launch_order):
-        for stack in reversed(list(stacks)):
+    for stacks in plan.launch_order:
+        for stack in stacks:
             dependencies += "{}{}{}\n".format(Fore.YELLOW, stack.name, Style.RESET_ALL)
 
     print("The following stacks in the following order will be deleted:\n{}".format(dependencies))

--- a/sceptre/config/graph.py
+++ b/sceptre/config/graph.py
@@ -36,6 +36,19 @@ class StackGraph(object):
     def __iter__(self):
         return self.graph.__iter__()
 
+    def filtered(self, source_stacks, reverse=False):
+        graph = (nx.reverse if reverse else nx.DiGraph)(self.graph)
+
+        relevant = set(source_stacks)
+        for stack in source_stacks:
+            relevant |= nx.algorithms.dag.ancestors(graph, stack)
+        graph.remove_nodes_from({stack for stack in graph if stack not in relevant})
+
+        filtered = StackGraph(set())
+        filtered.graph = graph
+
+        return filtered
+
     def count_dependencies(self, stack):
         """
         Returns the number of incoming edges a given Stack has in the
@@ -101,14 +114,3 @@ class StackGraph(object):
 
         if not dependencies:
             self.graph.add_node(stack)
-
-    def reverse_graph(self):
-        """
-        Reverses the direction of the edge in a StackGraph. Normally, an
-        edge represents a 'depends on' relationship. In reverse this is
-        'has dependency'. Useful when deleting Stacks.
-        """
-
-        rev = StackGraph(set())
-        rev.graph = nx.reverse(self.graph)
-        return rev

--- a/tests/fixtures-vpc/config/account/stack-group/config.yaml
+++ b/tests/fixtures-vpc/config/account/stack-group/config.yaml
@@ -1,0 +1,1 @@
+template_bucket_name: stack_group_template_bucket_name

--- a/tests/fixtures-vpc/config/account/stack-group/region/config.yaml
+++ b/tests/fixtures-vpc/config/account/stack-group/region/config.yaml
@@ -1,0 +1,3 @@
+region: region_region
+dependencies:
+  - top/level

--- a/tests/fixtures-vpc/config/account/stack-group/region/vpc.yaml
+++ b/tests/fixtures-vpc/config/account/stack-group/region/vpc.yaml
@@ -1,0 +1,5 @@
+template_path: path/to/template
+parameters:
+  param1: val1
+dependencies:
+  - "child/level"

--- a/tests/fixtures-vpc/config/config.yaml
+++ b/tests/fixtures-vpc/config/config.yaml
@@ -1,0 +1,4 @@
+profile: account_profile
+project_code: account_project_code
+region: account_region
+require_version: ">=0a"

--- a/tests/fixtures-vpc/config/top/level.yaml
+++ b/tests/fixtures-vpc/config/top/level.yaml
@@ -1,0 +1,1 @@
+template_path: somethingelse.py

--- a/tests/fixtures-vpc/hooks/custom_hook.py
+++ b/tests/fixtures-vpc/hooks/custom_hook.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+
+from sceptre.hooks import Hook
+
+
+class CustomHook(Hook):
+    """
+    This is a test task.
+
+    """
+    def __init__(self, *args, **kwargs):
+        super(CustomHook, self).__init__(*args, **kwargs)
+
+    def run(self):
+        """
+        Prints a statement
+
+        """
+        print("Custom task output")

--- a/tests/fixtures-vpc/resolvers/custom_resolver.py
+++ b/tests/fixtures-vpc/resolvers/custom_resolver.py
@@ -1,0 +1,9 @@
+from sceptre.resolvers import Resolver
+
+
+class CustomResolver(Resolver):
+    def __init__(self, *args, **kwargs):
+        super(CustomResolver, self).__init__(*args, **kwargs)
+
+    def resolve(self):
+        return "value"

--- a/tests/fixtures-vpc/stack_policies/lock.json
+++ b/tests/fixtures-vpc/stack_policies/lock.json
@@ -1,0 +1,10 @@
+{
+  "Statement" : [
+    {
+      "Effect" : "Deny",
+      "Action" : "Update:*",
+      "Principal": "*",
+      "Resource" : "*"
+    }
+  ]
+}

--- a/tests/fixtures-vpc/stack_policies/unlock.json
+++ b/tests/fixtures-vpc/stack_policies/unlock.json
@@ -1,0 +1,10 @@
+{
+  "Statement" : [
+    {
+      "Effect" : "Allow",
+      "Action" : "Update:*",
+      "Principal": "*",
+      "Resource" : "*"
+    }
+  ]
+}

--- a/tests/fixtures-vpc/templates/compiled_vpc.json
+++ b/tests/fixtures-vpc/templates/compiled_vpc.json
@@ -1,0 +1,43 @@
+{
+    "Outputs": {
+        "VpcId": {
+            "Description": "New VPC ID",
+            "Value": {
+                "Ref": "VirtualPrivateCloud"
+            }
+        }
+    },
+    "Parameters": {
+        "CidrBlock": {
+            "Default": "10.0.0.0/16",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "IGWAttachment": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "VirtualPrivateCloud"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "VirtualPrivateCloud": {
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "CidrBlock"
+                },
+                "EnableDnsHostnames": "true",
+                "EnableDnsSupport": "true",
+                "InstanceTenancy": "default"
+            },
+            "Type": "AWS::EC2::VPC"
+        }
+    }
+}

--- a/tests/fixtures-vpc/templates/compiled_vpc_sud.json
+++ b/tests/fixtures-vpc/templates/compiled_vpc_sud.json
@@ -1,0 +1,35 @@
+{
+    "Outputs": {
+        "VpcId": {
+            "Description": "New VPC ID",
+            "Value": {
+                "Ref": "VirtualPrivateCloud"
+            }
+        }
+    },
+    "Resources": {
+        "IGWAttachment": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "VirtualPrivateCloud"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "VirtualPrivateCloud": {
+            "Properties": {
+                "CidrBlock": "10.0.0.0/16",
+                "EnableDnsHostnames": "true",
+                "EnableDnsSupport": "true",
+                "InstanceTenancy": "default"
+            },
+            "Type": "AWS::EC2::VPC"
+        }
+    }
+}

--- a/tests/fixtures-vpc/templates/sg.j2
+++ b/tests/fixtures-vpc/templates/sg.j2
@@ -1,0 +1,7 @@
+Resources:
+    {% for sg in sceptre_user_data %}
+    {{ sg.name  }}:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+            InboundIp: {{ sg.inbound_ip  }}
+    {% endfor %}

--- a/tests/fixtures-vpc/templates/vpc.j2
+++ b/tests/fixtures-vpc/templates/vpc.j2
@@ -1,0 +1,9 @@
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ sceptre_user_data.vpc_id }}
+Outputs:
+  VpcId:
+    Value:
+      Ref: VPC

--- a/tests/fixtures-vpc/templates/vpc.json
+++ b/tests/fixtures-vpc/templates/vpc.json
@@ -1,0 +1,43 @@
+{
+    "Outputs": {
+        "VpcId": {
+            "Description": "New VPC ID",
+            "Value": {
+                "Ref": "VirtualPrivateCloud"
+            }
+        }
+    },
+    "Parameters": {
+        "CidrBlock": {
+            "Default": "10.0.0.0/16",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "IGWAttachment": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "VirtualPrivateCloud"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "VirtualPrivateCloud": {
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "CidrBlock"
+                },
+                "EnableDnsHostnames": "true",
+                "EnableDnsSupport": "true",
+                "InstanceTenancy": "default"
+            },
+            "Type": "AWS::EC2::VPC"
+        }
+    }
+}

--- a/tests/fixtures-vpc/templates/vpc.py
+++ b/tests/fixtures-vpc/templates/vpc.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from troposphere import Template, Parameter, Ref, Output
+
+from troposphere.ec2 import VPC, InternetGateway, VPCGatewayAttachment
+
+
+def sceptre_handler(sceptre_user_data):
+    t = Template()
+
+    cidr_block_param = t.add_parameter(Parameter(
+        "CidrBlock",
+        Type="String",
+        Default="10.0.0.0/16",
+    ))
+
+    vpc = t.add_resource(VPC(
+        "VirtualPrivateCloud",
+        CidrBlock=Ref(cidr_block_param),
+        InstanceTenancy="default",
+        EnableDnsSupport=True,
+        EnableDnsHostnames=True,
+    ))
+
+    igw = t.add_resource(InternetGateway(
+        "InternetGateway",
+    ))
+
+    t.add_resource(VPCGatewayAttachment(
+        "IGWAttachment",
+        VpcId=Ref(vpc),
+        InternetGatewayId=Ref(igw),
+    ))
+
+    t.add_output(Output(
+        "VpcId",
+        Description="New VPC ID",
+        Value=Ref(vpc)
+    ))
+    return t.to_json()

--- a/tests/fixtures-vpc/templates/vpc.template
+++ b/tests/fixtures-vpc/templates/vpc.template
@@ -1,0 +1,43 @@
+{
+    "Outputs": {
+        "VpcId": {
+            "Description": "New VPC ID",
+            "Value": {
+                "Ref": "VirtualPrivateCloud"
+            }
+        }
+    },
+    "Parameters": {
+        "CidrBlock": {
+            "Default": "10.0.0.0/16",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "IGWAttachment": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "VirtualPrivateCloud"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "VirtualPrivateCloud": {
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "CidrBlock"
+                },
+                "EnableDnsHostnames": "true",
+                "EnableDnsSupport": "true",
+                "InstanceTenancy": "default"
+            },
+            "Type": "AWS::EC2::VPC"
+        }
+    }
+}

--- a/tests/fixtures-vpc/templates/vpc.yaml
+++ b/tests/fixtures-vpc/templates/vpc.yaml
@@ -1,0 +1,28 @@
+---
+Outputs:
+  VpcId:
+    Description: New VPC ID
+    Value:
+      Ref: VirtualPrivateCloud
+Parameters:
+  CidrBlock:
+    Default: 10.0.0.0/16
+    Type: String
+Resources:
+  IGWAttachment:
+    Properties:
+      InternetGatewayId:
+        Ref: InternetGateway
+      VpcId:
+        Ref: VirtualPrivateCloud
+    Type: AWS::EC2::VPCGatewayAttachment
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+  VirtualPrivateCloud:
+    Properties:
+      CidrBlock:
+        Ref: CidrBlock
+      EnableDnsHostnames: 'true'
+      EnableDnsSupport: 'true'
+      InstanceTenancy: default
+    Type: AWS::EC2::VPC

--- a/tests/fixtures-vpc/templates/vpc.yaml.j2
+++ b/tests/fixtures-vpc/templates/vpc.yaml.j2
@@ -1,0 +1,9 @@
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ sceptre_user_data.vpc_id }}
+Outputs:
+  VpcId:
+    Value:
+      Ref: VPC

--- a/tests/fixtures-vpc/templates/vpc_sgt.py
+++ b/tests/fixtures-vpc/templates/vpc_sgt.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+from troposphere import Template, Parameter, Ref, Output
+
+from troposphere.ec2 import VPC, InternetGateway, VPCGatewayAttachment
+
+
+class VpcTemplate(object):
+
+    def __init__(self):
+        self.template = Template()
+
+        self.add_parameters()
+
+        self.add_vpc()
+        self.add_igw()
+
+        self.add_outputs()
+
+    def add_parameters(self):
+        t = self.template
+
+        self.cidr_block_param = t.add_parameter(Parameter(
+            "CidrBlock",
+            Type="String",
+            Default="10.0.0.0/16",
+        ))
+
+    def add_vpc(self):
+        t = self.template
+
+        self.vpc = t.add_resource(VPC(
+            "VirtualPrivateCloud",
+            CidrBlock=Ref(self.cidr_block_param),
+            InstanceTenancy="default",
+            EnableDnsSupport=True,
+            EnableDnsHostnames=True,
+        ))
+
+    def add_igw(self):
+        t = self.template
+
+        self.igw = t.add_resource(InternetGateway(
+            "InternetGateway",
+        ))
+
+        t.add_resource(VPCGatewayAttachment(
+            "IGWAttachment",
+            VpcId=Ref(self.vpc),
+            InternetGatewayId=Ref(self.igw),
+        ))
+
+    def add_outputs(self):
+        t = self.template
+
+        t.add_output(Output(
+            "VpcId",
+            Description="New VPC ID",
+            Value=Ref(self.vpc)
+        ))
+
+
+def sceptre_handler(sceptre_user_data):
+    vpc = VpcTemplate()
+    return vpc.template.to_json()

--- a/tests/fixtures-vpc/templates/vpc_sud.py
+++ b/tests/fixtures-vpc/templates/vpc_sud.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from troposphere import Template, Ref, Output
+
+from troposphere.ec2 import VPC, InternetGateway, VPCGatewayAttachment
+
+
+def sceptre_handler(sceptre_user_data):
+
+    t = Template()
+
+    vpc = t.add_resource(VPC(
+        "VirtualPrivateCloud",
+        CidrBlock=sceptre_user_data["cidr_block"],
+        InstanceTenancy="default",
+        EnableDnsSupport=True,
+        EnableDnsHostnames=True,
+    ))
+
+    igw = t.add_resource(InternetGateway(
+        "InternetGateway",
+    ))
+
+    t.add_resource(VPCGatewayAttachment(
+        "IGWAttachment",
+        VpcId=Ref(vpc),
+        InternetGatewayId=Ref(igw),
+    ))
+
+    t.add_output(Output(
+        "VpcId",
+        Description="New VPC ID",
+        Value=Ref(vpc)
+    ))
+
+    return t.to_json()

--- a/tests/fixtures-vpc/templates/vpc_sud_incorrect_function.py
+++ b/tests/fixtures-vpc/templates/vpc_sud_incorrect_function.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+
+def sceptre_incorrect_function():
+    pass

--- a/tests/fixtures-vpc/templates/vpc_sud_incorrect_handler.py
+++ b/tests/fixtures-vpc/templates/vpc_sud_incorrect_handler.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+
+def sceptre_handler():
+    pass

--- a/tests/fixtures-vpc/templates/vpc_t.py
+++ b/tests/fixtures-vpc/templates/vpc_t.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from troposphere import Template, Parameter, Ref, Output
+
+from troposphere.ec2 import VPC, InternetGateway, VPCGatewayAttachment
+
+t = Template()
+
+cidr_block_param = t.add_parameter(Parameter(
+    "CidrBlock",
+    Type="String",
+    Default="10.0.0.0/16",
+))
+
+vpc = t.add_resource(VPC(
+    "VirtualPrivateCloud",
+    CidrBlock=Ref(cidr_block_param),
+    InstanceTenancy="default",
+    EnableDnsSupport=True,
+    EnableDnsHostnames=True,
+))
+
+igw = t.add_resource(InternetGateway(
+    "InternetGateway",
+))
+
+igw_attachment = t.add_resource(VPCGatewayAttachment(
+    "IGWAttachment",
+    VpcId=Ref(vpc),
+    InternetGatewayId=Ref(igw),
+))
+
+vpc_id_output = t.add_output(Output(
+    "VpcId",
+    Description="New VPC ID",
+    Value=Ref(vpc)
+))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestCli(object):
         self.mock_stack.dependencies = []
 
         self.mock_config_reader.construct_stacks.return_value = \
-            set([self.mock_stack])
+            set([self.mock_stack]), set([self.mock_stack])
 
         self.mock_stack_actions.stack = self.mock_stack
 

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -199,14 +199,15 @@ class TestConfigReader(object):
         sentinel.stack.dependencies = []
 
         mock_collect_s3_details.return_value = sentinel.s3_details
-        self.context.project_path = os.path.abspath("tests/fixtures")
+        self.context.project_path = os.path.abspath("tests/fixtures-vpc")
         self.context.command_path = "account/stack-group/region/vpc.yaml"
         stacks = ConfigReader(self.context).construct_stacks()
-        mock_Stack.assert_called_with(
+
+        mock_Stack.assert_any_call(
             name="account/stack-group/region/vpc",
             project_code="account_project_code",
             template_path=os.path.join(
-                self.test_project_path, "templates/path/to/template"
+                self.context.project_path, "templates/path/to/template"
             ),
             region="region_region",
             profile="account_profile",

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -223,18 +223,17 @@ class TestConfigReader(object):
             on_failure=None,
             stack_timeout=0
         )
-        assert stacks == {sentinel.stack}
+        assert stacks == ({sentinel.stack}, {sentinel.stack})
 
-    @pytest.mark.parametrize("filepaths,targets,expected_stacks", [
-        (["A/1.yaml"], ["A"], {"A/1"}),
-        (["A/1.yaml", "A/2.yaml", "A/3.yaml"], ["A"], {"A/3", "A/2", "A/1"}),
-        (["A/1.yaml", "A/A/1.yaml"], ["A", "A/A"], {"A/1", "A/A/1"}),
-        (["A/1.yaml", "A/A/1.yaml", "A/A/2.yaml"], ["A", "A/A"],
-         {"A/1", "A/A/1", "A/A/2"}),
-        (["A/A/1.yaml", "A/B/1.yaml"], ["A", "A/A", "A/B"], {"A/A/1", "A/B/1"})
+    @pytest.mark.parametrize("filepaths,expected_stacks", [
+        (["A/1.yaml"], {"A/1"}),
+        (["A/1.yaml", "A/2.yaml", "A/3.yaml"], {"A/3", "A/2", "A/1"}),
+        (["A/1.yaml", "A/A/1.yaml"], {"A/1", "A/A/1"}),
+        (["A/1.yaml", "A/A/1.yaml", "A/A/2.yaml"], {"A/1", "A/A/1", "A/A/2"}),
+        (["A/A/1.yaml", "A/B/1.yaml"], {"A/A/1", "A/B/1"})
     ])
     def test_construct_stacks_with_valid_config(
-        self, filepaths, targets, expected_stacks
+        self, filepaths, expected_stacks
     ):
         with self.runner.isolated_filesystem():
             project_path = os.path.abspath('./example')
@@ -265,5 +264,5 @@ class TestConfigReader(object):
 
             self.context.project_path = project_path
             config_reader = ConfigReader(self.context)
-            stacks = config_reader.construct_stacks()
-            assert {str(stack) for stack in stacks} == expected_stacks
+            all_stacks, command_stacks = config_reader.construct_stacks()
+            assert {str(stack) for stack in all_stacks} == expected_stacks


### PR DESCRIPTION
When deleting a stack group we want to delete any stacks in the group,
but also any stacks that depend on those stacks. In order to identify
these stacks properly the configuration for all stacks is now loaded
into the StackGraph, and the launch order is computed by finding all the
stacks reachable from the stacks targetted by the given command path.

For deletion, this search is performed on the reversed graph, meaning
anything that depends on the stacks to be deleted will also be deleted,
as desired.

-----------------

* [ ] Wrote [good commit messages][1].
* [ ] [Squashed related commits together][2] after the changes have been approved.
* [ ] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [ ] Added unit tests.
* [ ] Added integration tests (if applicable).
* [ ] All unit tests (`make test`) are passing.
* [ ] Used the same coding conventions as the rest of the project.
* [ ] The new code doesn't generate flake8 (`make lint`) offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
