### PR TITLE
[Resolve #558] Fix RecursionError

### DIFF
--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -61,7 +61,7 @@ class StackOutputBase(Resolver):
         self.logger.debug("Collecting outputs from '{0}'...".format(
             stack_name
         ))
-        connection_manager = self.stack.template.connection_manager
+        connection_manager = self.stack.connection_manager
 
         try:
             response = connection_manager.call(

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -22,7 +22,7 @@ class TestStackOutputResolver(object):
         stack = MagicMock(spec=Stack)
         stack.dependencies = []
         stack.project_code = "project-code"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack.connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "account/dev/vpc"
@@ -53,7 +53,7 @@ class TestStackOutputResolver(object):
         stack = MagicMock(spec=Stack)
         stack.dependencies = ["existing"]
         stack.project_code = "project-code"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack.connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "account/dev/vpc"
@@ -87,7 +87,7 @@ class TestStackOutputResolver(object):
         stack.dependencies = []
         stack.project_code = "project-code"
         stack.name = "account/dev/stack"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack.connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "account/dev/vpc"
@@ -119,7 +119,7 @@ class TestStackOutputResolver(object):
         stack.dependencies = []
         stack.project_code = "project-code"
         stack.name = "stack"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack.connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "vpc"
@@ -150,7 +150,7 @@ class TestStackOutputExternalResolver(object):
     def test_resolve(self, mock_get_output_value):
         stack = MagicMock(spec=Stack)
         stack.dependencies = []
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack.connection_manager = MagicMock(spec=ConnectionManager)
         stack_output_external_resolver = StackOutputExternal(
             "another/account-vpc::VpcId", stack
         )
@@ -181,7 +181,7 @@ class TestStackOutputBaseResolver(object):
 
     def setup_method(self, test_method):
         self.stack = MagicMock(spec=Stack)
-        self.stack.template.connection_manager = MagicMock(
+        self.stack.connection_manager = MagicMock(
             spec=ConnectionManager
         )
         self.base_stack_output_resolver = MockStackOutputBase(
@@ -212,7 +212,7 @@ class TestStackOutputBaseResolver(object):
             )
 
     def test_get_stack_outputs_with_valid_stack(self):
-        self.stack.template.connection_manager.call.return_value = {
+        self.stack.connection_manager.call.return_value = {
             "Stacks": [{
                 "Outputs": [
                     {
@@ -239,7 +239,7 @@ class TestStackOutputBaseResolver(object):
         }
 
     def test_get_stack_outputs_with_valid_stack_without_outputs(self):
-        self.stack.template.connection_manager.call.return_value = {
+        self.stack.connection_manager.call.return_value = {
             "Stacks": [{}]
         }
 
@@ -249,7 +249,7 @@ class TestStackOutputBaseResolver(object):
         assert response == {}
 
     def test_get_stack_outputs_with_unlaunched_stack(self):
-        self.stack.template.connection_manager.call.side_effect = ClientError(
+        self.stack.connection_manager.call.side_effect = ClientError(
             {
                 "Error": {
                     "Code": "404",
@@ -265,7 +265,7 @@ class TestStackOutputBaseResolver(object):
             )
 
     def test_get_stack_outputs_with_unkown_boto_error(self):
-        self.stack.template.connection_manager.call.side_effect = ClientError(
+        self.stack.connection_manager.call.side_effect = ClientError(
             {
                 "Error": {
                     "Code": "500",


### PR DESCRIPTION
Getting the connection manager from template object results in
a RecursionError.  Getting it from the stack object does not.