### PR TITLE
Update "Environment Path" -> "Stack Group Path" in documentation

### DIFF
--- a/docs/docs/stack_group_config.md
+++ b/docs/docs/stack_group_config.md
@@ -108,7 +108,7 @@ and would only be applied to builds in the `dev` StackGroup.
 
 Sceptre supports the use of templating in config files. Templating allows
 config files to be further configured using values from the command line,
-environment variables, files or parts of the environment path.
+environment variables, files or parts of the stack group path.
 
 Internally, Sceptre uses Jinja2 for templating, so any valid Jinja2 syntax
 should work with Sceptre templating.
@@ -196,16 +196,16 @@ region: eu-west-1
 
 Where `PROFILE` is the name of an environment variable.
 
-### Environment Path
+### Stack Group Path
 
-Config item values can be replaced with parts of the environment path:
+Config item values can be replaced with parts of the stack group path:
 
 ```yaml
 region: {% raw %}{{ stack_group_path.0 }}{% endraw %}
 profile: default
 ```
 
-Where the value is taken from the first part of the environment path from the
+Where the value is taken from the first part of the stack group path from the
 invoking sceptre command:
 
 ```shell


### PR DESCRIPTION
This makes the accompanying text match the code examples, and removes
confusing references to the old "Environment Path" name.

[Your PR description here]

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] This is a documentation change only, so I didn't add any tests.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
