### PR TITLE
[Resolves #630] Use yaml.safe_dump Everywhere

### DIFF
--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -112,16 +112,16 @@ def _generate_yaml(stream):
             try:
                 if isinstance(item, dict):
                     items.append(
-                            yaml.dump(item, default_flow_style=False, explicit_start=True)
+                            yaml.safe_dump(item, default_flow_style=False, explicit_start=True)
                     )
                 else:
                     items.append(
-                            yaml.dump(
+                            yaml.safe_dump(
                                 yaml.load(item), default_flow_style=False, explicit_start=True)
                     )
             except Exception:
                 print("An error occured whilst writing the YAML object.")
-        return yaml.dump(
+        return yaml.safe_dump(
                     [yaml.load(item) for item in items],
                     default_flow_style=False, explicit_start=True
                 )


### PR DESCRIPTION
Use `yaml.safe_dump` to only output plain YAML instead of Python objects.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests. (not applicable)
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
