### PR TITLE
Add StackGroup Config variables to template renderer

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -44,7 +44,7 @@ CONFIG_MERGE_STRATEGIES = {
     'region': strategies.child_wins,
     'template_bucket_name': strategies.child_wins,
     'template_key_value': strategies.child_wins,
-    'required_version': strategies.child_wins,
+    'required_version': strategies.child_wins
 }
 
 STACK_GROUP_CONFIG_ATTRIBUTES = ConfigAttributes(
@@ -55,7 +55,7 @@ STACK_GROUP_CONFIG_ATTRIBUTES = ConfigAttributes(
     {
         "template_bucket_name",
         "template_key_prefix",
-        "require_version"
+        "required_version"
     }
 )
 
@@ -308,10 +308,9 @@ class ConfigReader(object):
                 undefined=jinja2.StrictUndefined
             )
             template = jinja_env.get_template(basename)
+            self.templating_vars.update(stack_group_config)
             rendered_template = template.render(
-                environment_variable=environ,
-                **self.templating_vars,
-                **stack_group_config
+                self.templating_vars, environment_variable=environ
             )
 
             config = yaml.safe_load(rendered_template)
@@ -340,13 +339,13 @@ class ConfigReader(object):
         :raises: sceptre.exceptions.VersionIncompatibleException
         """
         sceptre_version = __version__
-        if 'require_version' in config:
-            require_version = config['require_version']
-            if Version(sceptre_version) not in SpecifierSet(require_version):
+        if 'required_version' in config:
+            required_version = config['required_version']
+            if Version(sceptre_version) not in SpecifierSet(required_version, True):
                 raise VersionIncompatibleError(
                     "Current sceptre version ({0}) does not meet version "
                     "requirements: {1}".format(
-                        sceptre_version, require_version
+                        sceptre_version, required_version
                     )
                 )
 

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -118,8 +118,6 @@ class Stack(object):
         self.template_bucket_name = template_bucket_name
         self.template_key_prefix = template_key_prefix
         self.required_version = required_version
-        self.hooks = hooks
-
         self.external_name = external_name or \
             get_external_stack_name(self.project_code, self.name)
 

--- a/tests/fixtures-vpc/config/config.yaml
+++ b/tests/fixtures-vpc/config/config.yaml
@@ -1,4 +1,4 @@
 profile: account_profile
 project_code: account_project_code
 region: account_region
-require_version: ">=0a"
+required_version: ">1.0"

--- a/tests/fixtures/config/account/stack-group/config.yaml
+++ b/tests/fixtures/config/account/stack-group/config.yaml
@@ -1,1 +1,2 @@
 template_bucket_name: stack_group_template_bucket_name
+required_version: ">1.0"

--- a/tests/fixtures/config/account/stack-group/region/config.yaml
+++ b/tests/fixtures/config/account/stack-group/region/config.yaml
@@ -1,3 +1,4 @@
 region: region_region
+required_version: ">1.0"
 dependencies:
   - top/level

--- a/tests/fixtures/config/account/stack-group/region/construct_nodes.yaml
+++ b/tests/fixtures/config/account/stack-group/region/construct_nodes.yaml
@@ -1,9 +1,9 @@
 template_path: path/to/template
 parameters:
-  param1: !stack_group_variable example
+  param1: !environment_variable example
   param2:
-    param3: !stack_group_variable example
-    param4: !stack_group_variable example
+    param3: !environment_variable example
+    param4: !environment_variable example
   param5:
-    - param6: !stack_group_variable example
-    - param7: !stack_group_variable example
+    - param6: !environment_variable example
+    - param7: !environment_variable example

--- a/tests/fixtures/config/account/stack-group/region/security_groups.yaml
+++ b/tests/fixtures/config/account/stack-group/region/security_groups.yaml
@@ -1,7 +1,7 @@
 parameters:
-  param1: {{ var.user_variable }}
+  param1: {{ var.variable_key }}
   param2: {{ environment_variable.TEST_ENV_VAR }}
-  param3: {{ stack_group_path.0 }}
-  param4: {{ stack_group_path.1 }}
-  param5: {{ stack_group_path.2 }}
-  param6: {{ stack_group_config.region }}
+  param3: {{ stack_group_config.region }}
+  param4: {{ stack_group_config.project_code }}
+  param5: {{ stack_group_config.required_version }}
+  param6: {{ stack_group_config.template_bucket_name }}

--- a/tests/fixtures/config/config.yaml
+++ b/tests/fixtures/config/config.yaml
@@ -1,4 +1,4 @@
 profile: account_profile
 project_code: account_project_code
 region: account_region
-require_version: ">=0a"
+required_version: ">1.0"

--- a/tests/fixtures/config/top/level.yaml
+++ b/tests/fixtures/config/top/level.yaml
@@ -1,1 +1,1 @@
-template_path: somethingelse.py
+template_path: vpc.py

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -144,9 +144,9 @@ class TestConfigReader(object):
             "parameters": {
                 "param1": "user_variable_value",
                 "param2": "environment_variable_value",
-                "param3": "account",
-                "param4": "stack-group",
-                "param5": "region",
+                "param3": "a",
+                "param4": "c",
+                "param5": "c",
                 "param6": "stack_group_region"
             }
         }

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -127,12 +127,15 @@ class TestConfigReader(object):
         }
 
     def test_read_with_templated_config_file(self):
-        self.context.user_variables = {"user_variable": "user_variable_value"}
+        self.context.user_variables = {"variable_key": "user_variable_value"}
         config_reader = ConfigReader(self.context)
-        config_reader.templating_vars["stack_group_config"] = {
-            "region": "stack_group_region"
-        }
 
+        config_reader.templating_vars["stack_group_config"] = {
+            "region": "region_region",
+            "project_code": "account_project_code",
+            "required_version": "'>1.0'",
+            "template_bucket_name": "stack_group_template_bucket_name"
+        }
         os.environ["TEST_ENV_VAR"] = "environment_variable_value"
         config = config_reader.read(
             "account/stack-group/region/security_groups.yaml"
@@ -144,16 +147,16 @@ class TestConfigReader(object):
             "parameters": {
                 "param1": "user_variable_value",
                 "param2": "environment_variable_value",
-                "param3": "a",
-                "param4": "c",
-                "param5": "c",
-                "param6": "stack_group_region"
+                "param3": "region_region",
+                "param4": "account_project_code",
+                "param5": ">1.0",
+                "param6": "stack_group_template_bucket_name"
             }
         }
 
     def test_aborts_on_incompatible_version_requirement(self):
         config = {
-            'require_version': '<0'
+            'required_version': '<0'
         }
         with pytest.raises(VersionIncompatibleError):
             ConfigReader(self.context)._check_version(config)
@@ -202,7 +205,6 @@ class TestConfigReader(object):
         self.context.project_path = os.path.abspath("tests/fixtures-vpc")
         self.context.command_path = "account/stack-group/region/vpc.yaml"
         stacks = ConfigReader(self.context).construct_stacks()
-
         mock_Stack.assert_any_call(
             name="account/stack-group/region/vpc",
             project_code="account_project_code",
@@ -223,7 +225,7 @@ class TestConfigReader(object):
             notifications=None,
             on_failure=None,
             stack_timeout=0,
-            required_version=None,
+            required_version='>1.0',
             template_bucket_name='stack_group_template_bucket_name',
             template_key_prefix=None
         )


### PR DESCRIPTION
At some point when rewriting to version 2 the StackGroup config was not being included in full during the template generation. This PR add the stack_group config back in to the template generation and updates the CONFIG_MERGE_STRATEGIES accordingly.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
