### PR TITLE
Resolve #622: Add official Python 3.7 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ colorama==0.3.7
 coverage==4.4.2
 flake8==3.5.0
 flake8-per-file-ignores==0.4
-freezegun==0.3.9
+freezegun==0.3.11
 Jinja2>=2.8,<3
 mock>=2.0.0,<2.1.0
-moto==0.4.31
+moto==1.3.7
 networkx==2.1
 packaging==16.8
 pygments==2.2.0

--- a/sceptre/__init__.py
+++ b/sceptre/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import warnings
 
 
 __author__ = 'Cloudreach'
@@ -14,5 +15,8 @@ class NullHandler(logging.Handler):  # pragma: no cover
     def emit(self, record):
         pass
 
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 logging.getLogger('sceptre').addHandler(NullHandler())

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py36,py37
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Note that this commit suppressed DeprecationWarnings due to dependencies
which have not yet updated their use of collections.abc.

Signed-off-by: Brendan Devenney <brendan.devenney@cloudreach.com>

Resolves #622

* Upgrades the necessary dependencies to versions which support Python 3.7.
* Adds py37 as a Tox target.
* Silences deprecation warnings to prevent [PyYAML #202](https://github.com/yaml/pyyaml/issues/202) polluting Sceptre output.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
