### PR TITLE
[Resolves #324] Add CAPABILITY_AUTO_EXPAND permission to enable transforms for SAM templates

### DIFF
--- a/integration-tests/features/create-change-set.feature
+++ b/integration-tests/features/create-change-set.feature
@@ -27,3 +27,10 @@ Feature: Create change set
     and stack "1/A" does not have change set "A"
     When the user creates change set "A" for stack "1/A" with ignore dependencies
     Then stack "1/A" has change set "A" in "CREATE_COMPLETE" state
+
+  Scenario: create new change set with a SAM template
+    Given stack "11/A" exists in "CREATE_COMPLETE" state
+    and the template for stack "11/A" is "sam_updated_template.yaml"
+    and stack "11/A" does not have change set "A"
+    When the user creates change set "A" for stack "11/A"
+    Then stack "11/A" has change set "A" in "CREATE_COMPLETE" state

--- a/integration-tests/features/create-stack.feature
+++ b/integration-tests/features/create-stack.feature
@@ -42,3 +42,9 @@ Feature: Create stack
     and the template for stack "1/A" is "valid_template.json"
     When the user creates stack "1/A" with ignore dependencies
     Then stack "1/A" exists in "CREATE_COMPLETE" state
+
+  Scenario: create new stack containing a SAM template transform
+    Given stack "10/A" does not exist
+    and the template for stack "10/A" is "sam_template.yaml"
+    When the user creates stack "10/A"
+    Then stack "10/A" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/update-stack.feature
+++ b/integration-tests/features/update-stack.feature
@@ -31,3 +31,8 @@ Feature: Update stack
     When the user updates stack "1/A" with ignore dependencies
     Then stack "1/A" exists in "UPDATE_COMPLETE" state
 
+  Scenario: update a stack that was newly created with a SAM template
+    Given stack "11/A" exists in "CREATE_COMPLETE" state
+    and the template for stack "11/A" is "sam_updated_template.yaml"
+    When the user updates stack "11/A"
+    Then stack "11/A" exists in "UPDATE_COMPLETE" state

--- a/integration-tests/sceptre-project/config/10/A.yaml
+++ b/integration-tests/sceptre-project/config/10/A.yaml
@@ -1,0 +1,2 @@
+stack_timeout: 1
+template_path: sam_template.yaml

--- a/integration-tests/sceptre-project/config/10/A.yaml
+++ b/integration-tests/sceptre-project/config/10/A.yaml
@@ -1,2 +1,1 @@
-stack_timeout: 1
 template_path: sam_template.yaml

--- a/integration-tests/sceptre-project/config/11/A.yaml
+++ b/integration-tests/sceptre-project/config/11/A.yaml
@@ -1,0 +1,1 @@
+template_path: sam_updated_template.yaml

--- a/integration-tests/sceptre-project/templates/sam_template.yaml
+++ b/integration-tests/sceptre-project/templates/sam_template.yaml
@@ -1,0 +1,6 @@
+Transform: 'AWS::Serverless-2016-10-31'
+
+Resources:
+    WaitConditionHandle:
+      Type: "AWS::CloudFormation::WaitConditionHandle"
+      Properties:

--- a/integration-tests/sceptre-project/templates/sam_template.yaml
+++ b/integration-tests/sceptre-project/templates/sam_template.yaml
@@ -1,6 +1,9 @@
 Transform: 'AWS::Serverless-2016-10-31'
 
 Resources:
-    WaitConditionHandle:
-      Type: "AWS::CloudFormation::WaitConditionHandle"
-      Properties:
+  TestFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: index.handler
+      Runtime: python3.6
+      InlineCode: "print('Hello World!')"

--- a/integration-tests/sceptre-project/templates/sam_updated_template.yaml
+++ b/integration-tests/sceptre-project/templates/sam_updated_template.yaml
@@ -1,0 +1,9 @@
+Transform: 'AWS::Serverless-2016-10-31'
+
+Resources:
+    TestFunction2:
+      Type: 'AWS::Serverless::Function'
+      Properties:
+        Handler: index.handler
+        Runtime: python3.6
+        InlineCode: "print('Hello Again World!')"

--- a/integration-tests/steps/change_sets.py
+++ b/integration-tests/steps/change_sets.py
@@ -16,7 +16,7 @@ def step_impl(context, stack_name, change_set_name, filename):
     retry_boto_call(
         context.client.create_change_set,
         StackName=full_name,
-        Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+        Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
         ChangeSetName=change_set_name,
         TemplateBody=read_template_file(context, filename)
     )

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -59,7 +59,7 @@ class StackActions(object):
         create_stack_kwargs = {
             "StackName": self.stack.external_name,
             "Parameters": self._format_parameters(self.stack.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             "NotificationARNs": self.stack.notifications,
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
@@ -111,7 +111,7 @@ class StackActions(object):
         update_stack_kwargs = {
             "StackName": self.stack.external_name,
             "Parameters": self._format_parameters(self.stack.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             "NotificationARNs": self.stack.notifications,
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
@@ -439,7 +439,7 @@ class StackActions(object):
         create_change_set_kwargs = {
             "StackName": self.stack.external_name,
             "Parameters": self._format_parameters(self.stack.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             "ChangeSetName": change_set_name,
             "NotificationARNs": self.stack.notifications,
             "Tags": [

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -99,7 +99,9 @@ class TestStackActions(object):
                     "ParameterKey": "key1",
                     "ParameterValue": "val1"
                 }],
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM',
+                                 'CAPABILITY_NAMED_IAM',
+                                 'CAPABILITY_AUTO_EXPAND'],
                 "RoleARN": sentinel.role_arn,
                 "NotificationARNs": [sentinel.notification],
                 "Tags": [
@@ -132,7 +134,9 @@ class TestStackActions(object):
                     "ParameterKey": "key1",
                     "ParameterValue": "val1"
                 }],
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM',
+                                 'CAPABILITY_NAMED_IAM',
+                                 'CAPABILITY_AUTO_EXPAND'],
                 "RoleARN": sentinel.role_arn,
                 "NotificationARNs": [],
                 "Tags": [
@@ -164,7 +168,9 @@ class TestStackActions(object):
                     "ParameterKey": "key1",
                     "ParameterValue": "val1"
                 }],
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM',
+                                 'CAPABILITY_NAMED_IAM',
+                                 'CAPABILITY_AUTO_EXPAND'],
                 "RoleARN": sentinel.role_arn,
                 "NotificationARNs": [sentinel.notification],
                 "Tags": [
@@ -192,7 +198,9 @@ class TestStackActions(object):
                     "ParameterKey": "key1",
                     "ParameterValue": "val1"
                 }],
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM',
+                                 'CAPABILITY_NAMED_IAM',
+                                 'CAPABILITY_AUTO_EXPAND'],
                 "RoleARN": sentinel.role_arn,
                 "NotificationARNs": [sentinel.notification],
                 "Tags": [
@@ -224,7 +232,9 @@ class TestStackActions(object):
                         "ParameterKey": "key1",
                         "ParameterValue": "val1"
                     }],
