### PR TITLE
Fix support for nested dicts in CLI --var flag

### DIFF
--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -82,18 +82,20 @@ def cli(
                 )
 
     if var:
+        def update_dict(variable):
+            variable_key, variable_value = variable.split("=")
+            keys = variable_key.split(".")
+
+            def nested_set(dic, keys, value):
+                for key in keys[:-1]:
+                    dic = dic.setdefault(key, {})
+                dic[keys[-1]] = value
+
+            nested_set(ctx.obj.get("user_variables"), keys, variable_value)
+
         # --var options overwrite --var-file options
         for variable in var:
-            variable_key, variable_value = variable.split("=")
-            if variable_key in ctx.obj.get("user_variables"):
-                logger.debug(
-                    "Duplicate variable encountered: {0}. "
-                    "Using value from --var option."
-                    .format(variable_key)
-                )
-            ctx.obj.get("user_variables").update(
-                {variable_key: variable_value}
-            )
+            update_dict(variable)
 
 
 cli.add_command(new_group)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,6 +77,31 @@ class TestCli(object):
             {},
             {"a": "1", "b": "2"}
         ),
+        # multiple --var options same key
+        (
+            ["--var", "a=1", "--var", "a=2", "noop"],
+            {},
+            {"a": "2"}
+        ),
+        (
+            ["--var-file", "foo.yaml", "--var", "key3.subkey1.id=id2", "noop"],
+            {
+                "foo.yaml": {
+                    "key1": "val1",
+                    "key2": "val2",
+                    "key3": {
+                        "subkey1": {
+                            "id": "id1"
+                        }
+                    }
+                }
+            },
+            {
+                "key1": "val1",
+                "key2": "val2",
+                "key3": {"subkey1": {"id": "id2"}}
+            }
+        ),
         # one --var-file option
         (
             ["--var-file", "foo.yaml", "noop"],


### PR DESCRIPTION
Previously, the `--var` flag would not support nested dictionary
overwriting. For example, a variable file such as

```
vars.yaml
---
top:
  middle:
    nested: hello
  middle2:
    nested_2: world
```

and a CLI command:

`sceptre --var-file vars.yaml --var top.middle.nested=hi launch
dev`

would result in a failure as `top.middle.nested` would be treated as
the full key name in the dictionary but jinja would attempt to parse
the `.`'s  as keys.

This commit fixes that behaviour by enabling support for `.` separated
strings that represent keys in a nested dictionary.

Thus `--var top.middle.nested=hi` would be treated as:

```
top: {
    middle: {
        nested: hi
    }
}
```

[Resolves #641]

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
