### PR TITLE
[Resolves #531] Normalise os paths

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -11,7 +11,7 @@ import collections
 import datetime
 import fnmatch
 import logging
-from os import path, environ, walk
+from os import environ, path, walk
 from pkg_resources import iter_entry_points
 import yaml
 
@@ -24,8 +24,9 @@ from sceptre.exceptions import InvalidConfigFileError
 from sceptre.exceptions import InvalidSceptreDirectoryError
 from sceptre.exceptions import VersionIncompatibleError
 from sceptre.exceptions import ConfigFileNotFoundError
+from sceptre.helpers import sceptreise_path
 from sceptre.stack import Stack
-from . import strategies
+from sceptre.config import strategies
 
 ConfigAttributes = collections.namedtuple("Attributes", "required optional")
 
@@ -116,9 +117,7 @@ class ConfigReader(object):
         self._check_valid_project_path(self.full_config_path)
 
         # Add Resolver and Hook classes to PyYAML loader
-        self._add_yaml_constructors(
-            ["sceptre.hooks", "sceptre.resolvers"]
-        )
+        self._add_yaml_constructors(["sceptre.hooks", "sceptre.resolvers"])
         if not self.context.user_variables:
             self.context.user_variables = {}
 
@@ -204,8 +203,8 @@ class ConfigReader(object):
 
         while todo:
             abs_path = todo.pop()
-            rel_path = path.relpath(abs_path,
-                                    start=self.context.full_config_path())
+            rel_path = path.relpath(
+                abs_path, start=self.context.full_config_path())
             directory, filename = path.split(rel_path)
 
             if directory in stack_group_configs:
@@ -215,7 +214,7 @@ class ConfigReader(object):
                     self.read(path.join(directory, self.context.config_file))
 
             stack = self._construct_stack(rel_path, stack_group_config)
-            stack_map[rel_path] = stack
+            stack_map[sceptreise_path(rel_path)] = stack
 
             if abs_path.startswith(self.context.full_command_path()):
                 command_stacks.add(stack)
@@ -223,7 +222,10 @@ class ConfigReader(object):
         stacks = set()
         for stack in stack_map.values():
             if not self.context.ignore_dependencies:
-                stack.dependencies = [stack_map[dep] for dep in stack.dependencies]
+                stack.dependencies = [
+                    stack_map[sceptreise_path(dep)]
+                    for dep in stack.dependencies
+                ]
             else:
                 stack.dependencies = []
             stacks.add(stack)
@@ -334,8 +336,7 @@ class ConfigReader(object):
         :rtype: dict
         """
         config = {}
-        abs_directory_path = path.join(
-            self.full_config_path, directory_path)
+        abs_directory_path = path.join(self.full_config_path, directory_path)
         if path.isfile(path.join(abs_directory_path, basename)):
             jinja_env = jinja2.Environment(
                 loader=jinja2.FileSystemLoader(abs_directory_path),
@@ -345,7 +346,7 @@ class ConfigReader(object):
             self.templating_vars.update(stack_group_config)
             rendered_template = template.render(
                 self.templating_vars,
-                command_path=self.context.command_path.split("/"),
+                command_path=self.context.command_path.split(path.sep),
                 environment_variable=environ
             )
 
@@ -450,7 +451,7 @@ class ConfigReader(object):
 
         abs_template_path = path.join(
             self.context.project_path, self.context.templates_path,
-            config["template_path"]
+            sceptreise_path(config["template_path"])
         )
 
         s3_details = self._collect_s3_details(

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -9,6 +9,8 @@ paths used in a Sceptre project.
 
 from os import path
 
+from sceptre.helpers import normalise_path
+
 
 class SceptreContext(object):
     """
@@ -45,7 +47,7 @@ class SceptreContext(object):
                  no_colour=False, ignore_dependencies=False):
         # project_path: absolute path to the base sceptre project folder
         # e.g. absolute_path/to/sceptre_directory
-        self.project_path = project_path
+        self.project_path = normalise_path(project_path)
 
         # config_path: holds the project stack_groups
         # e.g {project_path}/config
@@ -53,7 +55,9 @@ class SceptreContext(object):
 
         # command_path path to either stack group or stack
         # e.g. {project_path/config_path}/command_path
