### PR TITLE
Fix `list` and `describe` cli output

### DIFF
--- a/integration-tests/steps/change_sets.py
+++ b/integration-tests/steps/change_sets.py
@@ -281,17 +281,14 @@ def step_impl(context, stack_name):
         context.client.list_change_sets,
         StackName=full_name
     )
-
-    del response["ResponseMetadata"]
     for output in context.output:
-        del output["ResponseMetadata"]
-        assert response == output
+        assert output == {stack_name: response.get("Summaries", {})}
 
 
 @then('no change sets for stack "{stack_name}" are listed')
 def step_impl(context, stack_name):
     for output in context.output:
-        assert output["Summaries"] == []
+        assert output == {stack_name: []}
 
 
 @then('change set "{change_set_name}" for stack "{stack_name}" is described')

--- a/integration-tests/steps/stack_groups.py
+++ b/integration-tests/steps/stack_groups.py
@@ -195,7 +195,8 @@ def step_impl(context, stack_group_name, status):
 @then('no resources are described')
 def step_impl(context):
     for stack_resources in context.response:
-        assert stack_resources == []
+        stack_name = next(iter(stack_resources))
+        assert stack_resources == {stack_name: []}
 
 
 @then('stack "{stack_name}" is described as "{status}"')
@@ -214,8 +215,8 @@ def step_impl(context, stack_group_name):
     expected_resources = {}
     sceptre_response = []
     for stack_resources in context.response:
-        for resource in stack_resources:
-            sceptre_response.append(resource["PhysicalResourceId"])
+        for resource in stack_resources.values():
+            sceptre_response.append(resource[0]["PhysicalResourceId"])
 
     for short_name, full_name in stacks_names.items():
         time.sleep(1)
@@ -237,8 +238,9 @@ def step_impl(context, stack_name):
     expected_resources = {}
     sceptre_response = []
     for stack_resources in context.response:
-        for resource in stack_resources:
-            sceptre_response.append(resource["PhysicalResourceId"])
+        for resource in stack_resources.values():
+            if resource:
+                sceptre_response.append(resource[0].get("PhysicalResourceId"))
 
     response = retry_boto_call(
         context.client.describe_stack_resources,

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -325,14 +325,13 @@ def step_impl(context, stack_name):
         context.client.describe_stack_resources,
         StackName=full_name
     )
-
     properties = {"LogicalResourceId", "PhysicalResourceId"}
     formatted_response = [
         {k: v for k, v in item.items() if k in properties}
         for item in response["StackResources"]
     ]
 
-    assert [formatted_response] == context.output
+    assert [{stack_name: formatted_response}] == context.output
 
 
 @then('stack "{stack_name}" does not exist and stack "{dependant_stack_name}" exists in "{desired_state}"')

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -82,7 +82,7 @@ def describe_policy(ctx, path):
     responses = plan.get_policy()
     for response in responses.values():
         write(
-            response.get('StackPolicyBody', {}),
+            response,
             context.output_format,
             context.no_colour
         )

--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -73,7 +73,7 @@ def write(var, output_format="str", no_colour=True):
     stream = var
 
     if output_format == "json":
-        encoder = CustomJsonEncoder()
+        encoder = CustomJsonEncoder(indent=4)
         stream = encoder.encode(var)
     if output_format == "yaml":
         stream = yaml.safe_dump(var, default_flow_style=False)

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -116,6 +116,4 @@ def list_change_sets(ctx, path):
     ]
 
     for response in responses:
-        if response['ResponseMetadata']['HTTPStatusCode'] == 200:
-            del response['ResponseMetadata']
         write(response, context.output_format)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -481,12 +481,12 @@ class TestStackActions(object):
             command="describe_stack_resources",
             kwargs={"StackName": sentinel.external_name}
         )
-        assert response == [
+        assert response == {self.stack.name: [
             {
                 "LogicalResourceId": sentinel.logical_resource_id,
                 "PhysicalResourceId": sentinel.physical_resource_id
             }
-        ]
+        ]}
 
     @patch("sceptre.plan.actions.StackActions._describe")
     def test_describe_outputs_sends_correct_request(self, mock_describe):
