### PR TITLE
[Resolves #355] expose stack_config to Jinja2 templates

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -441,10 +441,12 @@ key within Jinja2 templates.
 .. note::
 
    In addition to ``sceptre_user_data``, Jinja2 templates also have access to
-   ``stack_group_config``, which contains both Sceptre-managed keys (such as
-   ``project_code`` and ``region``) and any custom keys from your StackGroup
-   ``config.yaml`` files. See the
-   `Templates <templates.html#jinja>`_ documentation for more details.
+   ``stack_group_config`` and ``stack_config``. ``stack_group_config`` contains
+   both Sceptre-managed keys (such as ``project_code`` and ``region``) and any
+   custom keys from your StackGroup ``config.yaml`` files. ``stack_config``
+   contains the stack's own configuration keys (such as ``stack_name`` and
+   ``parameters``). See the `Templates <templates.html#jinja>`_ documentation
+   for more details.
 
 sceptre_user_data_inheritance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -34,8 +34,29 @@ Config file.
 Stack Group Config is also accessible within Jinja2 Templates as
 ``stack_group_config``. This allows you to reference values such as
 ``project_code``, ``region``, and any custom keys defined in your
-StackGroup ``config.yaml`` files without having to duplicate them into
-``sceptre_user_data``.
+
+Stack Config is accessible within Jinja2 Templates as ``stack_config``.
+This contains the individual stack's configuration keys such as
+``stack_name``, ``parameters``, ``stack_tags``, and ``dependencies``.
+Note that ``sceptre_user_data`` is excluded from ``stack_config`` to avoid
+duplication, since it is already available as a top-level variable.
+
+.. note::
+
+   Keys referenced in templates must be defined somewhere in the StackGroup
+   config hierarchy or the stack config file. If a key is missing, Jinja2
+   will raise an ``UndefinedError``. You can use Jinja2 defaults to handle
+   optional keys: ``{{ stack_group_config.team | default("unknown") }}``.
+
+The following variables are available in Jinja2 Templates:
+
+- ``sceptre_user_data`` - The ``sceptre_user_data`` defined in the Stack Config file.
+- ``stack_group_config`` - The StackGroup Config, including both Sceptre-managed keys
+  (``project_code``, ``region``, ``template_bucket_name``, etc.) and any custom keys
+  defined in your ``config.yaml`` files.
+- ``stack_config`` - The Stack Config, including keys such as ``stack_name``,
+  ``parameters``, ``stack_tags``, and ``dependencies``. The ``sceptre_user_data``
+  key is excluded since it is available as a top-level variable.
 
 For example, given a ``config.yaml``:
 
@@ -45,7 +66,18 @@ For example, given a ``config.yaml``:
    region: us-east-1
    environment: production
 
-All keys are accessible in Jinja2 templates:
+And a stack config ``dev/vpc.yaml``:
+
+.. code-block:: yaml
+
+   template:
+     path: vpc.j2
+     type: file
+   stack_name: my-custom-vpc
+   sceptre_user_data:
+     cidr_block: 10.0.0.0/16
+
+All variables can be used together in a Jinja2 template:
 
 .. code-block:: jinja
 
@@ -61,20 +93,8 @@ All keys are accessible in Jinja2 templates:
              Value: {{ stack_group_config.project_code }}
            - Key: Environment
              Value: {{ stack_group_config.environment }}
-
-.. note::
-
-   Keys referenced in templates must be defined somewhere in the StackGroup
-   config hierarchy. If a key is missing, Jinja2 will raise an
-   ``UndefinedError``. You can use Jinja2 defaults to handle optional keys:
-   ``{{ stack_group_config.team | default("unknown") }}``.
-
-The following variables are available in Jinja2 Templates:
-
-- ``sceptre_user_data`` - The ``sceptre_user_data`` defined in the Stack Config file.
-- ``stack_group_config`` - The StackGroup Config, including both Sceptre-managed keys
-  (``project_code``, ``region``, ``template_bucket_name``, etc.) and any custom keys
-  defined in your ``config.yaml`` files.
+           - Key: StackName
+             Value: {{ stack_config.stack_name }}
 
 
 Example

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -412,6 +412,7 @@ class Stack:
                 stack_group_config=self.stack_group_config,
                 s3_details=self.s3_details,
                 connection_manager=self.connection_manager,
