### PR TITLE
Issue 573: Remove duplication of timestamp (v2)

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -777,7 +777,6 @@ class StackActions(object):
         ]
         for event in new_events:
             self.logger.info(" ".join([
-                event["Timestamp"].replace(microsecond=0).isoformat(),
                 self.stack.name,
                 event["LogicalResourceId"],
                 event["ResourceType"],


### PR DESCRIPTION
This removes the extra timestamp on the right when cloudformation is running.

I'm submitting a PR for both v1/v2 as it seems like the log line contains duplicated timestamp in v1 and v2.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