@@ -497,7 +497,7 @@ class TestStackActions(object):
         }
         response = self.actions.describe_outputs()
         mock_describe.assert_called_once_with()
-        assert response == sentinel.outputs
+        assert response == {self.stack.name: sentinel.outputs}
 
     @patch("sceptre.plan.actions.StackActions._describe")
     def test_describe_outputs_handles_stack_with_no_outputs(
@@ -507,7 +507,7 @@ class TestStackActions(object):
             "Stacks": [{}]
         }
         response = self.actions.describe_outputs()
-        assert response == []
+        assert response == {self.stack.name: []}
 
     def test_continue_update_rollback_sends_correct_request(self):
         self.actions.continue_update_rollback()
@@ -541,8 +541,11 @@ class TestStackActions(object):
             }
         )
 
-    def test_get_stack_policy_sends_correct_request(self):
-        self.actions.get_policy()
+    @patch("sceptre.plan.actions.json")
+    def test_get_stack_policy_sends_correct_request(self, mock_Json):
+        mock_Json.loads.return_value = '{}'
+        mock_Json.dumps.return_value = '{}'
+        response = self.actions.get_policy()
         self.actions.connection_manager.call.assert_called_with(
             service="cloudformation",
             command="get_stack_policy",
@@ -550,6 +553,8 @@ class TestStackActions(object):
                 "StackName": sentinel.external_name
             }
         )
+
+        assert response == {sentinel.stack_name: '{}'}
 
     def test_create_change_set_sends_correct_request(self):
         self.template._body = sentinel.template

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,14 +213,14 @@ class TestCli(object):
 
     def test_describe_policy_with_existing_policy(self):
         self.mock_stack_actions.get_policy.return_value = {
-            "StackPolicyBody": ["Body"]
+            "dev/vpc": {"Statement": ["Body"]}
         }
 
         result = self.runner.invoke(
             cli, ["describe", "policy", "dev/vpc.yaml"]
         )
         assert result.exit_code == 0
-        assert result.output == "- Body\n\n"
+        assert result.output == "dev/vpc:\n  Statement:\n  - Body\n\n"
 
     def test_list_group_resources(self):
         response = {
@@ -380,9 +380,6 @@ class TestCli(object):
 
     def test_list_change_sets_with_200(self):
         self.mock_stack_actions.list_change_sets.return_value = {
-            "ResponseMetadata": {
-                "HTTPStatusCode": 200
-            },
             "ChangeSets": "Test"
         }
         result = self.runner.invoke(
@@ -393,9 +390,6 @@ class TestCli(object):
 
     def test_list_change_sets_without_200(self):
         response = {
-            "ResponseMetadata": {
-                "HTTPStatusCode": 404
-            },
             "ChangeSets": "Test"
         }
         self.mock_stack_actions.list_change_sets.return_value = response
@@ -673,8 +667,8 @@ class TestCli(object):
     @patch("sceptre.cli.click.echo")
     @pytest.mark.parametrize(
         "output_format,no_colour,expected_output", [
-            ("json", True, '{"stack": "CREATE_COMPLETE"}'),
-            ("json", False, '{"stack": "\x1b[32mCREATE_COMPLETE\x1b[0m\"}'),
+            ("json", True, '{\n    "stack": "CREATE_COMPLETE"\n}'),
+            ("json", False, '{\n    "stack": "\x1b[32mCREATE_COMPLETE\x1b[0m\"\n}'),
             ("yaml", True, "stack: CREATE_COMPLETE\n"),
             ("yaml", False, "stack: \x1b[32mCREATE_COMPLETE\x1b[0m\n")
         ]


### PR DESCRIPTION
Output for `list`actions has been improved slightly by including
stack names in the output.

Output for `describe` actions has been fixed so that YAML and JSON
is properly formatted.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [x] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
