### PR TITLE
fixed issue where it would failed to export if the output contains string with spaces or other special characters

### DIFF
--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -84,7 +84,7 @@ def list_outputs(ctx, path, export):
         for response in responses:
             for stack in response.values():
                 for output in stack:
-                    write("export SCEPTRE_{0}={1}".format(
+                    write("export SCEPTRE_{0}='{1}'".format(
                                 output.get("OutputKey"),
                                 output.get("OutputValue")
                             ), 'str')


### PR DESCRIPTION
fixed issue where it would failed to export if the output contains string with spaces or other special characters

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
