### PR TITLE
Hotfix/windows stack output

### DIFF
--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -7,7 +7,7 @@ import shlex
 
 from botocore.exceptions import ClientError
 
-from sceptre.helpers import normalise_path
+from sceptre.helpers import normalise_path, sceptreise_path
 from sceptre.resolvers import Resolver
 from sceptre.exceptions import DependencyStackMissingOutputError
 from sceptre.exceptions import StackDoesNotExistError
@@ -109,7 +109,7 @@ class StackOutput(StackOutputBase):
         Adds dependency to a Stack.
         """
         dep_stack_name, self.output_key = self.argument.split("::")
-        self.dependency_stack_name = normalise_path(dep_stack_name)
+        self.dependency_stack_name = sceptreise_path(normalise_path(dep_stack_name))
         self.stack.dependencies.append(self.dependency_stack_name)
 
     def resolve(self):


### PR DESCRIPTION
This PR is to fix an issue whereby the stack_output resolver does not work on windows systems.
https://github.com/cloudreach/sceptre/issues/716

In the stack_output resolver code, a function call is made to the `sceptreise_path` function so that windows path separators are transformed to unix style separators in the template name before comparison.
