### PR TITLE
[Resolves #617] allow for configuration path to be specified via CLI.…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,3 +45,5 @@
 - David Taddei [@davidtaddei](https://github.com/davidtaddei)
 
 - Dennis Conrad [@dennisconrad](https://github.com/dennisconrad)
+
+- Paul Miller [@pwrsmiller](https://github.com/pwrmiller)

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -35,6 +35,9 @@ from sceptre.cli.helpers import setup_logging, catch_exceptions
 @click.option("--debug", is_flag=True, help="Turn on debug logging.")
 @click.option("--dir", "directory", help="Specify sceptre directory.")
 @click.option(
+    "--config-dir", "config_directory", default="config",
+    help="Specify sceptre config directory.")
+@click.option(
     "--output", type=click.Choice(["text", "yaml", "json"]), default="text",
     help="The formatting style for command output.")
 @click.option("--no-colour", is_flag=True, help="Turn off output colouring.")
@@ -48,7 +51,7 @@ from sceptre.cli.helpers import setup_logging, catch_exceptions
 @click.pass_context
 @catch_exceptions
 def cli(
-        ctx, debug, directory, output, no_colour, var, var_file, ignore_dependencies
+        ctx, debug, directory, config_directory, output, no_colour, var, var_file, ignore_dependencies
 ):
     """
     Sceptre is a tool to manage your cloud native infrastructure deployments.
@@ -63,7 +66,8 @@ def cli(
         "output_format": output,
         "no_colour": no_colour,
         "ignore_dependencies": ignore_dependencies,
-        "project_path": directory if directory else os.getcwd()
+        "project_path": directory if directory else os.getcwd(),
+        "config_path": config_directory if config_directory else "config"
     }
     if var_file:
         for fh in var_file:

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -30,6 +30,7 @@ def create_command(ctx, path, change_set_name, yes):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         ignore_dependencies=ctx.obj.get("ignore_dependencies")

--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -33,6 +33,7 @@ def delete_command(ctx, path, change_set_name, yes):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         ignore_dependencies=ctx.obj.get("ignore_dependencies")

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -41,6 +41,7 @@ def describe_change_set(ctx, path, change_set_name, verbose):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
@@ -73,6 +74,7 @@ def describe_policy(ctx, path):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -28,6 +28,7 @@ def execute_command(ctx, path, change_set_name, yes):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         ignore_dependencies=ctx.obj.get("ignore_dependencies")

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -27,6 +27,7 @@ def launch_command(ctx, path, yes):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         ignore_dependencies=ctx.obj.get("ignore_dependencies")

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -32,6 +32,7 @@ def list_resources(ctx, path):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
@@ -68,6 +69,7 @@ def list_outputs(ctx, path, export):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path", None),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables", {}),
         options=ctx.obj.get("options", {}),
         output_format=ctx.obj.get("output_format"),
@@ -107,6 +109,7 @@ def list_change_sets(ctx, path):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         output_format=ctx.obj.get("output_format"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/new.py
+++ b/sceptre/cli/new.py
@@ -34,8 +34,8 @@ def new_stack_group(ctx, stack_group):
     cwd = ctx.obj.get("project_path")
     for item in os.listdir(cwd):
         # If already a config folder create a sub stack_group
-        if os.path.isdir(item) and item == "config":
-            config_dir = os.path.join(os.getcwd(), "config")
+        if os.path.isdir(item) and item == ctx.obj.get('config_path'):
+            config_dir = os.path.join(os.getcwd(), ctx.obj.get('config_path'))
             _create_new_stack_group(config_dir, stack_group)
 
 
@@ -53,7 +53,7 @@ def new_project(ctx, project_name):
     :type project_name: str
     """
     cwd = os.getcwd()
-    sceptre_folders = {"config", "templates"}
+    sceptre_folders = {ctx.obj.get('config_path'), "templates"}
     project_folder = os.path.join(cwd, project_name)
     try:
         os.mkdir(project_folder)
@@ -75,7 +75,7 @@ def new_project(ctx, project_name):
         "region": os.environ.get("AWS_DEFAULT_REGION", "")
     }
 
-    config_path = os.path.join(cwd, project_name, "config")
+    config_path = os.path.join(cwd, project_name, ctx.obj.get('config_path'))
     _create_config_file(config_path, config_path, defaults)
 
 

--- a/sceptre/cli/policy.py
+++ b/sceptre/cli/policy.py
@@ -29,6 +29,7 @@ def set_policy_command(ctx, path, policy_file, built_in):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         ignore_dependencies=ctx.obj.get("ignore_dependencies")

--- a/sceptre/cli/status.py
+++ b/sceptre/cli/status.py
@@ -24,6 +24,7 @@ def status_command(ctx, path):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         no_colour=ctx.obj.get("no_colour"),

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -24,6 +24,7 @@ def validate_command(ctx, path):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
@@ -55,6 +56,7 @@ def generate_command(ctx, path):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
@@ -84,6 +86,7 @@ def estimate_cost_command(ctx, path):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -43,6 +43,7 @@ def update_command(ctx, path, change_set, verbose, yes):
     context = SceptreContext(
         command_path=path,
         project_path=ctx.obj.get("project_path"),
+        config_path=ctx.obj.get("config_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -334,9 +334,7 @@ class ConfigReader(object):
                 command_path=self.context.command_path.split("/"),
                 environment_variable=environ
             )
-
             config = yaml.safe_load(rendered_template)
-
             return config
 
     @staticmethod

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -23,6 +23,9 @@ class SceptreContext(object):
     :param command_path: The relative path to either StackGroup or Stack.
     :type command_path: str
 
+    :param config_path: The path relative to project_path for the config folder
+    :type config_path: str
+
     :param user_variables: Used to replace the value of anyvitem in a Config\
             file with a value defined by the CLI flag or in a YAML variable\
             file
@@ -40,7 +43,7 @@ class SceptreContext(object):
     :type no_colour: bool
     """
 
-    def __init__(self, project_path, command_path,
+    def __init__(self, project_path, command_path, config_path="config",
                  user_variables=None, options=None, output_format=None,
                  no_colour=False, ignore_dependencies=False):
         # project_path: absolute path to the base sceptre project folder
@@ -49,14 +52,14 @@ class SceptreContext(object):
 
         # config_path: holds the project stack_groups
         # e.g {project_path}/config
-        self.config_path = "config"  # user definable later in v2
+        self.config_path = config_path
 
         # command_path path to either stack group or stack
         # e.g. {project_path/config_path}/command_path
         self.command_path = command_path
 
         # config_file: stack group config. User definable later in v2
-        # e.g. {project_path/config/command_path}/config_file
+        # e.g. {project_path/config_path/command_path}/config_file
         self.config_file = "config.yaml"
 
         # templates_path: holds tempaltes. User definable later in v2

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -25,7 +25,8 @@ class TestConfigReader(object):
         )
         self.context = SceptreContext(
             project_path=self.test_project_path,
-            command_path="A"
+            command_path="A",
+            config_path="config"
         )
 
     def test_config_reader_correctly_initialised(self):
@@ -34,7 +35,7 @@ class TestConfigReader(object):
 
     def test_config_reader_with_invalid_path(self):
         with pytest.raises(InvalidSceptreDirectoryError):
-            ConfigReader(SceptreContext("/path/does/not/exist", "example"))
+            ConfigReader(SceptreContext("/path/does/not/exist", "example", "example"))
 
     @pytest.mark.parametrize("filepaths,target", [
         (

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -13,6 +13,7 @@ class TestSceptreContext(object):
     def test_context_with_path(self):
         self.context = SceptreContext(
             project_path="project_path/to/sceptre",
+            config_path="config",
             command_path=sentinel.command_path,
             user_variables=sentinel.user_variables,
             options=sentinel.options,
@@ -27,6 +28,7 @@ class TestSceptreContext(object):
     def test_full_config_path_returns_correct_path(self):
         context = SceptreContext(
             project_path="project_path",
+            config_path="config",
             command_path=sentinel.command_path,
             user_variables=sentinel.user_variables,
             options=sentinel.options,
@@ -38,9 +40,25 @@ class TestSceptreContext(object):
         full_config_path = path.join("project_path", self.config_path)
         assert context.full_config_path() == full_config_path
 
+    def test_modified_config_path_returns_correct_path(self):
+        context = SceptreContext(
+            project_path="project_path",
+            config_path="some_other_path",
+            command_path=sentinel.command_path,
+            user_variables=sentinel.user_variables,
+            options=sentinel.options,
+            output_format=sentinel.output_format,
+            no_colour=sentinel.no_colour,
+            ignore_dependencies=sentinel.ignore_dependencies
+        )
+
+        full_config_path = path.join("project_path", "some_other_path")
+        assert context.full_config_path() == full_config_path
+
     def test_full_command_path_returns_correct_path(self):
         context = SceptreContext(
             project_path="project_path",
+            config_path="config",
             command_path="command",
             user_variables=sentinel.user_variables,
             options=sentinel.options,
@@ -57,6 +75,7 @@ class TestSceptreContext(object):
     def test_full_templates_path_returns_correct_path(self):
         context = SceptreContext(
             project_path="project_path",
+            config_path="config",
             command_path="command",
             user_variables=sentinel.user_variables,
             options=sentinel.options,


### PR DESCRIPTION
This allows the `--config-dir` parameter to be specified for the CLI, and allows the config directory to be changed from the default of `config`. 

## PR Checklist

- [:heavy_check_mark:] Wrote a good commit message & description.
- [:heavy_check_mark:] Commit message starts with `[Resolve #issue-number]`.
- [:heavy_check_mark:] Added/Updated unit tests.
- [N/A] Added/Updated integration tests (if applicable).
- [:heavy_check_mark:] All unit tests (`make test`) are passing.
- [:heavy_check_mark:] Used the same coding conventions as the rest of the project.
- [:heavy_check_mark:] The new code passes flake8 (`make lint`) checks.
- [:heavy_check_mark:] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.
