### PR TITLE
Update custom hook docs

### DIFF
--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -110,8 +110,7 @@ in the `sceptre.hooks module`.
 Hooks are require to implement a `run()` function that takes no parameters and
 to call the base class initializer.
 
-Hooks may have access to `argument`, `stack_config`, `stack_group_config` and
-`connection_manager` as object attributes. For example `self.stack_config`.
+Hooks may have access to `argument`, and `stack` as object attributes. For example `self.stack`.
 
 Sceptre uses the `sceptre.hooks` entry point to locate hook classes. Your
 custom hook can be written anywhere and is installed as Python package.
@@ -145,10 +144,12 @@ class CustomHook(Hook):
         self.argument is available from the base class and contains the
         argument defined in the Sceptre config file (see below)
 
-        The following attributes may be available from the base class:
-        self.stack_config  (A dict of data from <stack_name>.yaml)
-        self.stack.stack_group_config  (A dict of data from config.yaml)
-        self.connection_manager (A connection_manager)
+        The following parameters may be available to Hooks:
+        
+        :param argument: The argument of the hook.
+        :type argument: str
+        :param stack: The associated stack of the hook.
+        :type stack: sceptre.stack.Stack
         """
         print(self.argument)
 ```


### PR DESCRIPTION
When writing a hook I ran into a issue where documented properties weren't in the Hook base class. Traced this to a similar issue with resolvers #548

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
