### PR TITLE
Bug fix for issue with backslash in S3 url on windows

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -401,7 +401,7 @@ class ConfigReader(object):
         s3_details = None
         if "template_bucket_name" in config:
             template_key = "/".join([
-                stack_name, "{time_stamp}.json".format(
+                stack_name.replace("\\", "/"), "{time_stamp}.json".format(
                     time_stamp=datetime.datetime.utcnow().strftime(
                         "%Y-%m-%d-%H-%M-%S-%fZ"
                     )

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -401,7 +401,7 @@ class ConfigReader(object):
         s3_details = None
         if "template_bucket_name" in config:
             template_key = "/".join([
-                stack_name.replace("\\", "/"), "{time_stamp}.json".format(
+                sceptreise_path(stack_name), "{time_stamp}.json".format(
                     time_stamp=datetime.datetime.utcnow().strftime(
                         "%Y-%m-%d-%H-%M-%S-%fZ"
                     )


### PR DESCRIPTION
Bug fix for issue https://github.com/cloudreach/sceptre/issues/703

When using sceptre on windows, the stack name can contain backslashes. If using a deployment S3 bucket then these backslashes can end up in the S3 url, which causes the template to fail validation.

`sceptre --debug launch dev/mystack.yaml -y`

The output looks like this:

```
[2019-05-13 11:04:02] - Uploading template to: 's3://mybucket/myprefix/dev\mystack/2019-05-13-10-04-01-977892Z.json'
[2019-05-13 11:04:02] - s3-deployment - Template URL: 'https://mybucket/myprefix/dev\mystack/2019-05-13-10-04-01-977892Z.json'
An error occurred (ValidationError) when calling the UpdateStack operation: TemplateURL must be an Amazon S3 URL.
```

The fix is to replace any backslashes in the stack name with forward slashes when resolving the `template_key` from the `stack_name`.

Tested on my system.