### PR TITLE
Fix delete stack confirmation message

### DIFF
--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -50,7 +50,7 @@ def delete_command(ctx, path, change_set_name, yes):
     print("The following stacks in the following order will be deleted:\n{}".format(dependencies))
 
     confirmation(
-        plan.delete_change_set.__name__,
+        plan.delete.__name__,
         yes,
         change_set=change_set_name,
         command_path=path


### PR DESCRIPTION
Delete message was displaying `Do you want to delete_change_set ...` where it should just be 
`Do you want to delete ...`

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
