### PR TITLE
[Resolves #522] Add ignore-dependencies flag

### DIFF
--- a/integration-tests/features/create-change-set.feature
+++ b/integration-tests/features/create-change-set.feature
@@ -20,3 +20,10 @@ Feature: Create change set
     When the user creates change set "A" for stack "1/A"
     Then a "ClientError" is raised
     and the user is told "stack does not exist"
+
+  Scenario: create new change set with updated template and ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and the template for stack "1/A" is "updated_template.json"
+    and stack "1/A" does not have change set "A"
+    When the user creates change set "A" for stack "1/A" with ignore dependencies
+    Then stack "1/A" has change set "A" in "CREATE_COMPLETE" state

--- a/integration-tests/features/create-stack.feature
+++ b/integration-tests/features/create-stack.feature
@@ -36,3 +36,9 @@ Feature: Create stack
     and the stack_timeout for stack "8/C" is "1"
     When the user creates stack "8/C"
     Then stack "8/C" exists in "ROLLBACK_COMPLETE" state
+
+  Scenario: create new stack that ignores dependencies 
+    Given stack "1/A" does not exist
+    and the template for stack "1/A" is "valid_template.json"
+    When the user creates stack "1/A" with ignore dependencies
+    Then stack "1/A" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/delete-change-set.feature
+++ b/integration-tests/features/delete-change-set.feature
@@ -5,6 +5,13 @@ Feature: Delete change set
     and stack "1/A" has change set "A" using "updated_template.json"
     When the user deletes change set "A" for stack "1/A"
     Then stack "1/A" does not have change set "A"
+      
+
+  Scenario: delete a change set that exists with ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and stack "1/A" has change set "A" using "updated_template.json"
+    When the user deletes change set "A" for stack "1/A" with ignore dependencies
+    Then stack "1/A" does not have change set "A"
 
   # @wip
   # Scenario: delete a change set that does not exist

--- a/integration-tests/features/delete-stack-group.feature
+++ b/integration-tests/features/delete-stack-group.feature
@@ -14,3 +14,8 @@ Feature: Delete stack_group
     Given stack "2/A" exists in "CREATE_COMPLETE" state
     When the user deletes stack_group "2"
     Then all the stacks in stack_group "2" do not exist
+
+  Scenario: delete a stack_group that already exists with ignore dependencies
+    Given all the stacks in stack_group "2" are in "CREATE_COMPLETE"
+    When the user deletes stack_group "2" with ignore dependencies
+    Then all the stacks in stack_group "2" do not exist

--- a/integration-tests/features/delete-stack.feature
+++ b/integration-tests/features/delete-stack.feature
@@ -9,3 +9,15 @@ Feature: Delete stack
     Given stack "1/A" does not exist
     When the user deletes stack "1/A"
     Then stack "1/A" does not exist
+
+  Scenario: delete a stack that exists with ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    When the user deletes stack "1/A" with ignore dependencies
+    Then stack "1/A" does not exist
+
+  Scenario: delete a stack that exists with dependencies ignoring dependencies
+    Given stack "4/C" exists in "CREATE_COMPLETE" state 
+    and stack "3/A" exists in "CREATE_COMPLETE" state 
+    and stack "3/A" depends on stack "4/C"
+    When the user deletes stack "4/C" with ignore dependencies
+    Then stack "4/C" does not exist and stack "3/A" exists in "CREATE_COMPLETE"

--- a/integration-tests/features/describe-change-set.feature
+++ b/integration-tests/features/describe-change-set.feature
@@ -12,3 +12,11 @@ Feature: Describe change sets
     When the user describes change set "A" for stack "1/A"
     Then a "ClientError" is raised
     and the user is told "change set does not exist"
+
+  Scenario: describe a change set that exists with ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and stack "1/A" has change set "A" using "updated_template.json"
+    When the user describes change set "A" for stack "1/A" with ignore dependencies
+    Then change set "A" for stack "1/A" is described
+
+

--- a/integration-tests/features/describe-stack-group-resources.feature
+++ b/integration-tests/features/describe-stack-group-resources.feature
@@ -16,3 +16,9 @@ Feature: Describe stack_group resources
     and stack "2/C" does not exist
     When the user describes resources in stack_group "2"
     Then only resources in stack "2/A" are described
+
+  Scenario: describe resources of a stack_group that already exists with ignore dependencies
+    Given all the stacks in stack_group "2" are in "CREATE_COMPLETE"
+    When the user describes resources in stack_group "2" with ignore dependencies
+    Then only all resources in stack_group "2" are described
+

--- a/integration-tests/features/describe-stack-group.feature
+++ b/integration-tests/features/describe-stack-group.feature
@@ -18,3 +18,9 @@ Feature: Describe stack_group
     Then stack "2/A" is described as "CREATE_COMPLETE"
     and stack "2/B" is described as "UPDATE_COMPLETE"
     and stack "2/C" is described as "PENDING"
+
+  Scenario: describe a stack_group that already exists with ignore dependencies
+    Given all the stacks in stack_group "2" are in "CREATE_COMPLETE"
+    When the user describes stack_group "2" with ignore dependencies
+    Then all stacks in stack_group "2" are described as "CREATE_COMPLETE"
+

--- a/integration-tests/features/describe-stack-resources.feature
+++ b/integration-tests/features/describe-stack-resources.feature
@@ -4,3 +4,8 @@ Feature: Describe-stack-resources
     Given stack "1/A" exists in "CREATE_COMPLETE" state
     When the user describes the resources of stack "1/A"
     Then the resources of stack "1/A" are described
+
+  Scenario: describe the resources of a stack that exists with ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    When the user describes the resources of stack "1/A" with ignore dependencies
+    Then the resources of stack "1/A" are described

--- a/integration-tests/features/execute-change-set.feature
+++ b/integration-tests/features/execute-change-set.feature
@@ -13,3 +13,11 @@ Feature: Execute change set
     When the user executes change set "A" for stack "1/A"
     Then a "ClientError" is raised
     and the user is told "change set does not exist"
+
+  Scenario: execute a change set that exists with ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and stack "1/A" has change set "A" using "updated_template.json"
+    When the user executes change set "A" for stack "1/A" with ignore dependencies
+    Then stack "1/A" does not have change set "A"
+    and stack "1/A" was updated with change set "A"
+

--- a/integration-tests/features/generate-template.feature
+++ b/integration-tests/features/generate-template.feature
@@ -21,6 +21,11 @@ Feature: Generate template
     When the user generates the template for stack "1/A"
     Then the output is the same as the string returned by "valid_template.py"
 
+  Scenario: Generate template using a valid python template file with ignore dependencies
+    Given the template for stack "1/A" is "valid_template.py"
+    When the user generates the template for stack "1/A" with ignore dependencies
+    Then the output is the same as the string returned by "valid_template.py"
+
   Scenario Outline: Generating erroneous python templates
     Given the template for stack "1/A" is "<filename>"
     When the user generates the template for stack "1/A"

--- a/integration-tests/features/launch-stack-group.feature
+++ b/integration-tests/features/launch-stack-group.feature
@@ -4,6 +4,11 @@ Feature: Launch stack_group
     Given stack_group "2" does not exist
     When the user launches stack_group "2"
     Then all the stacks in stack_group "2" are in "CREATE_COMPLETE"
+  
+  Scenario: launch a stack_group, excluding dependencies, that does not exist
+    Given stack_group "2" does not exist
+    When the user launches stack_group "2"
+    Then all the stacks in stack_group "2" are in "CREATE_COMPLETE"
 
   Scenario: launch a stack_group that already exists
     Given all the stacks in stack_group "2" are in "CREATE_COMPLETE"
@@ -37,3 +42,8 @@ Feature: Launch stack_group
     Given stack_group "5" does not exist
     When the user launches stack_group "5"
     Then all the stacks in stack_group "5" are in "CREATE_COMPLETE"
+
+  Scenario: launch a stack_group that does not exist ignoring dependencies
+    Given stack_group "2" does not exist
+    When the user launches stack_group "2" with ignore dependencies
+    Then all the stacks in stack_group "2" are in "CREATE_COMPLETE"

--- a/integration-tests/features/launch-stack.feature
+++ b/integration-tests/features/launch-stack.feature
@@ -17,3 +17,10 @@ Feature: Launch stack
     and the template for stack "1/A" is "valid_template.json"
     When the user launches stack "1/A"
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
+
+  Scenario: launch a new stack with ignore dependencies
+    Given stack "1/A" does not exist
+    and the template for stack "1/A" is "valid_template.json"
+    When the user launches stack "1/A" with ignore dependencies
+    Then stack "1/A" exists in "CREATE_COMPLETE" state
+

--- a/integration-tests/features/list-change-sets.feature
+++ b/integration-tests/features/list-change-sets.feature
@@ -11,3 +11,11 @@ Feature: List change sets
     and stack "1/A" has no change sets
     When the user lists change sets for stack "1/A"
     Then no change sets for stack "1/A" are listed
+
+  Scenario: list change sets on existing stack with change sets with ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and stack "1/A" has change set "A" using "updated_template.json"
+    When the user lists change sets for stack "1/A" with ignore dependencies
+    Then the change sets for stack "1/A" are listed
+
+

--- a/integration-tests/features/update-stack.feature
+++ b/integration-tests/features/update-stack.feature
@@ -24,3 +24,10 @@ Feature: Update stack
     and the stack_timeout for stack "1/A" is "1"
     When the user updates stack "1/A"
     Then stack "1/A" exists in "UPDATE_ROLLBACK_COMPLETE" state
+
+  Scenario: update a stack that was newly created with ignore dependencies
+    Given stack "1/A" exists in "CREATE_COMPLETE" state
+    and the template for stack "1/A" is "updated_template.json"
+    When the user updates stack "1/A" with ignore dependencies
+    Then stack "1/A" exists in "UPDATE_COMPLETE" state
+

--- a/integration-tests/features/validate-template.feature
+++ b/integration-tests/features/validate-template.feature
@@ -10,3 +10,9 @@ Feature: Validate template
     When the user validates the template for stack "1/A"
     Then a "ClientError" is raised
     and the user is told "the template is malformed"
+
+  Scenario: validate a vaild template with ignore dependencies
+    Given the template for stack "1/A" is "valid_template.json"
+    When the user validates the template for stack "1/A" with ignore dependencies
+    Then the user is told "the template is valid"
+

--- a/integration-tests/steps/templates.py
+++ b/integration-tests/steps/templates.py
@@ -50,11 +50,41 @@ def step_impl(context, stack_name):
         context.error = e
 
 
+@when('the user validates the template for stack "{stack_name}" with ignore dependencies')
+def step_impl(context, stack_name):
+    sceptre_context = SceptreContext(
+        command_path=stack_name + '.yaml',
+        project_path=context.sceptre_dir,
+        ignore_dependencies=True
+    )
+
+    sceptre_plan = SceptrePlan(sceptre_context)
+    try:
+        response = sceptre_plan.validate()
+        context.response = response
+    except ClientError as e:
+        context.error = e
+
+
 @when('the user generates the template for stack "{stack_name}"')
 def step_impl(context, stack_name):
     sceptre_context = SceptreContext(
         command_path=stack_name + '.yaml',
         project_path=context.sceptre_dir
+    )
+    sceptre_plan = SceptrePlan(sceptre_context)
+    try:
+        context.output = sceptre_plan.generate()
+    except Exception as e:
+        context.error = e
+
+
+@when('the user generates the template for stack "{stack_name}" with ignore dependencies')
+def step_impl(context, stack_name):
+    sceptre_context = SceptreContext(
+        command_path=stack_name + '.yaml',
+        project_path=context.sceptre_dir,
+        ignore_dependencies=True
     )
     sceptre_plan = SceptrePlan(sceptre_context)
     try:

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -43,10 +43,12 @@ from sceptre.cli.helpers import setup_logging, catch_exceptions
 @click.option(
     "--var-file", multiple=True, type=click.File("rb"),
     help="A YAML file of variables to template into config files.")
+@click.option(
+    "--ignore-dependencies", is_flag=True, help="Ignore dependencies when executing command.")
 @click.pass_context
 @catch_exceptions
 def cli(
-        ctx, debug, directory, no_colour, output, var, var_file
+        ctx, debug, directory, output, no_colour, var, var_file, ignore_dependencies
 ):
     """
     Sceptre is a tool to manage your cloud native infrastructure deployments.
@@ -60,6 +62,7 @@ def cli(
         "user_variables": {},
         "output_format": output,
         "no_colour": no_colour,
+        "ignore_dependencies": ignore_dependencies,
         "project_path": directory if directory else os.getcwd()
     }
     if var_file:

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -32,7 +32,8 @@ def create_command(ctx, path, change_set_name, yes):
         command_path=path,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options")
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     action = "create"

--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -35,7 +35,8 @@ def delete_command(ctx, path, change_set_name, yes):
         command_path=path,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options")
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -43,7 +43,8 @@ def describe_change_set(ctx, path, change_set_name, verbose):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
-        no_colour=ctx.obj.get("no_colour")
+        no_colour=ctx.obj.get("no_colour"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)
@@ -73,8 +74,8 @@ def describe_policy(ctx, path):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
-        no_colour=ctx.obj.get("no_colour")
-
+        no_colour=ctx.obj.get("no_colour"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -28,7 +28,8 @@ def execute_command(ctx, path, change_set_name, yes):
         command_path=path,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options")
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -29,7 +29,8 @@ def launch_command(ctx, path, yes):
         command_path=path,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options")
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -33,7 +33,8 @@ def list_resources(ctx, path):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        output_format=ctx.obj.get("output_format")
+        output_format=ctx.obj.get("output_format"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
     plan = SceptrePlan(context)
 
@@ -67,7 +68,8 @@ def list_outputs(ctx, path, export):
         project_path=ctx.obj.get("project_path", None),
         user_variables=ctx.obj.get("user_variables", {}),
         options=ctx.obj.get("options", {}),
-        output_format=ctx.obj.get("output_format", {})
+        output_format=ctx.obj.get("output_format", {}),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)
@@ -103,7 +105,8 @@ def list_change_sets(ctx, path):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         output_format=ctx.obj.get("output_format"),
-        options=ctx.obj.get("options")
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/policy.py
+++ b/sceptre/cli/policy.py
@@ -31,7 +31,8 @@ def set_policy_command(ctx, path, policy_file, built_in):
         command_path=path,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options")
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
     plan = SceptrePlan(context)
 

--- a/sceptre/cli/status.py
+++ b/sceptre/cli/status.py
@@ -28,7 +28,8 @@ def status_command(ctx, path):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         no_colour=ctx.obj.get("no_colour"),
-        output_format=ctx.obj.get("output_format")
+        output_format=ctx.obj.get("output_format"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -27,7 +27,8 @@ def validate_command(ctx, path):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        output_format=ctx.obj.get("output_format")
+        output_format=ctx.obj.get("output_format"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)
@@ -57,7 +58,8 @@ def generate_command(ctx, path):
         command_path=path,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options")
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)
@@ -85,7 +87,8 @@ def estimate_cost_command(ctx, path):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        output_format=ctx.obj.get("output_format")
+        output_format=ctx.obj.get("output_format"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -46,7 +46,8 @@ def update_command(ctx, path, change_set, verbose, yes):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        output_format=ctx.obj.get("output_format")
+        output_format=ctx.obj.get("output_format"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -42,7 +42,7 @@ class SceptreContext(object):
 
     def __init__(self, project_path, command_path,
                  user_variables=None, options=None, output_format=None,
-                 no_colour=False):
+                 no_colour=False, ignore_dependencies=False):
         # project_path: absolute path to the base sceptre project folder
         # e.g. absolute_path/to/sceptre_directory
         self.project_path = project_path
@@ -69,6 +69,7 @@ class SceptreContext(object):
         self.options = options if options else {}
         self.output_format = output_format if output_format else ""
         self.no_colour = no_colour if no_colour is True else False
+        self.ignore_dependencies = ignore_dependencies if ignore_dependencies is True else False
 
     def full_config_path(self):
         """

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -37,7 +37,12 @@ class SceptrePlan(object):
         return executor.execute(*args)
 
     def _generate_launch_order(self, reverse=False):
+        if self.context.ignore_dependencies:
+            return [self.command_stacks]
+
         graph = self.graph.filtered(self.command_stacks, reverse)
+        if self.context.ignore_dependencies:
+            return [self.command_stacks]
 
         launch_order = []
         while graph.graph:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,6 @@ exclude =
 max-complexity = 12
 per-file-ignores = 
 	docs/_api/conf.py: E265
-	integration-tests/steps/*: F811,F403,F405
+	integration-tests/steps/*: E501,F811,F403,F405
 max-line-length = 99
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,6 +298,21 @@ class TestCli(object):
         assert result.exit_code == exit_code
 
     @pytest.mark.parametrize(
+        "command, ignore_dependencies", [
+            ("create", True),
+            ("create", False),
+            ("delete", True),
+            ("delete", False),
+        ]
+    )
+    def test_ignore_dependencies_commands(self, command, ignore_dependencies):
+        args = [command, "dev/vpc.yaml", "cs-1", "-y"]
+        if ignore_dependencies:
+            args.insert(0, "--ignore-dependencies")
+        result = self.runner.invoke(cli, args)
+        assert result.exit_code == 0
+
+    @pytest.mark.parametrize(
         "command,yes_flag", [
             ("create", True),
             ("create", False),

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -17,7 +17,8 @@ class TestSceptreContext(object):
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
-            no_colour=sentinel.no_colour
+            no_colour=sentinel.no_colour,
+            ignore_dependencies=sentinel.ignore_dependencies
         )
 
         sentinel.project_path = "project_path/to/sceptre"
@@ -30,7 +31,8 @@ class TestSceptreContext(object):
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
-            no_colour=sentinel.no_colour
+            no_colour=sentinel.no_colour,
+            ignore_dependencies=sentinel.ignore_dependencies
         )
 
         full_config_path = path.join("project_path", self.config_path)
@@ -43,7 +45,8 @@ class TestSceptreContext(object):
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
-            no_colour=sentinel.no_colour
+            no_colour=sentinel.no_colour,
+            ignore_dependencies=sentinel.ignore_dependencies
         )
         full_command_path = path.join("project_path",
                                       self.config_path,
@@ -58,7 +61,8 @@ class TestSceptreContext(object):
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
-            no_colour=sentinel.no_colour
+            no_colour=sentinel.no_colour,
+            ignore_dependencies=sentinel.ignore_dependencies
         )
         full_templates_path = path.join("project_path", self.templates_path)
         assert context.full_templates_path() == full_templates_path


### PR DESCRIPTION
Adding a `--ignore-dependencies` flag so that Sceptre will only execute
a command on the given Stack or StackGroup and ignore all other
dependant Stacks. Useful when wanting to operate on a single Stack, for
example, when creating a Change Set.

Reverts `ConfigReader().construct_stack()` to a previous implementation
(182f0b64f1bfbb439c7e6f7778a3ce0d0774d187) to handle case where root is
the stack file and changes root to the command path so that full project
is not loaded upfront.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
