### PR TITLE
[Resolves #1572] Fix use of deprecated utcnow()

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -581,9 +581,9 @@ class ConfigReader(object):
                 [
                     sceptreise_path(stack_name),
                     "{time_stamp}.json".format(
-                        time_stamp=datetime.datetime.utcnow().strftime(
-                            "%Y-%m-%d-%H-%M-%S-%fZ"
-                        )
+                        time_stamp=datetime.datetime.now(
+                            datetime.timezone.utc
+                        ).strftime("%Y-%m-%d-%H-%M-%S-%fZ")
                     ),
                 ]
             )


### PR DESCRIPTION
The datetime.datetime.utcnow() call is deprecated and results in warnings when running in Python version 3.12.

Replace it with datetime.datetime.now(datetime.timezone.utc) which works in Python 3.9 onwards without the deprecation warning.

[Your PR description here]

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
