### PR TITLE
[Resolves #570] Improve Stack.__repr__()

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -145,20 +145,26 @@ class Stack(object):
     def __repr__(self):
         return (
             "sceptre.stack.Stack("
-            "name='{name}', project_code='{project_code}', "
-            "template_path='{template_path}', region='{region}', "
-            "template_bucket_name='{template_bucket_name}', "
-            "template_key_prefix='{template_key_prefix}', "
-            "required_version='{required_version}', "
-            "profile='{profile}', "
+            "name={name}, "
+            "project_code={project_code}, "
+            "template_path={template_path}, "
+            "region={region}, "
+            "template_bucket_name={template_bucket_name}, "
+            "template_key_prefix={template_key_prefix}, "
+            "required_version={required_version}, "
+            "profile={profile}, "
             "sceptre_user_data={sceptre_user_data}, "
             "parameters={parameters}, "
-            "hooks={hooks}, s3_details='{s3_details}', "
-            "dependencies={dependencies}, role_arn='{role_arn}', "
-            "protected='{protected}', tags={tags}, "
-            "external_name='{external_name}', "
-            "notifications={notifications}, on_failure='{on_failure}', "
-            "stack_timeout='{stack_timeout}', "
+            "hooks={hooks}, "
+            "s3_details={s3_details}, "
+            "dependencies={dependencies}, "
+            "role_arn={role_arn}, "
+            "protected={protected}, "
+            "tags={tags}, "
+            "external_name={external_name}, "
+            "notifications={notifications}, "
+            "on_failure={on_failure}, "
+            "stack_timeout={stack_timeout}, "
             "stack_group_config={stack_group_config}"
             ")".format(
                 name=self.name,
@@ -187,6 +193,34 @@ class Stack(object):
 
     def __str__(self):
         return self.name
+
+    def __eq__(self, stack):
+        return (
+            self.name == stack.name and
+            self.project_code == stack.project_code and
+            self.template_path == stack.template_path and
+            self.region == stack.region and
+            self.template_bucket_name == stack.template_bucket_name and
+            self.template_key_prefix == stack.template_key_prefix and
+            self.required_version == stack.required_version and
+            self.profile == stack.profile and
+            self.sceptre_user_data == stack.sceptre_user_data and
+            self.parameters == stack.parameters and
+            self.hooks == stack.hooks and
+            self.s3_details == stack.s3_details and
+            self.dependencies == stack.dependencies and
+            self.role_arn == stack.role_arn and
+            self.protected == stack.protected and
+            self.tags == stack.tags and
+            self.external_name == stack.external_name and
+            self.notifications == stack.notifications and
+            self.on_failure == stack.on_failure and
+            self.stack_timeout == stack.stack_timeout and
+            self.stack_group_config == stack.stack_group_config
+        )
+
+    def __hash__(self):
+        return hash(str(self))
 
     @property
     def template(self):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -151,15 +151,15 @@ class Stack(object):
             "template_key_prefix='{template_key_prefix}', "
             "required_version='{required_version}', "
             "profile='{profile}', "
-            "sceptre_user_data='{sceptre_user_data}', "
-            "parameters='{parameters}', "
-            "hooks='{hooks}', s3_details='{s3_details}', "
-            "dependencies='{dependencies}', role_arn='{role_arn}', "
-            "protected='{protected}', tags='{tags}', "
+            "sceptre_user_data={sceptre_user_data}, "
+            "parameters={parameters}, "
+            "hooks={hooks}, s3_details='{s3_details}', "
+            "dependencies={dependencies}, role_arn='{role_arn}', "
+            "protected='{protected}', tags={tags}, "
             "external_name='{external_name}', "
-            "notifications='{notifications}', on_failure='{on_failure}', "
+            "notifications={notifications}, on_failure='{on_failure}', "
             "stack_timeout='{stack_timeout}', "
-            "stack_group_config='{stack_group_config}'"
+            "stack_group_config={stack_group_config}"
             ")".format(
                 name=self.name,
                 project_code=self.project_code,

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -67,15 +67,15 @@ class TestStack(object):
             "template_key_prefix='sentinel.template_key_prefix', "\
             "required_version='sentinel.required_version', "\
             "profile='sentinel.profile', " \
-            "sceptre_user_data='sentinel.sceptre_user_data', " \
-            "parameters='{'key1': 'val1'}', "\
-            "hooks='{}', s3_details='None', " \
-            "dependencies='sentinel.dependencies', "\
+            "sceptre_user_data=sentinel.sceptre_user_data, " \
+            "parameters={'key1': 'val1'}, "\
+            "hooks={}, s3_details='None', " \
+            "dependencies=sentinel.dependencies, "\
             "role_arn='sentinel.role_arn', " \
-            "protected='False', tags='{'tag1': 'val1'}', " \
+            "protected='False', tags={'tag1': 'val1'}, " \
             "external_name='sentinel.external_name', " \
-            "notifications='[sentinel.notification]', " \
+            "notifications=[sentinel.notification], " \
             "on_failure='sentinel.on_failure', " \
             "stack_timeout='sentinel.stack_timeout', " \
-            "stack_group_config='{}'" \
+            "stack_group_config={}" \
             ")"

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import importlib
 from mock import sentinel, MagicMock
 
 from sceptre.stack import Stack
@@ -59,23 +60,38 @@ class TestStack(object):
     def test_repr(self):
         assert self.stack.__repr__() == \
             "sceptre.stack.Stack(" \
-            "name='sentinel.stack_name', " \
-            "project_code='sentinel.project_code', " \
-            "template_path='sentinel.template_path', " \
-            "region='sentinel.region', " \
-            "template_bucket_name='sentinel.template_bucket_name', "\
-            "template_key_prefix='sentinel.template_key_prefix', "\
-            "required_version='sentinel.required_version', "\
-            "profile='sentinel.profile', " \
+            "name=sentinel.stack_name, " \
+            "project_code=sentinel.project_code, " \
+            "template_path=sentinel.template_path, " \
+            "region=sentinel.region, " \
+            "template_bucket_name=sentinel.template_bucket_name, "\
+            "template_key_prefix=sentinel.template_key_prefix, "\
+            "required_version=sentinel.required_version, "\
+            "profile=sentinel.profile, " \
             "sceptre_user_data=sentinel.sceptre_user_data, " \
             "parameters={'key1': 'val1'}, "\
-            "hooks={}, s3_details='None', " \
+            "hooks={}, "\
+            "s3_details=None, " \
             "dependencies=sentinel.dependencies, "\
-            "role_arn='sentinel.role_arn', " \
-            "protected='False', tags={'tag1': 'val1'}, " \
-            "external_name='sentinel.external_name', " \
+            "role_arn=sentinel.role_arn, "\
+            "protected=False, "\
+            "tags={'tag1': 'val1'}, "\
+            "external_name=sentinel.external_name, " \
             "notifications=[sentinel.notification], " \
-            "on_failure='sentinel.on_failure', " \
-            "stack_timeout='sentinel.stack_timeout', " \
+            "on_failure=sentinel.on_failure, " \
+            "stack_timeout=sentinel.stack_timeout, " \
             "stack_group_config={}" \
             ")"
+
+    def test_repr_can_eval_correctly(self):
+        sceptre = importlib.import_module('sceptre')
+        mock = importlib.import_module('mock')
+        evaluated_stack = eval(
+                repr(self.stack),
+                {
+                    'sceptre': sceptre,
+                    'sentinel': mock.mock.sentinel
+                }
+            )
+        assert isinstance(evaluated_stack, Stack)
+        assert evaluated_stack.__eq__(self.stack)


### PR DESCRIPTION
Previously, dict and list types were contained within strings in
`sceptre.stack.Stack.__repr__()`. This commit removes the strings so that
a `stack.__repr__()` can be used to create a stack using `eval()`.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
