### PR TITLE
[Resolves #607] format docstring for better --help

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 behave==1.2.5
 boto3>=1.3.0,<2
 bumpversion==0.5.3
-click==6.7
+click==7.0
 colorama==0.3.7
 coverage==4.4.2
 flake8==3.5.0

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -6,7 +6,7 @@ from sceptre.plan.plan import SceptrePlan
 from sceptre.cli.helpers import stack_status_exit_code
 
 
-@click.command(name="create")
+@click.command(name="create", short_help="Creates a stack or a change set.")
 @click.argument("path")
 @click.argument("change-set-name", required=False)
 @click.option(
@@ -16,10 +16,9 @@ from sceptre.cli.helpers import stack_status_exit_code
 @catch_exceptions
 def create_command(ctx, path, change_set_name, yes):
     """
-    Creates a stack or a change set.
-
     Creates a stack for a given config PATH. Or if CHANGE_SET_NAME is specified
     creates a change set for stack in PATH.
+    \f
 
     :param path: Path to a Stack or StackGroup
     :type path: str

--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -9,7 +9,7 @@ from sceptre.plan.plan import SceptrePlan
 from colorama import Fore, Style
 
 
-@click.command(name="delete")
+@click.command(name="delete", short_help="Deletes a stack or a change set.")
 @click.argument("path")
 @click.argument("change-set-name", required=False)
 @click.option(
@@ -19,10 +19,9 @@ from colorama import Fore, Style
 @catch_exceptions
 def delete_command(ctx, path, change_set_name, yes):
     """
-    Deletes a stack or a change set.
-
     Deletes a stack for a given config PATH. Or if CHANGE_SET_NAME is specified
     deletes a change set for stack in PATH.
+    \f
 
     :param path: Path to execute command on.
     :type path: str

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -29,6 +29,7 @@ def describe_group(ctx):
 def describe_change_set(ctx, path, change_set_name, verbose):
     """
     Describes the change set.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str
@@ -64,6 +65,7 @@ def describe_change_set(ctx, path, change_set_name, verbose):
 def describe_policy(ctx, path):
     """
     Displays the stack policy used.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -16,6 +16,7 @@ from sceptre.plan.plan import SceptrePlan
 def execute_command(ctx, path, change_set_name, yes):
     """
     Executes a Change Set.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -7,7 +7,7 @@ from sceptre.cli.helpers import stack_status_exit_code
 from sceptre.plan.plan import SceptrePlan
 
 
-@click.command(name="launch")
+@click.command(name="launch", short_help="Launch a Stack or StackGroup.")
 @click.argument("path")
 @click.option(
     "-y", "--yes", is_flag=True, help="Assume yes to all questions."
@@ -16,9 +16,8 @@ from sceptre.plan.plan import SceptrePlan
 @catch_exceptions
 def launch_command(ctx, path, yes):
     """
-    Launch a Stack or StackGroup.
-
     Launch a Stack or StackGroup for a given config PATH.
+    \f
 
     :param path: The path to launch. Can be a Stack or StackGroup.
     :type path: str

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -24,6 +24,7 @@ def list_group():
 def list_resources(ctx, path):
     """
     List resources for stack or stack_group.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str
@@ -57,6 +58,7 @@ def list_resources(ctx, path):
 def list_outputs(ctx, path, export):
     """
     List outputs for stack.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str
@@ -97,6 +99,7 @@ def list_outputs(ctx, path, export):
 def list_change_sets(ctx, path):
     """
     List change sets for stack.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str

--- a/sceptre/cli/new.py
+++ b/sceptre/cli/new.py
@@ -18,16 +18,15 @@ def new_group():
     pass
 
 
-@new_group.command("group")
+@new_group.command("group", short_help="Creates a new Stack Group directory in a project.")
 @click.argument('stack_group')
 @catch_exceptions
 @click.pass_context
 def new_stack_group(ctx, stack_group):
     """
-    Creates a new Stack Group directory in a project.
-
     Creates StackGroup folder in the project and a config.yaml with any
     required properties.
+    \f
 
     :param stack_group: Name of the StackGroup directory to create.
     :type stack_group: str
@@ -40,15 +39,15 @@ def new_stack_group(ctx, stack_group):
             _create_new_stack_group(config_dir, stack_group)
 
 
-@new_group.command("project")
+@new_group.command("project", short_help="Creates a new project.")
 @catch_exceptions
 @click.argument('project_name')
 @click.pass_context
 def new_project(ctx, project_name):
     """
-    Creates a new project.
     Creates PROJECT_NAME project folder and a config.yaml with any
     required properties.
+    \f
 
     :param project_name: The name of the Sceptre Project to create.
     :type project_name: str

--- a/sceptre/cli/policy.py
+++ b/sceptre/cli/policy.py
@@ -5,7 +5,7 @@ from sceptre.cli.helpers import catch_exceptions
 from sceptre.plan.plan import SceptrePlan
 
 
-@click.command(name="set-policy")
+@click.command(name="set-policy", short_help="Sets Stack policy.")
 @click.argument("path")
 @click.argument("policy-file", required=False)
 @click.option(
@@ -16,16 +16,15 @@ from sceptre.plan.plan import SceptrePlan
 @catch_exceptions
 def set_policy_command(ctx, path, policy_file, built_in):
     """
-    Sets Stack policy.
-
     Sets a specific Stack policy for either a file or using a built-in policy.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str
     :param policy_file: path to the AWS Policy file to use.
     :type policy_file: str
     :param built_in: the name of the built-in policy file to use.
-    :type built-in: str
+    :type built_in: str
     """
     context = SceptreContext(
         command_path=path,

--- a/sceptre/cli/status.py
+++ b/sceptre/cli/status.py
@@ -8,16 +8,15 @@ from sceptre.cli.helpers import (
 from sceptre.plan.plan import SceptrePlan
 
 
-@click.command(name="status")
+@click.command(name="status", short_help="Print status of stack or stack_group.")
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
 def status_command(ctx, path):
     """
-    Print status of stack or stack_group.
-
     Prints the stack status or the status of the stacks within a
     stack_group for a given config PATH.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -9,15 +9,14 @@ from sceptre.cli.helpers import (
 from sceptre.plan.plan import SceptrePlan
 
 
-@click.command(name="validate")
+@click.command(name="validate", short_help="Validates the template.")
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
 def validate_command(ctx, path):
     """
-    Validates the template.
-
     Validates the template used for stack in PATH.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str
@@ -41,15 +40,14 @@ def validate_command(ctx, path):
         write(response, context.output_format)
 
 
-@click.command(name="generate")
+@click.command(name="generate", short_help="Prints the template.")
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
 def generate_command(ctx, path):
     """
-    Prints the template.
-
     Prints the template used for stack in PATH.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str
@@ -69,17 +67,16 @@ def generate_command(ctx, path):
     write(output, context.output_format)
 
 
-@click.command(name="estimate-cost")
+@click.command(name="estimate-cost", short_help="Estimates the cost of the template.")
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
 def estimate_cost_command(ctx, path):
     """
-    Estimates the cost of the template.
-
     Prints a URI to STOUT that provides an estimated cost based on the
     resources in the stack. This command will also attempt to open a web
     browser with the returned URI.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -10,7 +10,7 @@ from sceptre.stack_status import StackChangeSetStatus
 from sceptre.plan.plan import SceptrePlan
 
 
-@click.command(name="update")
+@click.command(name="update", short_help="Update a stack.")
 @click.argument("path")
 @click.option(
     "-c", "--change-set", is_flag=True,
@@ -26,10 +26,9 @@ from sceptre.plan.plan import SceptrePlan
 @catch_exceptions
 def update_command(ctx, path, change_set, verbose, yes):
     """
-    Update a stack.
-
     Updates a stack for a given config PATH. Or perform an update via
     change-set when the change-set flag is set.
+    \f
 
     :param path: Path to execute the command on.
     :type path: str

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("CHANGELOG.md") as history_file:
 
 install_requirements = [
     "boto3>=1.3,<2.0",
-    "click==6.7",
+    "click==7.0",
     "PyYaml>=4.2b1,<5.0",
     "Jinja2>=2.8,<3",
     "packaging==16.8",


### PR DESCRIPTION
bumping click to 7.0 that allows truncation of docstrings.
additionally, moved some of the docstrings to short_help to avoid repetition.
finally, minor fix to one of the docstrings.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
