### PR TITLE
[Resolve #579] fix update-stack return code

### DIFF
--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -149,6 +149,13 @@ class StackDoesNotExistError(SceptreException):
     pass
 
 
+class NoUpdatesToPerformError(SceptreException):
+    """
+    Error raised when there are no stack updates to perform.
+    """
+    pass
+
+
 class StackConfigurationDoesNotExistError(SceptreException):
     """
     Error raised when a stack configuration does not exist.


### PR DESCRIPTION
The update-stack command returns a non 0 status when there are no
changes to peform.  No updates is not be an Error, it should behave
like launch-stack where no updates is not an error either.  Fix
it so that sceptre ignores the error from boto when there are no
changes to the stack.  This will help run sceptre in a CI/CD scenario.


-----------------

* [x] Wrote [good commit messages][1].
* [x] [Squashed related commits together][2] after the changes have been approved.
* [x] Commit message starts with `[Resolve #issue-number]` (if a related issue exists).
* [x] Added unit tests.
* [x] Added integration tests (if applicable).
* [x] All unit tests (`make test`) are passing.
* [x] Used the same coding conventions as the rest of the project.
* [x] The new code doesn't generate flake8 (`make lint`) offenses.
* [x] The PR relates to *only* one subject with a clear title
  axd description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit