### PR TITLE
[Resolves #539] Update docs for Custom Resolver `setup.py`

### DIFF
--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -15,11 +15,11 @@ If required, users can create their own `hooks`, as described in the section
 
 ## Hook points
 
-`before_create` or `after_create` - run hook before or after stack creation.
+`before_create` or `after_create` - run hook before or after Stack creation.
 
-`before_update` or `after_update` - run hook before or after stack update.
+`before_update` or `after_update` - run hook before or after Stack update.
 
-`before_delete` or `after_delete` - run hook before or after stack deletion.
+`before_delete` or `after_delete` - run hook before or after Stack deletion.
 
 Syntax:
 
@@ -160,9 +160,10 @@ from setuptools import setup
 
 setup(
     name='custom_hook',
+    py_modules=['<custom_hook_name>'],
     entry_points={
         'sceptre.hooks': [
-            'custom_hook = custom_hook:CustomHook',
+            '<custom_hook_name> = <custom_hook_name>:CustomHook',
         ],
     }
 )
@@ -170,7 +171,7 @@ setup(
 
 Then install using `python setup.py install` or `pip install .` commands.
 
-This hook can be used in a stack config file with the following syntax:
+This hook can be used in a Stack config file with the following syntax:
 
 ```yaml
 template_path: <...>

--- a/docs/docs/resolvers.md
+++ b/docs/docs/resolvers.md
@@ -88,21 +88,21 @@ from.
 Fetches the value of an output from a different Stack in the same account and
 region.
 
-If the Stack whose output is being fetched is in the same environment, the
+If the Stack whose output is being fetched is in the same StackGroup, the
 basename of that Stack can be used.
 
 Syntax:
 
 ```yaml
 parameters/sceptre_user_data:
-  <name>: !stack_output_external <full_stack_name>.yaml::<output_name>
+  <name>: !stack_output_external <full_stack_name>::<output_name> <optional-aws-profile-name>
 ```
 
 Example:
 
 ```yaml
 parameters:
-  VpcIdParameter: !stack_output_external prj-network-vpc.yaml::VpcIdOutput
+  VpcIdParameter: !stack_output_external prj-network-vpc::VpcIdOutput prod
 ```
 
 ## Custom Resolvers
@@ -175,9 +175,10 @@ from setuptools import setup
 
 setup(
     name='custom_resolver',
+    py_modules=['<custom_resolver_name>'],
     entry_points={
         'sceptre.resolvers': [
-            'custom_resolver = custom_resolver:CustomResolver',
+            '<custom_resolver_name> = <custom_resolver_name>:CustomResolver',
         ],
     }
 )
@@ -190,5 +191,5 @@ This resolver can be used in a Stack config file with the following syntax:
 ```yaml
 template_path: <...>
 parameters:
-  param1: !<your_resolver_name> <value>
+  param1: !<your_resolver_name> <value> <optional-aws-profile>
 ```


### PR DESCRIPTION
The documentation was missing `py_modules` in `setup.py` for custom resolvers. Omitting this meant that custom resolver modules were not "discoverable" outside of their local scope and therefore, Sceptre was unable to load them. 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