-        self.command_path = command_path
+        self.command_path = normalise_path(command_path)
+
+        self.normal_command_path = normalise_path(command_path)
 
         # config_file: stack group config. User definable later in v2
         # e.g. {project_path/config/command_path}/config_file

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -145,3 +145,10 @@ class InvalidConfigFileError(SceptreException):
     Error raised when a config file lacks mandatory keys.
     """
     pass
+
+
+class PathConversionError(SceptreException):
+    """
+    Error raised when a path is unable to be converted.
+    """
+    pass

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from os import sep
+
+from sceptre.exceptions import PathConversionError
 
 
 def get_external_stack_name(project_code, stack_name):
@@ -62,3 +65,46 @@ def _call_func_on_values(func, attr, cls):
         for index, value in enumerate(attr):
             func_on_instance(index)
     return attr
+
+
+def normalise_path(path):
+    """
+    Converts a path to use correct path separator.
+    Raises an PathConversionError if the path has a
+    trailing slash.
+    :param path: A directory path
+    :type path: str
+    :raises: sceptre.exceptions.PathConversionError
+    :returns: A normalised path with forward slashes.
+    :returns: string
+    """
+    if sep is '/':
+        path = path.replace('\\', '/')
+    elif sep is '\\':
+        path = path.replace('/', '\\')
+    if path.endswith("/") or path.endswith("\\"):
+        raise PathConversionError(
+            "'{0}' is an invalid path string. Paths should "
+            "not have trailing slashes.".format(path)
+        )
+    return path
+
+
+def sceptreise_path(path):
+    """
+    Converts a path to use correct sceptre path separator.
+    Raises an PathConversionError if the path has a
+    trailing slash.
+    :param path: A directory path
+    :type path: str
+    :raises: sceptre.exceptions.PathConversionError
+    :returns: A normalised path with forward slashes.
+    :returns: string
+    """
+    path = path.replace('\\', '/')
+    if path.endswith("/") or path.endswith("\\"):
+        raise PathConversionError(
+            "'{0}' is an invalid path string. Paths should "
+            "not have trailing slashes.".format(path)
+        )
+    return path

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -262,7 +262,7 @@ class StackActions(object):
         policy_path = path.join(
             # need to get to the base install path. __file__ will take us into
             # sceptre/actions so need to walk up the path.
-            path.abspath(path.join(__file__, "../..")),
+            path.abspath(path.join(__file__, "..", "..")),
             "stack_policies/lock.json"
         )
         self.set_policy(policy_path)
@@ -275,7 +275,7 @@ class StackActions(object):
         policy_path = path.join(
             # need to get to the base install path. __file__ will take us into
             # sceptre/actions so need to walk up the path.
-            path.abspath(path.join(__file__, "../..")),
+            path.abspath(path.join(__file__, "..", "..")),
             "stack_policies/unlock.json"
         )
         self.set_policy(policy_path)
@@ -367,10 +367,9 @@ class StackActions(object):
         UPDATE_ROLLBACK_COMPLETE.
         """
         self.logger.debug("%s - Continuing update rollback", self.stack.name)
-        continue_update_rollback_kwargs = \
-            {
-                "StackName": self.stack.external_name
-            }
+        continue_update_rollback_kwargs = {
+            "StackName": self.stack.external_name
+        }
         continue_update_rollback_kwargs.update(self._get_role_arn())
         self.connection_manager.call(
             service="cloudformation",

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -12,6 +12,7 @@ from sceptre.exceptions import ConfigFileNotFoundError
 from sceptre.config.graph import StackGraph
 from sceptre.config.reader import ConfigReader
 from sceptre.plan.executor import SceptrePlanExecutor
+from sceptre.helpers import sceptreise_path
 
 
 class SceptrePlan(object):
@@ -59,9 +60,9 @@ class SceptrePlan(object):
 
         if not launch_order:
             raise ConfigFileNotFoundError(
-                    "No stacks detected from the given path '{}'. Valid stack paths are: {}"
-                    .format(self.context.command_path, self._valid_stack_paths())
-                    )
+                "No stacks detected from the given path '{}'. Valid stack paths are: {}"
+                .format(sceptreise_path(self.context.command_path), self._valid_stack_paths())
+            )
 
         return launch_order
 
@@ -348,8 +349,8 @@ class SceptrePlan(object):
 
     def _valid_stack_paths(self):
         return [
-                path.relpath(path.join(dirpath, f), self.context.config_path)
-                for dirpath, dirnames, files in walk(self.context.config_path)
-                for f in files
-                if not f.endswith(self.context.config_file)
-            ]
+            sceptreise_path(path.relpath(path.join(dirpath, f), self.context.config_path))
+            for dirpath, dirnames, files in walk(self.context.config_path)
+            for f in files
+            if not f.endswith(self.context.config_file)
+        ]

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -7,6 +7,7 @@ import shlex
 
 from botocore.exceptions import ClientError
 
