### PR TITLE
[Resolve #1466 ] Extend STS session expiry for long running deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+### Fixed
+ - Refresh expired STS sessions automatically in ``ConnectionManager``; long-running
+   deployments no longer fail with authentication errors after the STS credential
+   lifetime elapses when ``sceptre_role`` is configured.
+ - Catch ``ExpiredToken`` / ``ExpiredTokenException`` errors reactively in
+   ``ConnectionManager.call()`` and retry with a freshly-created session; this
+   covers **all** credential sources (env-var tokens, profiles, instance roles)
+   not just sessions created via ``sceptre_role`` assumption.
+
 ## 4.6.0 (2025.12.09)
 - [Resolves #1568] Adding concurrency options to throttle deployments (#1560)
 - [Resolve #1562] Fix safe loads path (#1563)

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -311,7 +311,6 @@ class ConnectionManager(object):
                 }
 
                 session = self._session_class(**config)
-                self._boto_sessions[key] = session
 
                 if session.get_credentials() is None:
                     raise InvalidAWSCredentialsError(
@@ -349,10 +348,17 @@ class ConnectionManager(object):
                             )
                         )
 
-                    self._boto_sessions[key] = session
                     expiration = credentials.get("Expiration")
                     if expiration is not None:
                         self._boto_session_expirations[key] = expiration
+
+                # Delay insertion into the cache until after the full session
+                # construction (including the optional assume_role call) has
+                # succeeded.  This prevents a failed assume_role from leaving a
+                # partial, non-assumed base session cached under this key, which
+                # would otherwise be silently returned on subsequent calls without
+                # ever retrying assume_role.
+                self._boto_sessions[key] = session
 
                 self.logger.debug(
                     "Using credential set from %s: %s",
@@ -391,7 +397,12 @@ class ConnectionManager(object):
             self._boto_session_expirations.pop(key, None)
 
     def _evict_client_and_session(
-        self, service: str, region: str, profile: str, stack_name: str, sceptre_role: str
+        self,
+        service: str,
+        region: str,
+        profile: Optional[str],
+        stack_name: Optional[str],
+        sceptre_role: Optional[str],
     ) -> None:
         """Evict both the cached client and the underlying session for the given
         parameters.  Called reactively when AWS returns an ExpiredToken error so
@@ -400,9 +411,10 @@ class ConnectionManager(object):
 
         :param service: The boto3 service name.
         :param region: The AWS region.
-        :param profile: The AWS profile name.
-        :param stack_name: The CloudFormation stack name.
-        :param sceptre_role: The IAM role ARN (or None).
+        :param profile: The AWS profile name, or ``None`` if no profile is configured.
+        :param stack_name: The CloudFormation stack name, or ``None`` when not
+            targeting a specific stack.
+        :param sceptre_role: The IAM role ARN, or ``None`` if no role is assumed.
         """
         client_key = (service, region, profile, stack_name, sceptre_role)
         session_key = (region, profile, sceptre_role)

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -13,7 +13,8 @@ import random
 import threading
 import time
 import warnings
-from typing import Optional, Dict, Tuple, Any
+from datetime import datetime, timezone
+from typing import Optional, Dict, Tuple, Any, FrozenSet
 
 import boto3
 import deprecation
@@ -22,6 +23,13 @@ from botocore.exceptions import ClientError
 
 from sceptre.exceptions import InvalidAWSCredentialsError, RetryLimitExceededError
 from sceptre.helpers import mask_key, create_deprecated_alias_property
+
+# AWS error codes indicating that STS credentials or environment-variable tokens
+# have expired.  We handle these with a single catch-evict-retry in call() so
+# that ALL credential sources (not just sceptre_role) are covered.
+_EXPIRED_TOKEN_ERROR_CODES: FrozenSet[str] = frozenset(
+    {"ExpiredToken", "ExpiredTokenException"}
+)
 
 
 def _retry_boto_call(func):
@@ -91,6 +99,9 @@ class ConnectionManager(object):
     _session_lock = threading.Lock()
     _client_lock = threading.Lock()
     _boto_sessions = {}
+    # Maps session cache keys to their STS credential expiration datetimes.
+    # Only populated for sessions created via an assume_role call (sceptre_role).
+    _boto_session_expirations = {}
     _clients = {}
     _stack_keys = {}
 
@@ -284,6 +295,8 @@ class ConnectionManager(object):
             self.logger.debug("Getting Boto3 session")
             key = (region, profile, sceptre_role)
 
+            self._evict_session_if_expired(key)
+
             if self._boto_sessions.get(key) is None:
                 self.logger.debug("No Boto3 session found, creating one...")
                 self.logger.debug("Using cli credentials...")
@@ -337,6 +350,9 @@ class ConnectionManager(object):
                         )
 
                     self._boto_sessions[key] = session
+                    expiration = credentials.get("Expiration")
+                    if expiration is not None:
+                        self._boto_session_expirations[key] = expiration
 
                 self.logger.debug(
                     "Using credential set from %s: %s",
@@ -354,6 +370,48 @@ class ConnectionManager(object):
 
             return self._boto_sessions[key]
 
+    def _evict_session_if_expired(self, key: tuple) -> None:
+        """
+        Evicts the cached boto session and its expiration metadata for the
+        given session key if the STS temporary credentials have expired.
+
+        This must be called while holding ``_session_lock``.
+
+        :param key: The session cache key ``(region, profile, sceptre_role)``.
+        :type key: tuple
+        """
+        expiration = self._boto_session_expirations.get(key)
+        if expiration is not None and expiration <= datetime.now(timezone.utc):
+            self.logger.debug(
+                "STS credentials for session key %s have expired; evicting from "
+                "cache to force a refresh on next use.",
+                key,
+            )
+            self._boto_sessions.pop(key, None)
+            self._boto_session_expirations.pop(key, None)
+
+    def _evict_client_and_session(
+        self, service: str, region: str, profile: str, stack_name: str, sceptre_role: str
+    ) -> None:
+        """Evict both the cached client and the underlying session for the given
+        parameters.  Called reactively when AWS returns an ExpiredToken error so
+        that the next ``_get_client`` call creates a completely fresh session and
+        client regardless of which credential source was in use.
+
+        :param service: The boto3 service name.
+        :param region: The AWS region.
+        :param profile: The AWS profile name.
+        :param stack_name: The CloudFormation stack name.
+        :param sceptre_role: The IAM role ARN (or None).
+        """
+        client_key = (service, region, profile, stack_name, sceptre_role)
+        session_key = (region, profile, sceptre_role)
+        with self._client_lock:
+            self._clients.pop(client_key, None)
+        with self._session_lock:
+            self._boto_sessions.pop(session_key, None)
+            self._boto_session_expirations.pop(session_key, None)
+
     def _get_client(self, service, region, profile, stack_name, sceptre_role):
         """
         Returns the Boto3 client associated with <service>.
@@ -368,6 +426,19 @@ class ConnectionManager(object):
         """
         with self._client_lock:
             key = (service, region, profile, stack_name, sceptre_role)
+            session_key = (region, profile, sceptre_role)
+            # Evict the cached client when its underlying STS session has expired.
+            # We intentionally perform this check inline here rather than calling
+            # _evict_session_if_expired(), because that method modifies
+            # _boto_sessions/_boto_session_expirations and is designed to be called
+            # only while holding _session_lock.  Calling it here while holding
+            # _client_lock would modify shared session state without that lock.
+            # Instead we only discard the client entry; the subsequent call to
+            # _get_session() below will evict the expired session under _session_lock
+            # and create a fresh one.
+            expiration = self._boto_session_expirations.get(session_key)
+            if expiration is not None and expiration <= datetime.now(timezone.utc):
+                self._clients.pop(key, None)
             if self._clients.get(key) is None:
                 self.logger.debug("No %s client found, creating one...", service)
                 self._clients[key] = self._get_session(
@@ -464,7 +535,21 @@ class ConnectionManager(object):
             kwargs = {}
 
         client = self._get_client(service, region, profile, stack_name, sceptre_role)
-        return getattr(client, command)(**kwargs)
+        try:
+            return getattr(client, command)(**kwargs)
+        except ClientError as e:
+            if e.response["Error"]["Code"] in _EXPIRED_TOKEN_ERROR_CODES:
+                self.logger.debug(
+                    "Credentials expired (%s); evicting cached session and client "
+                    "then retrying the call once.",
+                    e.response["Error"]["Code"],
+                )
+                self._evict_client_and_session(
+                    service, region, profile, stack_name, sceptre_role
+                )
+                client = self._get_client(service, region, profile, stack_name, sceptre_role)
+                return getattr(client, command)(**kwargs)
+            raise
 
     def _coalesce_sceptre_role(self, iam_role: str, sceptre_role: str) -> str:
         """Evaluates the iam_role and sceptre_role parameters as passed to determine which value to

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -391,7 +391,12 @@ class ConnectionManager(object):
             self._boto_session_expirations.pop(key, None)
 
     def _evict_client_and_session(
-        self, service: str, region: str, profile: str, stack_name: str, sceptre_role: str
+        self,
+        service: str,
+        region: str,
+        profile: str,
+        stack_name: str,
+        sceptre_role: str,
     ) -> None:
         """Evict both the cached client and the underlying session for the given
         parameters.  Called reactively when AWS returns an ExpiredToken error so
@@ -547,7 +552,9 @@ class ConnectionManager(object):
                 self._evict_client_and_session(
                     service, region, profile, stack_name, sceptre_role
                 )
-                client = self._get_client(service, region, profile, stack_name, sceptre_role)
+                client = self._get_client(
+                    service, region, profile, stack_name, sceptre_role
+                )
                 return getattr(client, command)(**kwargs)
             raise
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -3,9 +3,11 @@ import warnings
 import pytest
 
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Union
 from unittest.mock import Mock, patch, sentinel, create_autospec
 from deprecation import fail_if_not_removed
+from freezegun import freeze_time
 
 from boto3.session import Session
 from botocore.exceptions import ClientError
@@ -33,6 +35,7 @@ class TestConnectionManager(object):
         self.mock_session: Union[Mock, Session] = self.session_class.return_value
 
         ConnectionManager._boto_sessions = {}
+        ConnectionManager._boto_session_expirations = {}
         ConnectionManager._clients = {}
         ConnectionManager._stack_keys = {}
 
@@ -306,6 +309,189 @@ class TestConnectionManager(object):
             service, region, profile, stack, sceptre_role
         )
         assert client_1 == client_2
+
+    # ------------------------------------------------------------------
+    # STS session expiry tests
+    #
+    # Background: AWS STS credentials obtained via assume_role carry a
+    # maximum lifetime (default 1 hour, up to 12 hours).  Before this
+    # fix, Sceptre cached the boto3 session indefinitely, which meant
+    # any deployment running longer than the credential lifetime would
+    # fail with an authentication error when the next AWS call was made
+    # on the expired session.  The tests below demonstrate both the
+    # previous flaw (expired-credential scenarios that formerly succeeded
+    # only because the stale cached value was blindly returned) and the
+    # corrected behaviour (the cache is evicted and a fresh session is
+    # obtained via a new assume_role call).
+    # ------------------------------------------------------------------
+
+    @freeze_time("2024-01-01 12:00:00")
+    def test_get_session__sts_credentials_not_yet_expired__reuses_cached_session(self):
+        """A session whose STS expiration is in the future must be reused
+        without triggering a new assume_role call."""
+        region = self.region
+        profile = None
+        sceptre_role = "arn:aws:iam::123456:role/my-role"
+        key = (region, profile, sceptre_role)
+        # Expiration is 1 hour after the frozen "now" (2024-01-01 13:00 UTC)
+        future_expiration = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+        self.connection_manager._boto_sessions[key] = sentinel.existing_session
+        self.connection_manager._boto_session_expirations[key] = future_expiration
+
+        session = self.connection_manager._get_session(profile, region, sceptre_role)
+
+        assert session is sentinel.existing_session
+        # Session class must NOT have been called — no new session was created.
+        self.session_class.assert_not_called()
+
+    @freeze_time("2024-01-01 12:00:00")
+    def test_get_session__sts_credentials_expired__evicts_and_recreates_session(self):
+        """A session whose STS expiration is in the past must be evicted from
+        the cache and a new session created via a fresh assume_role call.
+
+        This test demonstrates the previous flaw: before the fix, the stale
+        cached session would have been returned directly, causing subsequent
+        AWS calls to fail with an authentication error.
+        """
+        region = self.region
+        profile = None
+        sceptre_role = "arn:aws:iam::123456:role/my-role"
+        key = (region, profile, sceptre_role)
+        # Expiration was 1 hour before the frozen "now" (2024-01-01 11:00 UTC)
+        past_expiration = datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+        new_expiration = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+        # Prime the cache with a stale entry (simulates the pre-fix state)
+        self.connection_manager._boto_sessions[key] = sentinel.stale_session
+        self.connection_manager._boto_session_expirations[key] = past_expiration
+
+        # Configure assume_role to return fresh credentials for the new session
+        sts_client_mock = self.mock_session.client.return_value
+        sts_client_mock.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "new_id",
+                "SecretAccessKey": "new_key",
+                "SessionToken": "new_token",
+                "Expiration": new_expiration,
+            }
+        }
+
+        new_session = self.connection_manager._get_session(profile, region, sceptre_role)
+
+        # The stale session must have been replaced with a fresh one
+        assert new_session is not sentinel.stale_session
+        # The refreshed expiration must be persisted for future expiry checks
+        assert self.connection_manager._boto_session_expirations[key] == new_expiration
+
+    @freeze_time("2024-01-01 12:00:00")
+    def test_get_session__sts_expiration_stored_when_role_assumed(self):
+        """After a successful assume_role the ``Expiration`` timestamp is
+        stored in ``_boto_session_expirations`` so that future calls to
+        ``_get_session`` and ``_get_client`` can detect and handle expiry."""
+        region = self.region
+        profile = None
+        sceptre_role = "arn:aws:iam::123456:role/my-role"
+        key = (region, profile, sceptre_role)
+        expiration = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+        sts_client_mock = self.mock_session.client.return_value
+        sts_client_mock.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "id",
+                "SecretAccessKey": "key",
+                "SessionToken": "token",
+                "Expiration": expiration,
+            }
+        }
+
+        self.connection_manager._get_session(profile, region, sceptre_role)
+
+        assert self.connection_manager._boto_session_expirations.get(key) == expiration
+
+    def test_get_session__no_sceptre_role__no_expiration_stored(self):
+        """Without a ``sceptre_role`` no STS assume_role call is made and
+        therefore no expiration entry is stored in
+        ``_boto_session_expirations``."""
+        region = self.region
+        profile = None
+        sceptre_role = None
+
+        self.connection_manager._get_session(profile, region, sceptre_role)
+
+        assert self.connection_manager._boto_session_expirations == {}
+
+    @freeze_time("2024-01-01 12:00:00")
+    def test_get_client__underlying_session_expired__evicts_client_and_creates_new(
+        self,
+    ):
+        """If the STS session backing a cached client has expired, the cached
+        client must be evicted and a new one created from a refreshed session.
+
+        This test demonstrates the previous flaw: before the fix, the stale
+        client (backed by expired credentials) would have been returned and any
+        subsequent AWS call with it would have received an authentication error.
+        """
+        service = "cloudformation"
+        region = self.region
+        profile = None
+        sceptre_role = "arn:aws:iam::123456:role/my-role"
+        stack = None
+        client_key = (service, region, profile, stack, sceptre_role)
+        session_key = (region, profile, sceptre_role)
+        # Expiration 1 hour before frozen "now" — the session is expired
+        past_expiration = datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+        new_expiration = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+        # Prime the client cache with a stale client (simulates the pre-fix state)
+        stale_client = Mock(name="stale_client")
+        self.connection_manager._clients[client_key] = stale_client
+        # Record an expired STS timestamp for the underlying session
+        self.connection_manager._boto_session_expirations[session_key] = past_expiration
+
+        # Configure assume_role so the session refresh succeeds
+        sts_client_mock = self.mock_session.client.return_value
+        sts_client_mock.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "new_id",
+                "SecretAccessKey": "new_key",
+                "SessionToken": "new_token",
+                "Expiration": new_expiration,
+            }
+        }
+
+        new_client = self.connection_manager._get_client(
+            service, region, profile, stack, sceptre_role
+        )
+
+        # The stale client must have been replaced with a new one
+        assert new_client is not stale_client
+
+    @freeze_time("2024-01-01 12:00:00")
+    def test_get_client__underlying_session_not_expired__reuses_cached_client(self):
+        """If the STS session is still valid the cached client must be returned
+        as-is, without creating a new session or a new client."""
+        service = "cloudformation"
+        region = self.region
+        profile = None
+        sceptre_role = "arn:aws:iam::123456:role/my-role"
+        stack = None
+        client_key = (service, region, profile, stack, sceptre_role)
+        session_key = (region, profile, sceptre_role)
+        # Expiration 1 hour after frozen "now" — the session is still valid
+        future_expiration = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+        cached_client = Mock(name="cached_client")
+        self.connection_manager._clients[client_key] = cached_client
+        self.connection_manager._boto_session_expirations[session_key] = future_expiration
+
+        result = self.connection_manager._get_client(
+            service, region, profile, stack, sceptre_role
+        )
+
+        assert result is cached_client
+        # No new session or client must have been created
+        self.session_class.assert_not_called()
 
     def test_call__profile_region_and_role_are_stack_default__uses_instance_settings(
         self,
@@ -802,6 +988,146 @@ class TestConnectionManager(object):
         )
         assert connection_manager.iam_role == "sceptre_role"
         assert connection_manager.iam_role_session_duration == 123456
