### PR TITLE
[Resolves #674] Add persistent assume-role session cache to connectio…

### DIFF
--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -85,7 +85,8 @@ class TestConnectionManager(object):
             region_name="eu-west-1",
             aws_access_key_id=ANY,
             aws_secret_access_key=ANY,
-            aws_session_token=ANY
+            aws_session_token=ANY,
+            botocore_session=ANY
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")
@@ -103,7 +104,8 @@ class TestConnectionManager(object):
             region_name="eu-west-1",
             aws_access_key_id=ANY,
             aws_secret_access_key=ANY,
-            aws_session_token=ANY
+            aws_session_token=ANY,
+            botocore_session=ANY
         )
 
     @patch("sceptre.connection_manager.boto3.session.Session")


### PR DESCRIPTION
…n manager

As described in issue #674, this PR enables persistent session caching for assume-role profiles in botocore. It uses the same cache directory as awscli. It does not require awscli to work.

The initial version of this code created a botocore session, added the credential cache, and then passed the modified botocore session into the boto3 session. However, there was a bug when using non-default profiles. The assume-role provider object gets the profile name from the session during initialization, and does not update it when the session's profile name is updated. To work around this, I had to delay initialization of the assume-role provider object by creating the botocore session, passing it into the boto3 session to allow boto3 to set configuration values such as profile name, and _then_ adding the cache to the assume-role provider.

Example output/usage:

```
# First run
$ sceptre describe policy development/cluster
Converting cache key <hash> /Users/cyphus/.aws/cli/cache/<hash>.json
Converting cache key <hash> /Users/cyphus/.aws/cli/cache/<hash>.json
Enter MFA code for arn:aws:iam::XXXXXXXXXXXX:mfa/cyphus:
Converting cache key <hash> /Users/cyphus/.aws/cli/cache/<hash>.json
{'development/cluster': 'No Policy Information'}

# Subsequent runs (no MFA token required)
$ sceptre describe policy development/cluster
Converting cache key <hash> /Users/cyphus/.aws/cli/cache/<hash>.json
Converting cache key <hash> /Users/cyphus/.aws/cli/cache/<hash>.json
{'development/cluster': 'No Policy Information'}
```

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)