### PR TITLE
[Resolves #355] Expose stack_group_config to Jinja2 templates

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -441,8 +441,9 @@ key within Jinja2 templates.
 .. note::
 
    In addition to ``sceptre_user_data``, Jinja2 templates also have access to
-   ``stack_group_config``, which contains the resolved StackGroup Config values
-   such as ``project_code`` and ``region``. See the
+   ``stack_group_config``, which contains both Sceptre-managed keys (such as
+   ``project_code`` and ``region``) and any custom keys from your StackGroup
+   ``config.yaml`` files. See the
    `Templates <templates.html#jinja>`_ documentation for more details.
 
 sceptre_user_data_inheritance

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -438,6 +438,13 @@ Represents data to be passed to the ``sceptre_handler(sceptre_user_data)``
 function in Python templates or accessible under ``sceptre_user_data`` variable
 key within Jinja2 templates.
 
+.. note::
+
+   In addition to ``sceptre_user_data``, Jinja2 templates also have access to
+   ``stack_group_config``, which contains the resolved StackGroup Config values
+   such as ``project_code`` and ``region``. See the
+   `Templates <templates.html#jinja>`_ documentation for more details.
+
 sceptre_user_data_inheritance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Resolvable: No

--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -31,6 +31,34 @@ Template. Sceptre User Data is accessible within Templates as
 ``sceptre_user_data`` accesses the ``sceptre_user_data`` key in the Stack
 Config file.
 
+Stack Group Config is also accessible within Jinja2 Templates as
+``stack_group_config``. This allows you to reference values such as
+``project_code``, ``region``, and any other keys defined in your
+StackGroup config files without having to duplicate them into
+``sceptre_user_data``.
+
+For example:
+
+.. code-block:: jinja
+
+   AWSTemplateFormatVersion: '2010-09-09'
+   Description: 'VPC for {{ stack_group_config.project_code }} in {{ stack_group_config.region }}'
+   Resources:
+     VPC:
+       Type: AWS::EC2::VPC
+       Properties:
+         CidrBlock: {{ sceptre_user_data.cidr_block }}
+         Tags:
+           - Key: Project
+             Value: {{ stack_group_config.project_code }}
+
+The following variables are available in Jinja2 Templates:
+
+- ``sceptre_user_data`` - The ``sceptre_user_data`` defined in the Stack Config file.
+- ``stack_group_config`` - The resolved StackGroup Config, including keys such as
+  ``project_code``, ``region``, ``template_bucket_name``, and any custom keys
+  defined in your ``config.yaml`` files.
+
 
 Example
 ~~~~~~~

--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -33,11 +33,19 @@ Config file.
 
 Stack Group Config is also accessible within Jinja2 Templates as
 ``stack_group_config``. This allows you to reference values such as
-``project_code``, ``region``, and any other keys defined in your
-StackGroup config files without having to duplicate them into
+``project_code``, ``region``, and any custom keys defined in your
+StackGroup ``config.yaml`` files without having to duplicate them into
 ``sceptre_user_data``.
 
-For example:
+For example, given a ``config.yaml``:
+
+.. code-block:: yaml
+
+   project_code: my_project
+   region: us-east-1
+   environment: production
+
+All keys are accessible in Jinja2 templates:
 
 .. code-block:: jinja
 
@@ -51,12 +59,21 @@ For example:
          Tags:
            - Key: Project
              Value: {{ stack_group_config.project_code }}
+           - Key: Environment
+             Value: {{ stack_group_config.environment }}
+
+.. note::
+
+   Keys referenced in templates must be defined somewhere in the StackGroup
+   config hierarchy. If a key is missing, Jinja2 will raise an
+   ``UndefinedError``. You can use Jinja2 defaults to handle optional keys:
+   ``{{ stack_group_config.team | default("unknown") }}``.
 
 The following variables are available in Jinja2 Templates:
 
 - ``sceptre_user_data`` - The ``sceptre_user_data`` defined in the Stack Config file.
-- ``stack_group_config`` - The resolved StackGroup Config, including keys such as
-  ``project_code``, ``region``, ``template_bucket_name``, and any custom keys
+- ``stack_group_config`` - The StackGroup Config, including both Sceptre-managed keys
+  (``project_code``, ``region``, ``template_bucket_name``, etc.) and any custom keys
   defined in your ``config.yaml`` files.
 
 

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -675,13 +675,14 @@ class ConfigReader(object):
 
     def _parsed_stack_group_config(self, stack_group_config):
         """
-        Remove all config items that are supported by Sceptre and
-        remove the `project_path` and `stack_group_path` added by `read()`.
-        Return a dictionary that has only user-specified config items.
+        Return the stack group config with internal keys removed.
+
+        Removes only the ``stack_group_path`` key which is added internally
+        by ``read()``. All other keys, including Sceptre-managed keys
+        (e.g. ``project_code``, ``region``) and user-defined custom keys,
+        are preserved so they can be referenced in Jinja2 templates via
+        ``stack_group_config``.
         """
-        parsed_config = {
-            key: stack_group_config[key]
-            for key in set(stack_group_config) - set(CONFIG_MERGE_STRATEGIES)
-        }
-        parsed_config.pop("stack_group_path")
+        parsed_config = dict(stack_group_config)
+        parsed_config.pop("stack_group_path", None)
         return parsed_config

--- a/sceptre/template_handlers/__init__.py
+++ b/sceptre/template_handlers/__init__.py
@@ -90,3 +90,20 @@ class TemplateHandler:
             validate(instance=self.arguments, schema=self.schema())
         except ValidationError as e:
             raise TemplateHandlerArgumentsInvalidError(e)
+
+    def _get_jinja_vars(self):
+        """
+        Returns a dictionary of variables to pass to Jinja2 templates.
+
+        Includes ``sceptre_user_data`` and ``stack_group_config`` so that
+        Jinja2 templates can reference stack group config values such as
+        ``project_code`` and ``region`` directly, in addition to
+        ``sceptre_user_data``.
+
+        :returns: A dict of variables for Jinja2 template rendering.
+        :rtype: dict
+        """
+        return {
+            "sceptre_user_data": self.sceptre_user_data,
+            "stack_group_config": self.stack_group_config,
+        }

--- a/sceptre/template_handlers/file.py
+++ b/sceptre/template_handlers/file.py
@@ -44,7 +44,7 @@ class File(TemplateHandler):
             elif input_path.suffix in self.jinja_template_extensions:
                 return helper.render_jinja_template(
                     path,
-                    {"sceptre_user_data": self.sceptre_user_data},
+                    self._get_jinja_vars(),
                     self.stack_group_config.get("j2_environment", {}),
                 )
             elif input_path.suffix in self.python_template_extensions:

--- a/sceptre/template_handlers/http.py
+++ b/sceptre/template_handlers/http.py
@@ -71,7 +71,7 @@ class Http(TemplateHandler):
                     if path.suffix in self.jinja_template_extensions:
                         template = helper.render_jinja_template(
                             f.name,
-                            {"sceptre_user_data": self.sceptre_user_data},
+                            self._get_jinja_vars(),
                             self.stack_group_config.get("j2_environment", {}),
                         )
                     elif path.suffix in self.python_template_extensions:

--- a/sceptre/template_handlers/s3.py
+++ b/sceptre/template_handlers/s3.py
@@ -57,7 +57,7 @@ class S3(TemplateHandler):
                     if path.suffix in jinja_template_suffix:
                         template = helper.render_jinja_template(
                             f.name,
-                            {"sceptre_user_data": self.sceptre_user_data},
+                            self._get_jinja_vars(),
                             self.stack_group_config.get("j2_environment", {}),
                         )
                     elif path.suffix in python_template_suffix:

--- a/tests/fixtures/templates/vpc_with_config.j2
+++ b/tests/fixtures/templates/vpc_with_config.j2
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: VPC for {{ stack_group_config.project_code }} in {{ stack_group_config.region }}
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ sceptre_user_data.vpc_cidr }}
+      Tags:
+        - Key: Project
+          Value: {{ stack_group_config.project_code }}

