### PR TITLE
add missing output_format support to generate

### DIFF
--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -59,12 +59,13 @@ def generate_command(ctx, path):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
+        output_format=ctx.obj.get("output_format"),
         ignore_dependencies=ctx.obj.get("ignore_dependencies")
     )
 
     plan = SceptrePlan(context)
     responses = plan.generate()
-    write(responses.values())
+    write(responses.values(), context.output_format)
 
 
 @click.command(name="estimate-cost")


### PR DESCRIPTION
prior this fix generate action output_format default to "str" in v2.
