### PR TITLE
[Resolves #576] Fix envvar output

### DIFF
--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -79,12 +79,13 @@ def list_outputs(ctx, path, export):
     ]
 
     if export == "envvar":
-        write("\n".join(
-            "export SCEPTRE_{0}={1}".format(
-                output["OutputKey"], output["OutputValue"]
-            )
-            for response in responses for output in response
-        ))
+        for response in responses:
+            for stack in response.values():
+                for output in stack:
+                    write("export SCEPTRE_{0}={1}".format(
+                                output.get("OutputKey"),
+                                output.get("OutputValue")
+                            ), 'str')
     else:
         write(responses, context.output_format)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,7 +410,7 @@ class TestCli(object):
         assert yaml.safe_load(result.output) == [outputs]
 
     def test_list_outputs_with_export(self):
-        outputs = [{"OutputKey": "Key", "OutputValue": "Value"}]
+        outputs = {'stack': [{"OutputKey": "Key", "OutputValue": "Value"}]}
         self.mock_stack_actions.describe_outputs.return_value = outputs
         result = self.runner.invoke(
             cli, ["list", "outputs", "dev/vpc.yaml", "-e", "envvar"]


### PR DESCRIPTION
Envvar output in `sceptre list outputs...` was broken from 2.0.0. This PR resolves fixes this issue so that environment variables can be set from outputs as follows:

```bash
eval $(sceptre list outputs STACK -e envvar)
```

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
