### PR TITLE
Improve stack update for no changes

### DIFF
--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -162,8 +162,7 @@ def step_impl(context, stack_name):
     except ClientError as e:
         message = e.response['Error']['Message']
         if e.response['Error']['Code'] == 'ValidationError' \
-            and (message.endswith("does not exist")
-                 or message.endswith("No updates are to be performed.")):
+                and message.endswith("does not exist"):
             return
         else:
             raise e
@@ -183,8 +182,7 @@ def step_impl(context, stack_name):
     except ClientError as e:
         message = e.response['Error']['Message']
         if e.response['Error']['Code'] == 'ValidationError' \
-            and (message.endswith("does not exist")
-                 or message.endswith("No updates are to be performed.")):
+                and message.endswith("does not exist"):
             return
         else:
             raise e


### PR DESCRIPTION
Related to #678

I saw your commit c3ec5d9818a @ngfgrant and had a few concerns with it. Especially the "catch any exception" part. Also the `None` return caused on exceptions I think is a mistake.

Instead of special handling no changes updates in the launch method I've moved that logic into the update method.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
