### PR TITLE
Added support for CloudFormation Macros by adding CAPABILITY_AUTO_EXPAND

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -193,7 +193,7 @@ class Stack(object):
         create_stack_kwargs = {
             "StackName": self.external_name,
             "Parameters": self._format_parameters(self.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             "NotificationARNs": self.config.get("notifications", []),
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
@@ -232,7 +232,7 @@ class Stack(object):
         update_stack_kwargs = {
             "StackName": self.external_name,
             "Parameters": self._format_parameters(self.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             "NotificationARNs": self.config.get("notifications", []),
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
@@ -524,7 +524,7 @@ class Stack(object):
         create_change_set_kwargs = {
             "StackName": self.external_name,
             "Parameters": self._format_parameters(self.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             "ChangeSetName": change_set_name,
             "NotificationARNs": self.config.get("notifications", []),
             "Tags": [


### PR DESCRIPTION
CloudFormation Macros require Capability called CAPABILITY_AUTO_EXPAND.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
