### PR TITLE
Added support for CAPABILITY_AUTO_EXPAND

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -198,7 +198,7 @@ class Stack(object):
             create_stack_kwargs = {
                 "StackName": self.external_name,
                 "Parameters": self._format_parameters(self.parameters),
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
                 "NotificationARNs": self.config.get("notifications", []),
                 "Tags": [
                     {"Key": str(k), "Value": str(v)}
@@ -249,7 +249,7 @@ class Stack(object):
             update_stack_kwargs = {
                 "StackName": self.external_name,
                 "Parameters": self._format_parameters(self.parameters),
-                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+                "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
                 "NotificationARNs": self.config.get("notifications", []),
                 "Tags": [
                     {"Key": str(k), "Value": str(v)}
@@ -564,7 +564,7 @@ class Stack(object):
         create_change_set_kwargs = {
             "StackName": self.external_name,
             "Parameters": self._format_parameters(self.parameters),
-            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            "Capabilities": ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             "ChangeSetName": change_set_name,
             "NotificationARNs": self.config.get("notifications", []),
             "Tags": [


### PR DESCRIPTION
Added support for CloudFormation Macros by adding CAPABILITY_AUTO_EXPAND
CloudFormation Macros require capability called 'CAPABILITY_AUTO_EXPAND' to be checked.

[Your PR description here]

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
