### PR TITLE
[Resolve #725] fix overwritten project_code in stack_output dependencies

### DIFF
--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -122,11 +122,12 @@ class StackOutput(StackOutputBase):
         self.logger.debug("Resolving Stack output: {0}".format(self.argument))
 
         friendly_stack_name = self.dependency_stack_name.replace(TEMPLATE_EXTENSION, "")
-        stack_name = "-".join([self.stack.project_code, friendly_stack_name.replace("/", "-")])
 
         stack = next(
             stack for stack in self.stack.dependencies if stack.name == friendly_stack_name
         )
+
+        stack_name = "-".join([stack.project_code, friendly_stack_name.replace("/", "-")])
 
         return self._get_output_value(stack_name, self.output_key,
                                       profile=stack.profile, region=stack.region)

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -25,6 +25,7 @@ class TestStackOutputResolver(object):
         stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
+        dependency.project_code = "meh"
         dependency.name = "account/dev/vpc"
         dependency.profile = 'dependency_profile'
         dependency.region = 'dependency_region'
@@ -42,7 +43,7 @@ class TestStackOutputResolver(object):
         result = stack_output_resolver.resolve()
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
-            "project-code-account-dev-vpc", "VpcId",
+            "meh-account-dev-vpc", "VpcId",
             profile='dependency_profile', region='dependency_region'
         )
 
@@ -56,6 +57,7 @@ class TestStackOutputResolver(object):
         stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
+        dependency.project_code = "meh"
         dependency.name = "account/dev/vpc"
         dependency.profile = 'dependency_profile'
         dependency.region = 'dependency_region'
@@ -73,7 +75,7 @@ class TestStackOutputResolver(object):
         result = stack_output_resolver.resolve()
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
-            "project-code-account-dev-vpc", "VpcId",
+            "meh-account-dev-vpc", "VpcId",
             profile='dependency_profile', region='dependency_region'
         )
 
@@ -90,6 +92,7 @@ class TestStackOutputResolver(object):
         stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
+        dependency.project_code = "meh"
         dependency.name = "account/dev/vpc"
         dependency.profile = 'dependency_profile'
         dependency.region = 'dependency_region'
@@ -105,7 +108,7 @@ class TestStackOutputResolver(object):
         result = stack_output_resolver.resolve()
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
-            "project-code-account-dev-vpc", "VpcId",
+            "meh-account-dev-vpc", "VpcId",
             profile='dependency_profile', region='dependency_region'
         )
 
@@ -122,6 +125,7 @@ class TestStackOutputResolver(object):
         stack._connection_manager = MagicMock(spec=ConnectionManager)
 
         dependency = MagicMock()
+        dependency.project_code = "meh"
         dependency.name = "vpc"
         dependency.profile = 'dependency_profile'
         dependency.region = 'dependency_region'
@@ -137,7 +141,7 @@ class TestStackOutputResolver(object):
         result = stack_output_resolver.resolve()
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
-            "project-code-vpc", "VpcId",
+            "meh-vpc", "VpcId",
             profile='dependency_profile', region='dependency_region'
         )
 


### PR DESCRIPTION
Fixes #725 by making the `stack_output` resolver use the `project_code` of the dependent stack instead of its own `project_code`.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
