### PR TITLE
[Resolve #623] Catch missing config attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,22 @@ _site/
 /docs/_api/sceptre.rst
 /docs/_api/sceptre.hooks.rst
 /docs/_api/sceptre.resolvers.rst
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -138,3 +138,10 @@ class ConfigFileNotFoundError(SceptreException):
     Error raised when a config file does not exist.
     """
     pass
+
+
+class InvalidConfigFileError(SceptreException):
+    """
+    Error raised when a config file lacks mandatory keys.
+    """
+    pass

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -10,6 +10,7 @@ from sceptre.context import SceptreContext
 from sceptre.exceptions import VersionIncompatibleError
 from sceptre.exceptions import ConfigFileNotFoundError
 from sceptre.exceptions import InvalidSceptreDirectoryError
+from sceptre.exceptions import InvalidConfigFileError
 
 from freezegun import freeze_time
 from click.testing import CliRunner
@@ -276,3 +277,55 @@ class TestConfigReader(object):
             config_reader = ConfigReader(self.context)
             all_stacks, command_stacks = config_reader.construct_stacks()
             assert {str(stack) for stack in all_stacks} == expected_stacks
+
+    @pytest.mark.parametrize("filepaths,target,del_key", [
+        (["A/1.yaml"], "A/1.yaml", "project_code"),
+        (["A/1.yaml"], "A/1.yaml", "region"),
+        (["A/1.yaml"], "A/1.yaml", "template_path"),
+    ])
+    def test_missing_attr(
+        self, filepaths, target, del_key
+    ):
+        with self.runner.isolated_filesystem():
+            project_path = os.path.abspath('./example')
+            config_dir = os.path.join(project_path, "config")
+            os.makedirs(config_dir)
+
+            self.context.project_path = project_path
+
+            for rel_path in filepaths:
+                abs_path = os.path.join(config_dir, rel_path)
+                dir_path = abs_path
+                if abs_path.endswith(".yaml"):
+                    dir_path = os.path.split(abs_path)[0]
+                if not os.path.exists(dir_path):
+                    try:
+                        os.makedirs(dir_path)
+                    except OSError as exc:
+                        if exc.errno != errno.EEXIST:
+                            raise
+
+                config = {
+                    "project_code": "project_code",
+                    "region": "region",
+                    "template_path": rel_path
+                }
+
+                # Delete the mandatory key to be tested.
+                del config[del_key]
+
+                with open(abs_path, 'w') as config_file:
+                    yaml.safe_dump(
+                        config, stream=config_file, default_flow_style=False
+                    )
+
+            try:
+                config_reader = ConfigReader(self.context)
+                all_stacks, command_stacks = config_reader.construct_stacks()
+            except InvalidConfigFileError as e:
+                # Test that the missing key is reported.
+                assert del_key in str(e)
+            except Exception:
+                raise
+            else:
+                assert False


### PR DESCRIPTION
Signed-off-by: Brendan Devenney <brendan.devenney@cloudreach.com>

There are some unanswered questions to consider when reviewing this PR:

* Should the code be differentiating between Stack Config and Stack Group Config for the user's benefit? I'm a little thrown off by the fact you can successfully deploy a Stack without any files in the tree named `config.yaml`, despite the implication that `config.yaml` is mandatory in the [StackGroup Config](https://sceptre.cloudreach.com/latest/docs/stack_group_config.html) docs. Effectively, you can store all of your config in `vpc.yaml` and Sceptre won't complain.
* Do we care enough about invalid keys to add these checks? My opinion is yes, as a typo in a stack's config could be masked due to the attribute cascading down from a parent directory.

Also, for what it's worth, I have no idea if this is the most efficient way to flatten lists of lists into a single flat list. Some rough testing suggests it's the fasted way I know but please do consider if there's a better/cleaner way. 👍 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