--- a/tests/fixtures/templates/vpc_with_config.j2
+++ b/tests/fixtures/templates/vpc_with_config.j2
@@ -8,3 +8,5 @@ Resources:
       Tags:
         - Key: Project
           Value: {{ stack_group_config.project_code }}
+        - Key: Environment
+          Value: {{ stack_group_config.environment }}

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -319,6 +319,12 @@ class TestConfigReader(object):
             stack_group_config={
                 "project_path": self.context.project_path,
                 "custom_key": "custom_value",
+                "profile": "account_profile",
+                "project_code": "account_project_code",
+                "region": "region_region",
+                "required_version": ">1.0",
+                "template_bucket_name": "stack_group_template_bucket_name",
+                "dependencies": ["top/level"],
             },
             config=ANY,
         )

--- a/tests/test_template_handlers/test_file.py
+++ b/tests/test_template_handlers/test_file.py
@@ -75,7 +75,14 @@ class TestFile(object):
             stack_group_config={"project_path": project_path},
         )
         template_handler.handle()
-        mocked_render.assert_called_with(output_path, {"sceptre_user_data": None}, {})
+        mocked_render.assert_called_with(
+            output_path,
+            {
+                "sceptre_user_data": None,
+                "stack_group_config": {"project_path": project_path},
+            },
+            {},
+        )
 
     @pytest.mark.parametrize(
         "project_path,path,output_path",

--- a/tests/test_template_handlers/test_helper.py
+++ b/tests/test_template_handlers/test_helper.py
@@ -112,3 +112,35 @@ def test_render_jinja_template_non_existing_file():
             jinja_vars={"sceptre_user_data": {}},
             j2_environment={},
         )