+                stack_config=self.config,
             )
         return self._template
 

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -54,6 +54,7 @@ class Template(object):
         stack_group_config,
         connection_manager=None,
         s3_details=None,
+        stack_config=None,
     ):
         self.logger = StackLoggerAdapter(logging.getLogger(__name__), name)
         self.name = name
@@ -64,6 +65,7 @@ class Template(object):
         self.stack_group_config = stack_group_config
         self.connection_manager = connection_manager
         self.s3_details = s3_details
+        self.stack_config = stack_config or {}
 
         self._registry = None
         self._body = None
@@ -92,6 +94,7 @@ class Template(object):
                 sceptre_user_data=self.sceptre_user_data,
                 connection_manager=self.connection_manager,
                 stack_group_config=self.stack_group_config,
+                stack_config=self.stack_config,
             )
             handler.validate()
             body = handler.handle()

--- a/sceptre/template_handlers/__init__.py
+++ b/sceptre/template_handlers/__init__.py
@@ -49,6 +49,7 @@ class TemplateHandler:
         sceptre_user_data=None,
         connection_manager=None,
         stack_group_config=None,
+        stack_config=None,
     ):
         self.logger = StackLoggerAdapter(logging.getLogger(__name__), name)
         self.name = name
@@ -59,6 +60,10 @@ class TemplateHandler:
         if stack_group_config is None:
             stack_group_config = {}
         self.stack_group_config = stack_group_config
+
+        if stack_config is None:
+            stack_config = {}
+        self.stack_config = stack_config
 
     @abc.abstractmethod
     def schema(self):
@@ -95,15 +100,21 @@ class TemplateHandler:
         """
         Returns a dictionary of variables to pass to Jinja2 templates.
 
-        Includes ``sceptre_user_data`` and ``stack_group_config`` so that
-        Jinja2 templates can reference stack group config values such as
-        ``project_code`` and ``region`` directly, in addition to
-        ``sceptre_user_data``.
+        Includes ``sceptre_user_data``, ``stack_group_config``, and
+        ``stack_config`` so that Jinja2 templates can reference stack group
+        config values, stack config values, and ``sceptre_user_data``.
+
+        ``sceptre_user_data`` is excluded from ``stack_config`` to avoid
+        duplication, since it is already available as a top-level variable.
 
         :returns: A dict of variables for Jinja2 template rendering.
         :rtype: dict
         """
+        stack_config = {
+            k: v for k, v in self.stack_config.items() if k != "sceptre_user_data"
+        }
         return {
             "sceptre_user_data": self.sceptre_user_data,
             "stack_group_config": self.stack_group_config,
+            "stack_config": stack_config,
         }

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -81,6 +81,7 @@ class TestStackActions(object):
             stack_group_config={},
             connection_manager=self.stack.connection_manager,
             s3_details=None,
+            stack_config={},
         )
         assert response == sentinel.template
 

--- a/tests/test_template_handlers/test_file.py
+++ b/tests/test_template_handlers/test_file.py
@@ -80,6 +80,7 @@ class TestFile(object):
             {
                 "sceptre_user_data": None,
                 "stack_group_config": {"project_path": project_path},
+                "stack_config": {},
             },
             {},
         )

--- a/tests/test_template_handlers/test_template_handlers.py
+++ b/tests/test_template_handlers/test_template_handlers.py
@@ -75,3 +75,90 @@ class TestTemplateHandlers(TestCase):
         jinja_vars = handler._get_jinja_vars()
         assert jinja_vars["sceptre_user_data"] is None
         assert jinja_vars["stack_group_config"] == {}