+from sceptre.helpers import normalise_path
 from sceptre.resolvers import Resolver
 from sceptre.exceptions import DependencyStackMissingOutputError
 from sceptre.exceptions import StackDoesNotExistError
@@ -107,8 +108,8 @@ class StackOutput(StackOutputBase):
         """
         Adds dependency to a Stack.
         """
-        self.dependency_stack_name, self.output_key = self.argument.split("::")
-
+        dep_stack_name, self.output_key = self.argument.split("::")
+        self.dependency_stack_name = normalise_path(dep_stack_name)
         self.stack.dependencies.append(self.dependency_stack_name)
 
     def resolve(self):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -14,6 +14,7 @@ from sceptre.template import Template
 from sceptre.helpers import get_external_stack_name
 from sceptre.hooks import HookProperty
 from sceptre.resolvers import ResolvableProperty
+from sceptre.helpers import sceptreise_path
 
 
 class Stack(object):
@@ -116,14 +117,13 @@ class Stack(object):
     ):
         self.logger = logging.getLogger(__name__)
 
-        self.name = name
+        self.name = sceptreise_path(name)
         self.project_code = project_code
         self.region = region
         self.template_bucket_name = template_bucket_name
         self.template_key_prefix = template_key_prefix
         self.required_version = required_version
-        self.external_name = external_name or \
-            get_external_stack_name(self.project_code, self.name)
+        self.external_name = external_name or get_external_stack_name(self.project_code, self.name)
 
         self.template_path = template_path
         self.s3_details = s3_details
@@ -145,7 +145,7 @@ class Stack(object):
     def __repr__(self):
         return (
             "sceptre.stack.Stack("
-            "name={name}, "
+            "name='{name}', "
             "project_code={project_code}, "
             "template_path={template_path}, "
             "region={region}, "

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 from sceptre import __version__
 from setuptools import setup, find_packages
+from os import path
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -68,9 +69,9 @@ setup(
         ]
     },
     data_files=[
-        ("sceptre/stack_policies", [
-            "sceptre/stack_policies/lock.json",
-            "sceptre/stack_policies/unlock.json"
+        (path.join("sceptre", "stack_policies"), [
+            path.join("sceptre", "stack_policies", "lock.json"),
+            path.join("sceptre", "stack_policies", "unlock.json")
         ])
     ],
     include_package_data=True,

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -28,7 +28,7 @@ class TestStackActions(object):
         )
         self.mock_ConnectionManager = self.patcher_connection_manager.start()
         self.stack = Stack(
-            name=sentinel.stack_name, project_code=sentinel.project_code,
+            name='prod/app/stack', project_code=sentinel.project_code,
             template_path=sentinel.template_path, region=sentinel.region,
             profile=sentinel.profile, parameters={"key1": "val1"},
             sceptre_user_data=sentinel.sceptre_user_data, hooks={},
@@ -566,7 +566,7 @@ class TestStackActions(object):
             }
         )
 