+
+
+    # ------------------------------------------------------------------
+    # Reactive ExpiredToken retry tests
+    #
+    # Background: The proactive eviction mechanism (checking
+    # _boto_session_expirations before returning a cached client) only covers
+    # sessions created via assume_role (sceptre_role).  For all other
+    # credential sources — e.g. env-var tokens injected by Jenkins — the
+    # expiration is never stored, so the proactive check is a no-op.
+    #
+    # The reactive retry in call() catches ExpiredToken / ExpiredTokenException
+    # ClientErrors, evicts the stale client and session, and retries the call
+    # once with a freshly-created client.  These tests exercise that path.
+    # ------------------------------------------------------------------
+
+    def test_call__expired_token_error__evicts_and_retries_successfully(self):
+        """When the first API call returns an ``ExpiredToken`` ClientError,
+        call() must evict the stale client & session then retry and return the
+        successful response from the second attempt."""
+        service = "cloudformation"
+        command = "describe_stacks"
+        self.connection_manager.region = self.region
+        self.connection_manager.profile = None
+        self.connection_manager.sceptre_role = None
+
+        stale_client = Mock(name="stale_client")
+        expired_error = ClientError(
+            {"Error": {"Code": "ExpiredToken", "Message": "Token expired"}},
+            "DescribeStacks",
+        )
+        fresh_response = {"Stacks": []}
+        stale_client.describe_stacks.side_effect = [expired_error]
+
+        fresh_client = Mock(name="fresh_client")
+        fresh_client.describe_stacks.return_value = fresh_response
+
+        client_key = (service, self.region, None, None, None)
+        self.connection_manager._clients[client_key] = stale_client
+
+        # The fresh session returns fresh_client when .client() is called
+        self.mock_session.client.return_value = fresh_client
+
+        result = self.connection_manager.call(service, command)
+
+        assert result == fresh_response
+        # The stale client must have been evicted
+        assert self.connection_manager._clients.get(client_key) is not stale_client
+
+    def test_call__expired_token_exception__evicts_and_retries_successfully(self):
+        """``ExpiredTokenException`` (returned by STS and some other services)
+        must trigger the same evict-and-retry path as ``ExpiredToken``."""
+        service = "sts"
+        command = "get_caller_identity"
+        self.connection_manager.region = self.region
+        self.connection_manager.profile = None
+        self.connection_manager.sceptre_role = None
+
+        stale_client = Mock(name="stale_client")
+        expired_error = ClientError(
+            {
+                "Error": {
+                    "Code": "ExpiredTokenException",
+                    "Message": "Token is expired",
+                }
+            },
+            "GetCallerIdentity",
+        )
+        fresh_response = {"UserId": "AIDA...", "Account": "123456789012", "Arn": "..."}
+        stale_client.get_caller_identity.side_effect = [expired_error]
+
+        fresh_client = Mock(name="fresh_client")
+        fresh_client.get_caller_identity.return_value = fresh_response
+
+        client_key = (service, self.region, None, None, None)
+        self.connection_manager._clients[client_key] = stale_client
+
+        self.mock_session.client.return_value = fresh_client
+
+        result = self.connection_manager.call(service, command)
+
+        assert result == fresh_response
+        assert self.connection_manager._clients.get(client_key) is not stale_client
+
+    def test_call__expired_token__non_sceptre_role__evicts_base_session(self):
+        """Without a sceptre_role (env-var credentials only), an ``ExpiredToken``
+        error must still evict the cached session so that the retry creates a
+        fresh session reading current environment variables."""
+        service = "cloudformation"
+        command = "describe_stacks"
+        self.connection_manager.region = self.region
+        self.connection_manager.profile = None
+        self.connection_manager.sceptre_role = None
+
+        session_key = (self.region, None, None)
+        client_key = (service, self.region, None, None, None)
+
+        stale_session = Mock(name="stale_session")
+        stale_client = Mock(name="stale_client")
+        stale_client.describe_stacks.side_effect = ClientError(
+            {"Error": {"Code": "ExpiredToken", "Message": "Token expired"}},
+            "DescribeStacks",
+        )
+        self.connection_manager._boto_sessions[session_key] = stale_session
+        self.connection_manager._clients[client_key] = stale_client
+
+        fresh_client = Mock(name="fresh_client")
+        fresh_client.describe_stacks.return_value = {"Stacks": []}
+        self.mock_session.client.return_value = fresh_client
+
+        self.connection_manager.call(service, command)
+
+        # The stale session must have been evicted
+        assert self.connection_manager._boto_sessions.get(session_key) is not stale_session
+
+    def test_call__non_expiry_client_error__not_retried(self):
+        """A ClientError that is NOT an expiry error must propagate immediately
+        without triggering the evict-and-retry path."""
+        service = "cloudformation"
+        command = "describe_stacks"
+        self.connection_manager.region = self.region
+        self.connection_manager.profile = None
+        self.connection_manager.sceptre_role = None
+
+        other_error = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Access denied"}},
+            "DescribeStacks",
+        )
+        client = Mock(name="client")
+        client.describe_stacks.side_effect = other_error
+
+        client_key = (service, self.region, None, None, None)
+        self.connection_manager._clients[client_key] = client
+
+        with pytest.raises(ClientError) as exc_info:
+            self.connection_manager.call(service, command)
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+        # Called exactly once — no retry
+        client.describe_stacks.assert_called_once()
 
 
 class TestRetry:

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1089,6 +1089,7 @@ class TestConnectionManager(object):
 
         # assume_role must have been called on both the first and second attempt.
         assert sts_client_mock.assume_role.call_count == 2
