### PR TITLE
Use `importlib` instead of `imp`

### DIFF
--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -7,11 +7,11 @@ This module implements a Template class, which stores a CloudFormation template
 and implements methods for uploading it to S3.
 """
 
-import imp
 import logging
 import os
 import sys
 import threading
+from importlib.machinery import SourceFileLoader
 
 import botocore
 import jinja2
@@ -123,7 +123,7 @@ class Template(object):
         if not os.path.isfile(self.path):
             raise IOError("No such file or directory: '%s'", self.path)
 
-        module = imp.load_source(self.name, self.path)
+        module = SourceFileLoader(self.name, self.path).load_module()
 
         try:
             body = module.sceptre_handler(self.sceptre_user_data)

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Environment :: Console",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6"


### PR DESCRIPTION
`imp` was depreciated as of Python 3.4. This commit uses the
preferred `importlib`. Note this will cause Sceptre to be
incompatible with Python versions pre 2.7.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