-                    "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                    "Capabilities": ['CAPABILITY_IAM',
+                                     'CAPABILITY_NAMED_IAM',
+                                     'CAPABILITY_AUTO_EXPAND'],
                     "RoleARN": sentinel.role_arn,
                     "NotificationARNs": [sentinel.notification],
                     "Tags": [
@@ -262,7 +272,9 @@ class TestStackActions(object):
                     "ParameterKey": "key1",
                     "ParameterValue": "val1"
                 }],
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM',
+                                 'CAPABILITY_NAMED_IAM',
+                                 'CAPABILITY_AUTO_EXPAND'],
                 "RoleARN": sentinel.role_arn,
                 "NotificationARNs": [],
                 "Tags": [
@@ -570,7 +582,9 @@ class TestStackActions(object):
                     "ParameterKey": "key1",
                     "ParameterValue": "val1"
                 }],
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM',
+                                 'CAPABILITY_NAMED_IAM',
+                                 'CAPABILITY_AUTO_EXPAND'],
                 "ChangeSetName": sentinel.change_set_name,
                 "RoleARN": sentinel.role_arn,
                 "NotificationARNs": [sentinel.notification],
@@ -598,7 +612,9 @@ class TestStackActions(object):
                     "ParameterKey": "key1",
                     "ParameterValue": "val1"
                 }],
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM',
+                                 'CAPABILITY_NAMED_IAM',
+                                 'CAPABILITY_AUTO_EXPAND'],
                 "ChangeSetName": sentinel.change_set_name,
                 "RoleARN": sentinel.role_arn,
                 "NotificationARNs": [],


### PR DESCRIPTION
CloudFormation requires the CAPABILITY_AUTO_EXPAND permission in order to execute the SAM template transform (see issue #538 and #324). This PR adds this permission to the create stack, update stack, and create change set plan actions.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
