### PR TITLE
Move connection_manager to stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+## 2.1.2 (2019.05.07)
+
+### Fixed
+
+- Fix `stack_output` resolver recursion error
+
 ## 2.1.1 (2019.05.01)
 
 ### Fixed

--- a/sceptre/__init__.py
+++ b/sceptre/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 __author__ = 'Cloudreach'
 __email__ = 'sceptre@cloudreach.com'
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -62,7 +62,7 @@ class StackOutputBase(Resolver):
         self.logger.debug("Collecting outputs from '{0}'...".format(
             stack_name
         ))
-        connection_manager = self.stack.template.connection_manager
+        connection_manager = self.stack.connection_manager
 
         try:
             response = connection_manager.call(

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -128,6 +128,7 @@ class Stack(object):
         self.template_path = template_path
         self.s3_details = s3_details
         self._template = None
+        self._connection_manager = None
 
         self.protected = protected
         self.role_arn = role_arn
@@ -223,6 +224,20 @@ class Stack(object):
         return hash(str(self))
 
     @property
+    def connection_manager(self):
+        """
+        Returns ConnectionManager.
+         :returns: ConnectionManager.
+        :rtype: ConnectionManager
+        """
+        if self._connection_manager is None:
+            self._connection_manager = ConnectionManager(
+                self.region, self.profile, self.external_name
+            )
+
+        return self._connection_manager
+
+    @property
     def template(self):
         """
         Returns the CloudFormation Template used to create the Stack.
@@ -230,9 +245,6 @@ class Stack(object):
         :returns: The Stack's template.
         :rtype: str
         """
-        self.connection_manager = ConnectionManager(
-            self.region, self.profile, self.external_name
-        )
         if self._template is None:
             self._template = Template(
                 path=self.template_path,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1
+current_version = 2.1.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)|(?P<release_candidate>.*)
 commit = True
 tag = True

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -22,7 +22,7 @@ class TestStackOutputResolver(object):
         stack = MagicMock(spec=Stack)
         stack.dependencies = []
         stack.project_code = "project-code"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "account/dev/vpc"
@@ -53,7 +53,7 @@ class TestStackOutputResolver(object):
         stack = MagicMock(spec=Stack)
         stack.dependencies = ["existing"]
         stack.project_code = "project-code"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "account/dev/vpc"
@@ -87,7 +87,7 @@ class TestStackOutputResolver(object):
         stack.dependencies = []
         stack.project_code = "project-code"
         stack.name = "account/dev/stack"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "account/dev/vpc"
@@ -119,7 +119,7 @@ class TestStackOutputResolver(object):
         stack.dependencies = []
         stack.project_code = "project-code"
         stack.name = "stack"
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
         dependency.name = "vpc"
@@ -150,7 +150,7 @@ class TestStackOutputExternalResolver(object):
     def test_resolve(self, mock_get_output_value):
         stack = MagicMock(spec=Stack)
         stack.dependencies = []
-        stack.template.connection_manager = MagicMock(spec=ConnectionManager)
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
         stack_output_external_resolver = StackOutputExternal(
             "another/account-vpc::VpcId", stack
         )
@@ -181,7 +181,7 @@ class TestStackOutputBaseResolver(object):
 
     def setup_method(self, test_method):
         self.stack = MagicMock(spec=Stack)
-        self.stack.template.connection_manager = MagicMock(
+        self.stack._connection_manager = MagicMock(
             spec=ConnectionManager
         )
         self.base_stack_output_resolver = MockStackOutputBase(
@@ -212,7 +212,7 @@ class TestStackOutputBaseResolver(object):
             )
 
     def test_get_stack_outputs_with_valid_stack(self):
-        self.stack.template.connection_manager.call.return_value = {
+        self.stack.connection_manager.call.return_value = {
             "Stacks": [{
                 "Outputs": [
                     {
@@ -239,7 +239,7 @@ class TestStackOutputBaseResolver(object):
         }
 
     def test_get_stack_outputs_with_valid_stack_without_outputs(self):
-        self.stack.template.connection_manager.call.return_value = {
+        self.stack.connection_manager.call.return_value = {
             "Stacks": [{}]
         }
 
@@ -249,7 +249,7 @@ class TestStackOutputBaseResolver(object):
         assert response == {}
 
     def test_get_stack_outputs_with_unlaunched_stack(self):
-        self.stack.template.connection_manager.call.side_effect = ClientError(
+        self.stack.connection_manager.call.side_effect = ClientError(
             {
                 "Error": {
                     "Code": "404",
@@ -265,7 +265,7 @@ class TestStackOutputBaseResolver(object):
             )
 
     def test_get_stack_outputs_with_unkown_boto_error(self):
-        self.stack.template.connection_manager.call.side_effect = ClientError(
+        self.stack.connection_manager.call.side_effect = ClientError(
             {
                 "Error": {
                     "Code": "500",


### PR DESCRIPTION
There seemed to be a recursion issue which was probably an issue with
when a ResolvableProperty was called.

This commit attempts to fix this, however there may still be an underlying
issue. If there is then the real fix will be to try and remove
ResolvableProperties in favour of another implementation, they seem to
be causing more issues than they are worth.

Thanks to @michaetto, @zaro0508, @pha6d and @m1keil for contributing to this fix.

[Resolves #558]

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
