### PR TITLE
Fix accessing stack group

### DIFF
--- a/docs/docs/stack_config.md
+++ b/docs/docs/stack_config.md
@@ -272,7 +272,7 @@ parameters:
     param_4:
         {{ var.value4 }}
     param_5:
-        {{ environment_path.3 }}
+        {{ command_path.3 }}
     param_6:
         {{ environment_variable.VALUE_6 }}
 sceptre_user_data:

--- a/docs/docs/stack_group_config.md
+++ b/docs/docs/stack_group_config.md
@@ -108,7 +108,7 @@ and would only be applied to builds in the `dev` StackGroup.
 
 Sceptre supports the use of templating in config files. Templating allows
 config files to be further configured using values from the command line,
-environment variables, files or parts of the environment path.
+environment variables, files or parts of the `command_path`.
 
 Internally, Sceptre uses Jinja2 for templating, so any valid Jinja2 syntax
 should work with Sceptre templating.
@@ -196,16 +196,16 @@ region: eu-west-1
 
 Where `PROFILE` is the name of an environment variable.
 
-### Environment Path
+### Command Path
 
-Config item values can be replaced with parts of the environment path:
+Config item values can be replaced with parts of the `command_path`:
 
 ```yaml
-region: {% raw %}{{ environment_path.0 }}{% endraw %}
+region: {% raw %}{{ command_path.0 }}{% endraw %}
 profile: default
 ```
 
-Where the value is taken from the first part of the environment path from the
+Where the value is taken from the first part of the `command_path` from the
 invoking sceptre command:
 
 ```shell
@@ -234,7 +234,7 @@ template_key_prefix: my/prefix
 {% raw %}
 profile: {{ var.profile }}
 project_code: {{ var.project_code | default("prj") }}
-region: {{ environment_path.2 }}
+region: {{ command_path.2 }}
 template_bucket_name: {{ environment_variable.TEMPLATE_BUCKET_NAME }}
 {% endraw %}
 ```

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -330,7 +330,9 @@ class ConfigReader(object):
             template = jinja_env.get_template(basename)
             self.templating_vars.update(stack_group_config)
             rendered_template = template.render(
-                self.templating_vars, environment_variable=environ
+                self.templating_vars,
+                command_path=self.context.command_path.split("/"),
+                environment_variable=environ
             )
 
             config = yaml.safe_load(rendered_template)
@@ -430,7 +432,6 @@ class ConfigReader(object):
         s3_details = self._collect_s3_details(
             stack_name, config
         )
-
         stack = Stack(
             name=stack_name,
             project_code=config["project_code"],


### PR DESCRIPTION
In v1 `environment_path` was accessible as a list in templates,
split by the path separator.

In v2 the `environment_path` is known as the `command_path`. This
commit adds support for accessing the `command_path` back in to
Sceptre. For example, the user can now access parts of the
`command_path` in templates like {{ command_path.0 }}.


## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
