### PR TITLE
restore test

### DIFF
--- a/integration-tests/features/generate-template-s3.feature
+++ b/integration-tests/features/generate-template-s3.feature
@@ -10,3 +10,8 @@ Feature: Generate template s3
     Given the template for stack "13/C" is "jinja/valid_template.j2"
     When the user generates the template for stack "13/C"
     Then the output is the same as the contents of "valid_template.json" template
+
+  Scenario: Render python templates with S3 template handler
+    Given the template for stack "13/D" is "python/valid_template.py"
+    When the user generates the template for stack "13/D"
+    Then the output is the same as the contents of "valid_template.json" template

--- a/integration-tests/sceptre-project/config/13/D.yaml
+++ b/integration-tests/sceptre-project/config/13/D.yaml
@@ -1,0 +1,5 @@
+sceptre_user_data:
+  type: AWS::CloudFormation::WaitConditionHandle
+template:
+  path: sceptre-test-artifacts/13/python/valid_template.json
+  type: s3

--- a/integration-tests/sceptre-project/templates/python/valid_template.json
+++ b/integration-tests/sceptre-project/templates/python/valid_template.json
@@ -1,8 +1,0 @@
-{
-  "Resources": {
-    "WaitConditionHandle": {
-      "Type": "AWS::CloudFormation::WaitConditionHandle",
-      "Properties": {}
-    }
-  }
-}


### PR DESCRIPTION
restore an integration test to validate that the s3 template handler can
deploy python based templates.