### PR TITLE
[#Resolves 556] Clarify docs on stack_output resolver

### DIFF
--- a/docs/docs/resolvers.md
+++ b/docs/docs/resolvers.md
@@ -83,10 +83,13 @@ and builds that Stack before the current one.
 This resolver will add a dependency for the Stack in which needs the output
 from.
 
+With `!stack_output` you can reference any stack within a Sceptre project.
+
 ### stack_output_external
 
 Fetches the value of an output from a different Stack in the same account and
-region.
+region. You can specify a optional AWS profile to connect to a differnt
+account/region.
 
 If the Stack whose output is being fetched is in the same StackGroup, the
 basename of that Stack can be used.


### PR DESCRIPTION
In v1 stack_output resolver could only reference outputs from Stacks
within the same environment. In v2 stack_output can reference outputs
from any Stack in the Sceptre project.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