+
+
+@patch("pathlib.Path.exists")
+def test_render_jinja_template_with_stack_group_config_and_j2_environment(mock_pathlib):
+    """Test that stack_group_config and j2_environment work together in Jinja2 templates."""
+    mock_pathlib.return_value = True
+    jinja_template_path = os.path.join(
+        os.getcwd(), "tests/fixtures/templates", "vpc_with_config.j2"
+    )
+    jinja_vars = {
+        "sceptre_user_data": {"vpc_cidr": "10.0.0.0/16"},
+        "stack_group_config": {
+            "project_code": "my_project",
+            "region": "us-east-1",
+        },
+    }
+    j2_environment = {
+        "lstrip_blocks": True,
+        "trim_blocks": True,
+    }
+    result = helper.render_jinja_template(
+        path=jinja_template_path,
+        jinja_vars=jinja_vars,
+        j2_environment=j2_environment,
+    )
+    result_yaml = yaml.safe_load(result)
+    assert result_yaml["Description"] == "VPC for my_project in us-east-1"
+    assert result_yaml["Resources"]["VPC"]["Properties"]["CidrBlock"] == "10.0.0.0/16"
+    assert (
+        result_yaml["Resources"]["VPC"]["Properties"]["Tags"][0]["Value"]
+        == "my_project"
+    )

--- a/tests/test_template_handlers/test_helper.py
+++ b/tests/test_template_handlers/test_helper.py
@@ -126,6 +126,7 @@ def test_render_jinja_template_with_stack_group_config_and_j2_environment(mock_p
         "stack_group_config": {
             "project_code": "my_project",
             "region": "us-east-1",
+            "environment": "production",
         },
     }
     j2_environment = {
@@ -143,4 +144,8 @@ def test_render_jinja_template_with_stack_group_config_and_j2_environment(mock_p
     assert (
         result_yaml["Resources"]["VPC"]["Properties"]["Tags"][0]["Value"]
         == "my_project"
+    )
+    assert (
+        result_yaml["Resources"]["VPC"]["Properties"]["Tags"][1]["Value"]
+        == "production"
     )

--- a/tests/test_template_handlers/test_template_handlers.py
+++ b/tests/test_template_handlers/test_template_handlers.py
@@ -42,3 +42,35 @@ class TestTemplateHandlers(TestCase):
             template_handler.logger.info("Bonjour")
 
         assert handler.records[0].message == f"{template_handler.name} - Bonjour"
+
+    def test_get_jinja_vars_includes_sceptre_user_data(self):
+        user_data = {"vpc_cidr": "10.0.0.0/16"}
+        handler = MockTemplateHandler(
+            name="mock",
+            arguments={"argument": "test"},
+            sceptre_user_data=user_data,
+        )
+        jinja_vars = handler._get_jinja_vars()
+        assert jinja_vars["sceptre_user_data"] == user_data
+
+    def test_get_jinja_vars_includes_stack_group_config(self):
+        stack_group_config = {
+            "project_code": "my_project",
+            "region": "us-east-1",
+        }
+        handler = MockTemplateHandler(
+            name="mock",
+            arguments={"argument": "test"},
+            stack_group_config=stack_group_config,
+        )
+        jinja_vars = handler._get_jinja_vars()
+        assert jinja_vars["stack_group_config"] == stack_group_config
+
+    def test_get_jinja_vars_with_no_user_data_or_config(self):
+        handler = MockTemplateHandler(
+            name="mock",
+            arguments={"argument": "test"},
+        )
+        jinja_vars = handler._get_jinja_vars()
+        assert jinja_vars["sceptre_user_data"] is None
+        assert jinja_vars["stack_group_config"] == {}

--- a/tests/test_template_handlers/test_template_handlers.py
+++ b/tests/test_template_handlers/test_template_handlers.py
@@ -57,6 +57,7 @@ class TestTemplateHandlers(TestCase):
         stack_group_config = {
             "project_code": "my_project",
             "region": "us-east-1",
+            "environment": "production",
         }
         handler = MockTemplateHandler(
             name="mock",


### PR DESCRIPTION
Add stack_group_config as a variable available in Jinja2 templates, allowing templates
to reference custom config values from config.yaml and Sceptre managed config values
like project_code and region directly without duplicating them into sceptre_user_data.
This is backward-compatible — sceptre_user_data still works exactly as before.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