-        assert response == {sentinel.stack_name: '{}'}
+        assert response == {'prod/app/stack': '{}'}
 
     def test_create_change_set_sends_correct_request(self):
         self.template._body = sentinel.template

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -13,7 +13,7 @@ class TestSceptreContext(object):
     def test_context_with_path(self):
         self.context = SceptreContext(
             project_path="project_path/to/sceptre",
-            command_path=sentinel.command_path,
+            command_path="command-path",
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
@@ -27,7 +27,7 @@ class TestSceptreContext(object):
     def test_full_config_path_returns_correct_path(self):
         context = SceptreContext(
             project_path="project_path",
-            command_path=sentinel.command_path,
+            command_path="command-path",
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
+from os.path import join
+
+from sceptre.exceptions import PathConversionError
 from sceptre.helpers import get_external_stack_name
+from sceptre.helpers import normalise_path
+from sceptre.helpers import sceptreise_path
 
 
 class TestHelpers(object):
@@ -8,3 +15,55 @@ class TestHelpers(object):
     def test_get_external_stack_name(self):
         result = get_external_stack_name("prj", "dev/ew1/jump-host")
         assert result == "prj-dev-ew1-jump-host"
+
+    def test_normalise_path_with_valid_path(self):
+        path = normalise_path("valid/path")
+        assert path == join("valid", "path")
+
+    def test_normalise_path_with_backslashes_in_path(self):
+        path = normalise_path("valid\path")
+        assert path == join("valid", "path")
+
+    def test_normalise_path_with_double_backslashes_in_path(self):
+        path = normalise_path('valid\\path')
+        assert path == join("valid", "path")
+
+    def test_normalise_path_with_leading_slash(self):
+        path = normalise_path("/this/is/valid")
+        assert path == join("/this", "is", "valid")
+
+    def test_normalise_path_with_leading_backslash(self):
+        path = normalise_path('\\this\path\is\\valid')
+        assert path == join("/this", "path", "is", "valid")
+
+    def test_normalise_path_with_trailing_slash(self):
+        with pytest.raises(PathConversionError):
+            normalise_path(
+                "this/path/is/invalid/"
+            )
+
+    def test_normalise_path_with_trailing_backslash(self):
+        with pytest.raises(PathConversionError):
+            normalise_path(
+                'this\path\is\invalid\\'
+            )
+
+    def test_sceptreise_path_with_valid_path(self):
+        path = 'dev/app/stack'
+        assert sceptreise_path(path) == path
+
+    def test_sceptreise_path_with_windows_path(self):
+        windows_path = 'dev\\app\\stack'
+        assert sceptreise_path(windows_path) == 'dev/app/stack'
+
+    def test_sceptreise_path_with_trailing_slash(self):
+        with pytest.raises(PathConversionError):
+            sceptreise_path(
+                "this/path/is/invalid/"
+            )
+
+    def test_sceptreise_path_with_trailing_backslash(self):
+        with pytest.raises(PathConversionError):
+            sceptreise_path(
+                'this\path\is\invalid\\'
+            )

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -12,7 +12,7 @@ class TestSceptrePlan(object):
     def setup_method(self, test_method):
         self.patcher_SceptrePlan = patch("sceptre.plan.plan.SceptrePlan")
         self.stack = Stack(
-            name=sentinel.stack_name, project_code=sentinel.project_code,
+            name='dev/app/stack', project_code=sentinel.project_code,
             template_path=sentinel.template_path, region=sentinel.region,
             profile=sentinel.profile, parameters={"key1": "val1"},
             sceptre_user_data=sentinel.sceptre_user_data, hooks={},

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -11,7 +11,7 @@ class TestStack(object):
 
     def setup_method(self, test_method):
         self.stack = Stack(
-            name=sentinel.stack_name, project_code=sentinel.project_code,
+            name='dev/app/stack', project_code=sentinel.project_code,
             template_bucket_name=sentinel.template_bucket_name,
             template_key_prefix=sentinel.template_key_prefix,
             required_version=sentinel.required_version,
@@ -30,14 +30,14 @@ class TestStack(object):
 
     def test_initiate_stack(self):
         stack = Stack(
-            name=sentinel.stack_name, project_code=sentinel.project_code,
+            name='dev/stack/app', project_code=sentinel.project_code,
             template_path=sentinel.template_path,
             template_bucket_name=sentinel.template_bucket_name,
             template_key_prefix=sentinel.template_key_prefix,
             required_version=sentinel.required_version,
             region=sentinel.region, external_name=sentinel.external_name
         )
-        assert stack.name == sentinel.stack_name
+        assert stack.name == 'dev/stack/app'
         assert stack.project_code == sentinel.project_code
         assert stack.template_bucket_name == sentinel.template_bucket_name
         assert stack.template_key_prefix == sentinel.template_key_prefix
@@ -57,10 +57,10 @@ class TestStack(object):
         assert stack.on_failure is None
         assert stack.stack_group_config == {}
 
-    def test_repr(self):
+    def test_stack_repr(self):
         assert self.stack.__repr__() == \
             "sceptre.stack.Stack(" \
-            "name=sentinel.stack_name, " \
+            "name='dev/app/stack', " \
             "project_code=sentinel.project_code, " \
             "template_path=sentinel.template_path, " \
             "region=sentinel.region, " \
@@ -87,11 +87,11 @@ class TestStack(object):
         sceptre = importlib.import_module('sceptre')
         mock = importlib.import_module('mock')
         evaluated_stack = eval(
-                repr(self.stack),
-                {
-                    'sceptre': sceptre,
-                    'sentinel': mock.mock.sentinel
-                }
-            )
+            repr(self.stack),
+            {
+                'sceptre': sceptre,
+                'sentinel': mock.mock.sentinel
+            }
+        )
         assert isinstance(evaluated_stack, Stack)
         assert evaluated_stack.__eq__(self.stack)


### PR DESCRIPTION
The intention is to avoid unnecessary path manipulation between the end user and executing a command. In v1 [`_validate_path`](https://github.com/cloudreach/sceptre/blob/v1/sceptre/environment.py#L75) was responsible for this. Users of any operating system should now be able pass paths with native separators and sceptre work as intended.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
