### PR TITLE
Resolve #658: Generate non-trivial json and yaml

### DIFF
--- a/integration-tests/features/generate-template.feature
+++ b/integration-tests/features/generate-template.feature
@@ -12,6 +12,7 @@ Feature: Generate template
     | invalid_template.json     |
     | jinja/valid_template.json |
     | valid_template.yaml       |
+    | valid_template_func.yaml  |
     | malformed_template.yaml   |
     | invalid_template.yaml     |
     | jinja/valid_template.yaml |

--- a/integration-tests/sceptre-project/templates/valid_template_func.yaml
+++ b/integration-tests/sceptre-project/templates/valid_template_func.yaml
@@ -1,0 +1,8 @@
+Resources:
+    WaitConditionHandle:
+      Type: "AWS:CloudFormation::WaitConditionHandle"
+    WaitCondition:
+      Type: "AWS::CloudFormation::WaitCondition"
+      Properties:
+        Count: 1
+        Handle: !Ref WaitConditionHandle

--- a/integration-tests/steps/templates.py
+++ b/integration-tests/steps/templates.py
@@ -6,6 +6,7 @@ import yaml
 from botocore.exceptions import ClientError
 from sceptre.plan.plan import SceptrePlan
 from sceptre.context import SceptreContext
+from sceptre.cli.helpers import CfnYamlLoader
 
 
 def set_template_path(context, stack_name, template_name):
@@ -102,7 +103,7 @@ def step_impl(context, filename):
     with open(filepath) as template:
         body = template.read()
     for template in context.output.values():
-        assert yaml.safe_load(body) == yaml.safe_load(template)
+        assert yaml.load(body, Loader=CfnYamlLoader) == yaml.load(template, CfnYamlLoader)
 
 
 @then('the output is the same as the string returned by "{filename}"')

--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -1,9 +1,10 @@
 import logging
 import sys
-from functools import wraps
+from functools import partial, wraps
 
 import json
 import click
+import six
 import yaml
 
 from boto3.exceptions import Boto3Error
@@ -92,13 +93,13 @@ def _generate_json(stream):
                 if isinstance(item, dict):
                     items.append(item)
                 else:
-                    items.append(json.loads(item))
+                    items.append(yaml.load(item, Loader=CfnYamlLoader))
             except Exception:
                 print("An error occured writing the JSON object.")
         return encoder.encode(items)
     else:
         try:
-            return encoder.encode(json.loads(stream))
+            return encoder.encode(yaml.load(stream, Loader=CfnYamlLoader))
         except Exception:
             return encoder.encode(stream)
 
@@ -115,14 +116,14 @@ def _generate_yaml(stream):
                 else:
                     items.append(
                         yaml.safe_dump(
-                            yaml.load(item, Loader=yaml.FullLoader),
+                            yaml.load(item, Loader=CfnYamlLoader),
                             default_flow_style=False, explicit_start=True
                         )
                     )
             except Exception:
                 print("An error occured whilst writing the YAML object.")
         return yaml.safe_dump(
-            [yaml.load(item, Loader=yaml.FullLoader) for item in items],
+            [yaml.load(item, Loader=CfnYamlLoader) for item in items],
             default_flow_style=False, explicit_start=True
         )
     else:
@@ -268,3 +269,74 @@ class CustomJsonEncoder(json.JSONEncoder):
         :rtype: str
         """
         return str(item)
+
+
+CFN_FNS = [
+    'And',
+    'Base64',
+    'Cidr',
+    'Equals',
+    'FindInMap',
+    'GetAtt',
+    'GetAZs',
+    'If',
+    'ImportValue',
+    'Join',
+    'Not',
+    'Or',
+    'Select',
+    'Sub',
+    'Transform',
+]
+
+CFN_TAGS = [
+    'Condition',
+    'Ref',
+]
+
+
+def _getatt_constructor(loader, node):
+    if isinstance(node.value, six.text_type):
+        return node.value.split('.', 1)
+    elif isinstance(node.value, list):
+        seq = loader.construct_sequence(node)
+        for item in seq:
+            if not isinstance(item, six.text_type):
+                raise ValueError(
+                    "Fn::GetAtt does not support complex datastructures")
+        return seq
+    else:
+        raise ValueError("Fn::GetAtt only supports string or list values")
+
+
+def _tag_constructor(loader, tag_suffix, node):
+    if tag_suffix not in CFN_FNS and tag_suffix not in CFN_TAGS:
+        raise ValueError("Bad tag: !{tag_suffix}. Supported tags are: "
+                         "{supported_tags}".format(
+                             tag_suffix=tag_suffix,
+                             supported_tags=", ".join(sorted(CFN_TAGS + CFN_FNS))
+                         ))
+
+    if tag_suffix in CFN_FNS:
+        tag_suffix = "Fn::{tag_suffix}".format(tag_suffix=tag_suffix)
+
+    data = {}
+    yield data
+
+    if tag_suffix == 'Fn::GetAtt':
+        constructor = partial(_getatt_constructor, (loader, ))
+    elif isinstance(node, yaml.ScalarNode):
+        constructor = loader.construct_scalar
+    elif isinstance(node, yaml.SequenceNode):
+        constructor = loader.construct_sequence
+    elif isinstance(node, yaml.MappingNode):
+        constructor = loader.construct_mapping
+
+    data[tag_suffix] = constructor(node)
+
+
+class CfnYamlLoader(yaml.SafeLoader):
+    pass
+
+
+CfnYamlLoader.add_multi_constructor("!", _tag_constructor)


### PR DESCRIPTION
In cases where Cloudformation-specific tags were used (like !GetAtt, for
example), sceptre would fail to generate yaml and json output when `sceptre
generate` was called.

Here we use the loaders provided by Amazon's cfn-lint package to properly read
the cloudformation yaml after substitution, so that we can translate it to yaml
and json correctly without error.

A potential issue with this approach is that I used cfn-lint as a library to provide functionality for resolving all of the custom tags in cloudformation. There aren't any guarantees that I'm aware of for the stability of this API, but it will work at the pinned version. In service of this particular problem, I opened up an issue [here](https://github.com/aws-cloudformation/cfn-python-lint/issues/831) about this, since having a cfn encoder/decoder as a library would be super useful for more than just sceptre.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
