### PR TITLE
Fix CVE-2017-18342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ packaging==16.8
 pygments==2.2.0
 pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
-PyYaml==3.13
+PyYaml>=4.2b1,<5.0
 readme-renderer>=24.0
 setuptools>=40.6.2
 six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("CHANGELOG.md") as history_file:
 install_requirements = [
     "boto3>=1.3,<2.0",
     "click==6.7",
-    "PyYaml==3.13",
+    "PyYaml>=4.2b1,<5.0",
     "Jinja2>=2.8,<3",
     "packaging==16.8",
     "colorama==0.3.7",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,7 +244,7 @@ class TestCli(object):
         self.mock_stack_actions.describe_resources.return_value = response
         result = self.runner.invoke(cli, ["list", "resources", "dev"])
 
-        assert yaml.load(result.output) == [response]
+        assert yaml.safe_load(result.output) == [response]
         assert result.exit_code == 0
 
     def test_list_stack_resources(self):
@@ -258,7 +258,7 @@ class TestCli(object):
         }
         self.mock_stack_actions.describe_resources.return_value = response
         result = self.runner.invoke(cli, ["list", "resources", "dev/vpc.yaml"])
-        assert yaml.load(result.output) == [response]
+        assert yaml.safe_load(result.output) == [response]
         assert result.exit_code == 0
 
     @pytest.mark.parametrize(
@@ -375,7 +375,7 @@ class TestCli(object):
         if not verbose_flag:
             del response["VerboseProperty"]
             del response["Changes"][0]["ResourceChange"]["VerboseProperty"]
-        assert yaml.load(result.output) == response
+        assert yaml.safe_load(result.output) == response
         assert result.exit_code == 0
 
     def test_list_change_sets_with_200(self):
@@ -386,7 +386,7 @@ class TestCli(object):
             cli, ["list", "change-sets", "dev/vpc.yaml"]
         )
         assert result.exit_code == 0
-        assert yaml.load(result.output) == {"ChangeSets": "Test"}
+        assert yaml.safe_load(result.output) == {"ChangeSets": "Test"}
 
     def test_list_change_sets_without_200(self):
         response = {
@@ -398,7 +398,7 @@ class TestCli(object):
             cli, ["list", "change-sets", "dev/vpc.yaml"]
         )
         assert result.exit_code == 0
-        assert yaml.load(result.output) == response
+        assert yaml.safe_load(result.output) == response
 
     def test_list_outputs(self):
         outputs = [{"OutputKey": "Key", "OutputValue": "Value"}]
@@ -407,7 +407,7 @@ class TestCli(object):
             cli, ["list", "outputs", "dev/vpc.yaml"]
         )
         assert result.exit_code == 0
-        assert yaml.load(result.output) == [outputs]
+        assert yaml.safe_load(result.output) == [outputs]
 
     def test_list_outputs_with_export(self):
         outputs = [{"OutputKey": "Key", "OutputValue": "Value"}]
@@ -416,7 +416,7 @@ class TestCli(object):
             cli, ["list", "outputs", "dev/vpc.yaml", "-e", "envvar"]
         )
         assert result.exit_code == 0
-        assert yaml.load(result.output) == "export SCEPTRE_Key=Value"
+        assert yaml.safe_load(result.output) == "export SCEPTRE_Key=Value"
 
     def test_status_with_group(self):
         self.mock_stack_actions.get_status.return_value = {
@@ -451,7 +451,7 @@ class TestCli(object):
             assert os.path.isdir(template_dir)
 
             with open(os.path.join(config_dir, "config.yaml")) as config_file:
-                config = yaml.load(config_file)
+                config = yaml.safe_load(config_file)
 
             assert config == defaults
 
@@ -477,7 +477,7 @@ class TestCli(object):
             assert os.path.isdir(template_dir)
 
             with open(os.path.join(config_dir, "config.yaml")) as config_file:
-                config = yaml.load(config_file)
+                config = yaml.safe_load(config_file)
             assert existing_config == config
 
     def test_new_project_another_exception(self):
@@ -559,7 +559,7 @@ class TestCli(object):
             if result:
                 with open(os.path.join(stack_group_dir, "config.yaml"))\
                         as config_file:
-                    config = yaml.load(config_file)
+                    config = yaml.safe_load(config_file)
                 assert config == result
             else:
                 assert cmd_result.output.endswith(
@@ -585,7 +585,7 @@ class TestCli(object):
             )
             with open(os.path.join(
                     stack_group_dir, "config.yaml")) as config_file:
-                config = yaml.load(config_file)
+                config = yaml.safe_load(config_file)
             assert config == {"project_code": "", "region": ""}
 
     def test_new_stack_group_folder_with_another_exception(self):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -187,7 +187,7 @@ class TestTemplate(object):
             "tests/fixtures/templates/vpc.yaml"
         )
         output = self.template.body
-        output_dict = yaml.load(output)
+        output_dict = yaml.safe_load(output)
         with open("tests/fixtures/templates/compiled_vpc.json", "r") as f:
             expected_output_dict = json.loads(f.read())
         assert output_dict == expected_output_dict


### PR DESCRIPTION
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code.
In other words, yaml.safe_load is not used.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