+
     # ------------------------------------------------------------------
     # Reactive ExpiredToken retry tests
     #

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -377,7 +377,9 @@ class TestConnectionManager(object):
             }
         }
 
-        new_session = self.connection_manager._get_session(profile, region, sceptre_role)
+        new_session = self.connection_manager._get_session(
+            profile, region, sceptre_role
+        )
 
         # The stale session must have been replaced with a fresh one
         assert new_session is not sentinel.stale_session
@@ -483,7 +485,9 @@ class TestConnectionManager(object):
 
         cached_client = Mock(name="cached_client")
         self.connection_manager._clients[client_key] = cached_client
-        self.connection_manager._boto_session_expirations[session_key] = future_expiration
+        self.connection_manager._boto_session_expirations[session_key] = (
+            future_expiration
+        )
 
         result = self.connection_manager._get_client(
             service, region, profile, stack, sceptre_role
@@ -989,7 +993,6 @@ class TestConnectionManager(object):
         assert connection_manager.iam_role == "sceptre_role"
         assert connection_manager.iam_role_session_duration == 123456
 
-
     # ------------------------------------------------------------------
     # Reactive ExpiredToken retry tests
     #
@@ -1101,7 +1104,9 @@ class TestConnectionManager(object):
         self.connection_manager.call(service, command)
 
         # The stale session must have been evicted
-        assert self.connection_manager._boto_sessions.get(session_key) is not stale_session
+        assert (
+            self.connection_manager._boto_sessions.get(session_key) is not stale_session
+        )
 
     def test_call__non_expiry_client_error__not_retried(self):
         """A ClientError that is NOT an expiry error must propagate immediately

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -383,6 +383,20 @@ class TestConnectionManager(object):
         assert new_session is not sentinel.stale_session
         # The refreshed expiration must be persisted for future expiry checks
         assert self.connection_manager._boto_session_expirations[key] == new_expiration
+        # assume_role must have been called exactly once with the correct role ARN,
+        # proving that the refresh did not simply recreate a bare base session.
+        sts_client_mock.assume_role.assert_called_once_with(
+            RoleArn=sceptre_role,
+            RoleSessionName="my-role-session",
+        )
+        # The session class must have been invoked with the credentials that were
+        # returned by assume_role, confirming the assumed-role session was created.
+        self.session_class.assert_any_call(
+            aws_access_key_id="new_id",
+            aws_secret_access_key="new_key",
+            aws_session_token="new_token",
+            region_name=region,
+        )
 
     @freeze_time("2024-01-01 12:00:00")
     def test_get_session__sts_expiration_stored_when_role_assumed(self):
@@ -990,6 +1004,88 @@ class TestConnectionManager(object):
         assert connection_manager.iam_role_session_duration == 123456
 
 
+    # ------------------------------------------------------------------
+    # assume_role failure / partial-cache-poisoning guard tests
+    #
+    # Background: before the fix, the base (non-assumed) session was stored
+    # in _boto_sessions[key] immediately after being created and BEFORE
+    # assume_role() was called.  If assume_role() raised (e.g. AccessDenied),
+    # the partial base session remained in the cache and was silently returned
+    # on every subsequent call for that key, bypassing assume_role entirely.
+    #
+    # After the fix, insertion into _boto_sessions[key] is deferred until the
+    # entire session-construction path (including assume_role) has completed
+    # successfully, so a failure leaves the cache empty and forces a retry.
+    # ------------------------------------------------------------------
+
+    def test_get_session__assume_role_raises__does_not_cache_partial_base_session(self):
+        """When assume_role() raises, no entry must be left in _boto_sessions
+        so that the next call to _get_session retries the full construction."""
+        region = self.region
+        profile = None
+        sceptre_role = "arn:aws:iam::123456:role/my-role"
+        key = (region, profile, sceptre_role)
+
+        access_denied = ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDenied",
+                    "Message": "Not authorized to assume role",
+                }
+            },
+            "AssumeRole",
+        )
+        sts_client_mock = self.mock_session.client.return_value
+        sts_client_mock.assume_role.side_effect = access_denied
+
+        with pytest.raises(ClientError):
+            self.connection_manager._get_session(profile, region, sceptre_role)
+
+        # The partial base session must NOT have been cached under this key.
+        assert key not in self.connection_manager._boto_sessions
+
+    def test_get_session__assume_role_raises_then_succeeds__retries_assume_role_on_second_call(
+        self,
+    ):
+        """After a failed assume_role, a second _get_session call must attempt
+        assume_role again rather than returning the (non-assumed) base session
+        that was created internally during the first attempt."""
+        region = self.region
+        profile = None
+        sceptre_role = "arn:aws:iam::123456:role/my-role"
+        key = (region, profile, sceptre_role)
+
+        access_denied = ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDenied",
+                    "Message": "Not authorized to assume role",
+                }
+            },
+            "AssumeRole",
+        )
+        success_response = {
+            "Credentials": {
+                "AccessKeyId": "new_id",
+                "SecretAccessKey": "new_key",
+                "SessionToken": "new_token",
+            }
+        }
+        sts_client_mock = self.mock_session.client.return_value
+        sts_client_mock.assume_role.side_effect = [access_denied, success_response]
+
+        # First call must propagate the AccessDenied error.
+        with pytest.raises(ClientError) as exc_info:
+            self.connection_manager._get_session(profile, region, sceptre_role)
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+
+        # Second call must succeed and cache the proper assumed-role session.
+        session = self.connection_manager._get_session(profile, region, sceptre_role)
+        assert session is not None
+        assert key in self.connection_manager._boto_sessions
+
+        # assume_role must have been called on both the first and second attempt.
+        assert sts_client_mock.assume_role.call_count == 2
     # ------------------------------------------------------------------
     # Reactive ExpiredToken retry tests
     #


### PR DESCRIPTION
[Resolve #1466 ] This commit is to fix the issue: AWS STS Session hard limit duration of 1 hour for chained roles #1466. The implementation helps to recreate the new session if the earlier session has expired due to 1hour constraint for the chained roles based on the expiration attribute of the credentials.
