### PR TITLE
Remove unnecessary CLI output

### DIFF
--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -132,7 +132,7 @@ def setup_logging(debug, no_colour):
     formatter_class = logging.Formatter if no_colour else ColouredFormatter
 
     formatter = formatter_class(
-        fmt="[%(asctime)s] - %(name)s - %(message)s",
+        fmt="[%(asctime)s] - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S"
     )
 


### PR DESCRIPTION
Removes unnecessary CLI output from printing, mainly `... sceptre.plan.actions ...`

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
