### PR TITLE
block public access on template bucket

### DIFF
--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -226,7 +226,7 @@ class Template(object):
 
     def _create_bucket(self):
         """
-        Create the s3 bucket ``bucket_name``.
+        Create the private s3 bucket ``bucket_name``.
 
         :raises: botocore.exception.ClientError
 
@@ -234,7 +234,7 @@ class Template(object):
         bucket_name = self.s3_details["bucket_name"]
 
         self.logger.debug(
-            "%s - Creating new bucket '%s'", self.name, bucket_name
+            "%s - Creating new private bucket '%s'", self.name, bucket_name
         )
 
         if self.connection_manager.region == "us-east-1":
@@ -254,6 +254,20 @@ class Template(object):
                     }
                 }
             )
+
+        self.connection_manager.call(
+            service="s3",
+            command="put_public_access_block",
+            kwargs={
+                "Bucket": bucket_name,
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": True,
+                    "IgnorePublicAcls": True,
+                    "BlockPublicPolicy": True,
+                    "RestrictPublicBuckets": True,
+                },
+            }
+        )
 
     def get_boto_call_parameter(self):
         """


### PR DESCRIPTION
Sceptre creates an S3-Bucket for cloudformation templates (if `template_bucket_name` is set in the stack-group config). If the bucket does not exist, it will be created by sceptre automatically. This bucket is only for referencing cloudformation templates in the deployment and does not need to be public.

To assure that there is no public access, this PR configures newly created template buckets to block public access. 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
