### PR TITLE
[Resolves #634] Symlink support for v2

### DIFF
--- a/sceptre/cli/new.py
+++ b/sceptre/cli/new.py
@@ -123,7 +123,7 @@ def _get_nested_config(config_dir, path):
     :rtype: dict
     """
     config = {}
-    for root, _, files in os.walk(config_dir):
+    for root, _, files in os.walk(config_dir, followlinks=True):
         # Check that folder is within the final stack_group path
         if path.startswith(root) and "config.yaml" in files:
             config_path = os.path.join(root, "config.yaml")

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -179,7 +179,7 @@ class ConfigReader(object):
             todo = {root}
         else:
             todo = set()
-            for directory_name, sub_directories, files in walk(root):
+            for directory_name, sub_directories, files in walk(root, followlinks=True):
                 for filename in fnmatch.filter(files, '*.yaml'):
                     if filename.startswith('config.'):
                         continue


### PR DESCRIPTION
When parsing stacks and groups containing symbolic links the links were not being followed due to `os.walk()` not following symbolic links by default.  This pull request enables link following for uses of `os.walk()`.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
