### PR TITLE
[Resolve #605] Fix docs for protected stacks

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -18,7 +18,7 @@ particular Stack. The available keys are listed below.
 -  `notifications`_ *(optional)*
 -  `on_failure`_ *(optional)*
 -  `parameters`_ *(optional)*
--  `protected`_ *(optional)*
+-  `protect`_ *(optional)*
 -  `role_arn`_ *(optional)*
 -  `sceptre_user_data`_ *(optional)*
 -  `stack_name`_ *(optional)*
@@ -118,8 +118,8 @@ Example:
        - !stack_output security-groups::BaseSecurityGroupId
        - !file_contents /file/with/security_group_id.txt
 
-protected
-~~~~~~~~~
+protect
+~~~~~~~
 
 Stack protection against execution of the following commands:
 
@@ -131,6 +131,12 @@ Stack protection against execution of the following commands:
 
 If a user tries to run one of these commands on a protected Stack, Sceptre will
 throw an error.
+
+Example:
+
+.. code-block:: yaml
+
+  protect: true
 
 role_arn
 ~~~~~~~~
@@ -294,7 +300,7 @@ Examples
 .. _notifications: #notifications
 .. _on_failure: #on_failure
 .. _parameters: #parameters
-.. _protected: #protected
+.. _protect: #protect
 .. _role_arn: #role_arn
 .. _sceptre_user_data: #sceptre_user_data
 .. _stack_name: #stack_name


### PR DESCRIPTION
The documentation is now aligned with the implementation and specifies
that the word "protect" should be used to protect stacks (instead of
"protected").

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