+
+    def test_get_jinja_vars_includes_stack_config(self):
+        stack_config = {
+            "stack_name": "my-custom-stack",
+            "parameters": {"Param1": "Value1"},
+        }
+        handler = MockTemplateHandler(
+            name="dev/vpc",
+            arguments={"argument": "test"},
+            stack_config=stack_config,
+        )
+        jinja_vars = handler._get_jinja_vars()
+        assert jinja_vars["stack_config"] == stack_config
+
+    def test_get_jinja_vars_excludes_sceptre_user_data_from_stack_config(self):
+        user_data = {"vpc_cidr": "10.0.0.0/16"}
+        stack_config = {
+            "stack_name": "my-custom-stack",
+            "sceptre_user_data": user_data,
+            "parameters": {"Param1": "Value1"},
+        }
+        handler = MockTemplateHandler(
+            name="dev/vpc",
+            arguments={"argument": "test"},
+            sceptre_user_data=user_data,
+            stack_config=stack_config,
+        )
+        jinja_vars = handler._get_jinja_vars()
+        assert "sceptre_user_data" not in jinja_vars["stack_config"]
+        assert jinja_vars["stack_config"]["stack_name"] == "my-custom-stack"
+        assert jinja_vars["stack_config"]["parameters"] == {"Param1": "Value1"}
+        assert jinja_vars["sceptre_user_data"] == user_data
+
+    def test_get_jinja_vars_does_not_mutate_original_stack_config(self):
+        user_data = {"vpc_cidr": "10.0.0.0/16"}
+        stack_config = {
+            "stack_name": "my-custom-stack",
+            "sceptre_user_data": user_data,
+        }
+        handler = MockTemplateHandler(
+            name="dev/vpc",
+            arguments={"argument": "test"},
+            sceptre_user_data=user_data,
+            stack_config=stack_config,
+        )
+        handler._get_jinja_vars()
+        assert "sceptre_user_data" in handler.stack_config
+
+    def test_get_jinja_vars_stack_config_defaults_to_empty_dict(self):
+        handler = MockTemplateHandler(
+            name="mock",
+            arguments={"argument": "test"},
+        )
+        jinja_vars = handler._get_jinja_vars()
+        assert jinja_vars["stack_config"] == {}
+
+    def test_stack_config_flows_from_stack_to_jinja_vars(self):
+        """Test that stack config reaches the Jinja2 template context."""
+        from unittest.mock import patch, MagicMock
+        from sceptre.stack import Stack
+
+        stack = Stack(
+            name="dev/vpc",
+            project_code="my_project",
+            region="us-east-1",
+            template_handler_config={"type": "file", "path": "vpc.json"},
+            external_name="my-custom-stack-name",
+            config={
+                "stack_name": "my-custom-stack-name",
+                "project_code": "my_project",
+                "region": "us-east-1",
+            },
+        )
+
+        with patch(
+            "sceptre.template.Template._get_handler_of_type"
+        ) as mock_get_handler:
+            mock_handler_class = MagicMock()
+            mock_get_handler.return_value = mock_handler_class
+            mock_handler_instance = MagicMock()
+            mock_handler_class.return_value = mock_handler_instance
+            mock_handler_instance.handle.return_value = "{}"
+
+            _ = stack.template.body
+
+            call_kwargs = mock_handler_class.call_args[1]
+            assert call_kwargs["stack_config"]["stack_name"] == "my-custom-stack-name"


### PR DESCRIPTION
Add stack_config as a variable available in Jinja2 templates, allowing
templates to reference stack config values like stack_name, parameters,
and stack_tags directly.

depends on #1582 


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"issue-355","parentHead":"f93c9c0ac3ee8e3ac34d3e72019cd80eb4d6d524","parentPull":1582,"trunk":"master"}
```
-->
