### PR TITLE
[Resolves #355] Expose stack_config to Jinja2 templates

### DIFF
--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -31,6 +31,54 @@ Template. Sceptre User Data is accessible within Templates as
 ``sceptre_user_data`` accesses the ``sceptre_user_data`` key in the Stack
 Config file.
 
+The following variables are available in Jinja2 Templates:
+
+- ``sceptre_user_data`` - The ``sceptre_user_data`` defined in the Stack Config file.
+- ``stack_group_config`` - The StackGroup Config, including both Sceptre-managed keys
+  (``project_code``, ``region``, ``template_bucket_name``, etc.) and any custom keys
+  defined in your ``config.yaml`` files.
+- ``stack_config`` - The Stack Config, including keys such as ``stack_name``,
+  ``parameters``, ``stack_tags``, ``dependencies``, and any other keys defined
+  in the stack's config file.
+
+Example
+~~~~~~~
+
+Given a ``config.yaml``:
+
+.. code-block:: yaml
+
+   project_code: my_project
+   region: us-east-1
+   environment: production
+
+All variables can be used together in a Jinja2 template:
+
+.. code-block:: jinja
+
+   AWSTemplateFormatVersion: '2010-09-09'
+   Description: 'VPC for {{ stack_group_config.project_code }} in {{ stack_group_config.region }}'
+   Resources:
+     VPC:
+       Type: AWS::EC2::VPC
+       Properties:
+         CidrBlock: {{ sceptre_user_data.cidr_block }}
+         Tags:
+           - Key: Project
+             Value: {{ stack_group_config.project_code }}
+           - Key: Environment
+             Value: {{ stack_group_config.environment }}
+           - Key: StackName
+             Value: {{ stack_config.stack_name }}
+
+
+.. note::
+
+   Keys referenced in templates must be defined somewhere in the StackGroup
+   config hierarchy. If a key is missing, Jinja2 will raise an
+   ``UndefinedError``. You can use Jinja2 defaults to handle optional keys:
+   ``{{ stack_group_config.team | default("unknown") }}``.
+
 
 Example
 ~~~~~~~

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -412,6 +412,7 @@ class Stack:
                 stack_group_config=self.stack_group_config,
                 s3_details=self.s3_details,
                 connection_manager=self.connection_manager,
+                stack_config=self.config,
             )
         return self._template
 

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -54,6 +54,7 @@ class Template(object):
         stack_group_config,
         connection_manager=None,
         s3_details=None,
+        stack_config=None,
     ):
         self.logger = StackLoggerAdapter(logging.getLogger(__name__), name)
         self.name = name
@@ -64,6 +65,7 @@ class Template(object):
         self.stack_group_config = stack_group_config
         self.connection_manager = connection_manager
         self.s3_details = s3_details
+        self.stack_config = stack_config
 
         self._registry = None
         self._body = None
@@ -92,6 +94,7 @@ class Template(object):
                 sceptre_user_data=self.sceptre_user_data,
                 connection_manager=self.connection_manager,
                 stack_group_config=self.stack_group_config,
+                stack_config=self.stack_config,
             )
             handler.validate()
             body = handler.handle()

--- a/sceptre/template_handlers/__init__.py
+++ b/sceptre/template_handlers/__init__.py
@@ -49,6 +49,7 @@ class TemplateHandler:
         sceptre_user_data=None,
         connection_manager=None,
         stack_group_config=None,
+        stack_config=None,
     ):
         self.logger = StackLoggerAdapter(logging.getLogger(__name__), name)
         self.name = name
@@ -59,6 +60,10 @@ class TemplateHandler:
         if stack_group_config is None:
             stack_group_config = {}
         self.stack_group_config = stack_group_config
+
+        if stack_config is None:
+            stack_config = {}
+        self.stack_config = stack_config
 
     @abc.abstractmethod
     def schema(self):
@@ -90,3 +95,20 @@ class TemplateHandler:
             validate(instance=self.arguments, schema=self.schema())
         except ValidationError as e:
             raise TemplateHandlerArgumentsInvalidError(e)
+
+    def _get_jinja_vars(self):
+        """
+        Returns a dictionary of variables to pass to Jinja2 templates.
+
+        Includes ``sceptre_user_data``, ``stack_group_config``, and
+        ``stack_config`` so that Jinja2 templates can reference stack group
+        config values, stack config values, and ``sceptre_user_data``.
+
+        :returns: A dict of variables for Jinja2 template rendering.
+        :rtype: dict
+        """
+        return {
+            "sceptre_user_data": self.sceptre_user_data,
+            "stack_group_config": self.stack_group_config,
+            "stack_config": self.stack_config,
+        }

--- a/tests/test_template_handlers/test_file.py
+++ b/tests/test_template_handlers/test_file.py
@@ -75,7 +75,15 @@ class TestFile(object):
             stack_group_config={"project_path": project_path},
         )
         template_handler.handle()
-        mocked_render.assert_called_with(output_path, {"sceptre_user_data": None}, {})
+        mocked_render.assert_called_with(
+            output_path,
+            {
+                "sceptre_user_data": None,
+                "stack_group_config": {"project_path": project_path},
+                "stack_config": {},
+            },
+            {},
+        )
 
     @pytest.mark.parametrize(
         "project_path,path,output_path",

--- a/tests/test_template_handlers/test_template_handlers.py
+++ b/tests/test_template_handlers/test_template_handlers.py
@@ -42,3 +42,48 @@ class TestTemplateHandlers(TestCase):
             template_handler.logger.info("Bonjour")
 
         assert handler.records[0].message == f"{template_handler.name} - Bonjour"
+
+    def test_get_jinja_vars_includes_stack_config(self):
+        stack_config = {
+            "stack_name": "my-custom-stack",
+            "parameters": {"Param1": "Value1"},
+        }
+        handler = MockTemplateHandler(
+            name="dev/vpc",
+            arguments={"argument": "test"},
+            stack_config=stack_config,
+        )
+        jinja_vars = handler._get_jinja_vars()
+        assert jinja_vars["stack_config"] == stack_config
+
+    def test_stack_config_flows_from_stack_to_jinja_vars(self):
+        """Test that stack config reaches the Jinja2 template context."""
+        from unittest.mock import patch, MagicMock
+        from sceptre.stack import Stack
+
+        stack = Stack(
+            name="dev/vpc",
+            project_code="my_project",
+            region="us-east-1",
+            template_handler_config={"type": "file", "path": "vpc.json"},
+            external_name="my-custom-stack-name",
+            config={
+                "stack_name": "my-custom-stack-name",
+                "project_code": "my_project",
+                "region": "us-east-1",
+            },
+        )
+
+        with patch(
+            "sceptre.template.Template._get_handler_of_type"
+        ) as mock_get_handler:
+            mock_handler_class = MagicMock()
+            mock_get_handler.return_value = mock_handler_class
+            mock_handler_instance = MagicMock()
+            mock_handler_class.return_value = mock_handler_instance
+            mock_handler_instance.handle.return_value = "{}"
+
+            _ = stack.template.body
+
+            call_kwargs = mock_handler_class.call_args[1]
+            assert call_kwargs["stack_config"]["stack_name"] == "my-custom-stack-name"


### PR DESCRIPTION
Add stack_config as a variable available in Jinja2 templates, allowing templates
to reference custom config values from Sceptre stack config like stack_name and stack_tags

This is backward-compatible — sceptre_user_data still works exactly as before.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
